### PR TITLE
Add CI to push Apps Script

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,24 @@
+name: Push to GAS
+
+on:
+  push:
+    paths:
+      - 'src/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - name: Authenticate clasp
+        run: |
+          echo "${{ secrets.CLASP_CREDENTIALS }}" > $HOME/clasp.json
+          npx -y @google/clasp login --creds $HOME/clasp.json
+      - name: Push to Apps Script
+        run: npm run push

--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ your GAS project.
 All script files live directly under the `src` folder. **Do not create any
 subdirectories under `src`.**
 
+
+## Continuous Integration
+
+A GitHub Actions workflow automatically pushes code to the Apps Script project whenever files in `src/` change. To enable it, add your service account credentials JSON as the `CLASP_CREDENTIALS` secret in the repository settings.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to push to GAS on src updates
- document automatic push in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bdd81c388832b9895a0b47e1027b1