### PR TITLE
Improve publish/unpublish UX

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -453,8 +453,7 @@
                 this.elements.unpublishBtn.addEventListener('click', () => {
                     if (confirm('公開を終了しますか？')) {
                         this.gas.unpublishApp()
-                            .then(msg => {
-                                alert(msg);
+                            .then(() => {
                                 window.location.reload();
                             })
                             .catch(err => alert(err.message || 'エラーが発生しました'));

--- a/src/Unpublished.html
+++ b/src/Unpublished.html
@@ -85,12 +85,11 @@
             });
 
             function onPublishSuccess(message) {
-                messageArea.textContent = `${message} 3秒後にリロードします。`;
+                messageArea.textContent = `${message} ページを更新します...`;
                 messageArea.className = 'mt-4 text-sm h-5 text-green-400';
                 setTimeout(() => {
-                    // 自身をリロードするために window.top を使う
-                    window.top.location.reload();
-                }, 3000);
+                    window.location.reload();
+                }, 500);
             }
 
             function onPublishError(error) {


### PR DESCRIPTION
## Summary
- make Unpublished admin publish button reload faster
- redirect immediately after pressing Unpublish

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684be96ef238832b954c347e4e05afec