### PR TITLE
Optimize sheet data retrieval and front-end events

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -165,45 +165,51 @@ function getSheetData(sheetName, classFilter) {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
     if (!sheet) throw new Error(`指定されたシート「${sheetName}」が見つかりません。`);
 
-    const allValues = sheet.getDataRange().getValues();
-    if (allValues.length < 1) return { header: "シートにデータがありません", rows: [] };
-    
+    if (sheet.getLastRow() < 2) return { header: "シートにデータがありません", rows: [] };
+
     const userEmail = Session.getActiveUser().getEmail();
-    const headerIndices = getAndCacheHeaderIndices(sheetName, allValues[0]);
-    const dataRows = allValues.slice(1);
+
+    const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+    const headerIndices = getAndCacheHeaderIndices(sheetName, headerRow);
+    const numRows = sheet.getLastRow() - 1;
+
+    const emailCol = sheet.getRange(2, headerIndices[COLUMN_HEADERS.EMAIL] + 1, numRows).getValues().flat();
+    const classCol = sheet.getRange(2, headerIndices[COLUMN_HEADERS.CLASS] + 1, numRows).getValues().flat();
+    const opinionCol = sheet.getRange(2, headerIndices[COLUMN_HEADERS.OPINION] + 1, numRows).getValues().flat();
+    const reasonCol = sheet.getRange(2, headerIndices[COLUMN_HEADERS.REASON] + 1, numRows).getValues().flat();
+    const likesCol = sheet.getRange(2, headerIndices[COLUMN_HEADERS.LIKES] + 1, numRows).getValues().flat();
+
     const emailToNameMap = getRosterMap();
 
-    const filteredRows = dataRows.filter(row => {
-      if (!classFilter || classFilter === 'すべて') return true;
-      const className = row[headerIndices[COLUMN_HEADERS.CLASS]];
-      return className === classFilter;
-    });
+    const rows = [];
+    for (let i = 0; i < numRows; i++) {
+      const className = classCol[i];
+      if (classFilter && classFilter !== 'すべて' && className !== classFilter) {
+        continue;
+      }
 
-    const rows = filteredRows.map((row) => {
-      const email = row[headerIndices[COLUMN_HEADERS.EMAIL]];
-      const opinion = row[headerIndices[COLUMN_HEADERS.OPINION]];
-
+      const email = emailCol[i];
+      const opinion = opinionCol[i];
       if (email && opinion) {
-        const likersString = row[headerIndices[COLUMN_HEADERS.LIKES]] || '';
+        const likersString = likesCol[i] || '';
         const likers = likersString ? likersString.toString().split(',').filter(Boolean) : [];
-        const reason = row[headerIndices[COLUMN_HEADERS.REASON]] || '';
+        const reason = reasonCol[i] || '';
         const likes = likers.length;
         const baseScore = reason.length;
         const likeMultiplier = 1 + (likes * SCORING_CONFIG.LIKE_MULTIPLIER_FACTOR);
         const totalScore = baseScore * likeMultiplier;
-        return {
-          rowIndex: dataRows.indexOf(row) + 2,
+        rows.push({
+          rowIndex: i + 2,
           name: emailToNameMap[email] || email.split('@')[0],
-          class: row[headerIndices[COLUMN_HEADERS.CLASS]] || '未分類',
+          class: className || '未分類',
           opinion: opinion,
           reason: reason,
           likes: likes,
           hasLiked: userEmail ? likers.includes(userEmail) : false,
           score: totalScore
-        };
+        });
       }
-      return null;
-    }).filter(Boolean);
+    }
 
     rows.sort((a, b) => b.score - a.score);
     return { header: COLUMN_HEADERS.OPINION, rows: rows };
@@ -256,24 +262,29 @@ function getRosterMap() {
   if (cachedMap) { return JSON.parse(cachedMap); }
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(ROSTER_CONFIG.SHEET_NAME);
   if (!sheet) { console.error(`名簿シート「${ROSTER_CONFIG.SHEET_NAME}」が見つかりません。`); return {}; }
-  const rosterValues = sheet.getDataRange().getValues();
-  const rosterHeaders = rosterValues.shift();
-  const lastNameIndex = rosterHeaders.indexOf(ROSTER_CONFIG.HEADER_LAST_NAME);
-  const firstNameIndex = rosterHeaders.indexOf(ROSTER_CONFIG.HEADER_FIRST_NAME);
-  const nicknameIndex = rosterHeaders.indexOf(ROSTER_CONFIG.HEADER_NICKNAME);
-  const emailIndex = rosterHeaders.indexOf(ROSTER_CONFIG.HEADER_EMAIL);
+  const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+  const lastNameIndex = headerRow.indexOf(ROSTER_CONFIG.HEADER_LAST_NAME);
+  const firstNameIndex = headerRow.indexOf(ROSTER_CONFIG.HEADER_FIRST_NAME);
+  const nicknameIndex = headerRow.indexOf(ROSTER_CONFIG.HEADER_NICKNAME);
+  const emailIndex = headerRow.indexOf(ROSTER_CONFIG.HEADER_EMAIL);
   if (lastNameIndex === -1 || firstNameIndex === -1 || emailIndex === -1) { throw new Error(`名簿シート「${ROSTER_CONFIG.SHEET_NAME}」に必要な列が見つかりません。`); }
+  const numRows = sheet.getLastRow() - 1;
+  const lastNames = sheet.getRange(2, lastNameIndex + 1, numRows).getValues().flat();
+  const firstNames = sheet.getRange(2, firstNameIndex + 1, numRows).getValues().flat();
+  const nicknames = nicknameIndex !== -1 ? sheet.getRange(2, nicknameIndex + 1, numRows).getValues().flat() : [];
+  const emails = sheet.getRange(2, emailIndex + 1, numRows).getValues().flat();
+
   const nameMap = {};
-  rosterValues.forEach(row => {
-    const email = row[emailIndex];
-    const lastName = row[lastNameIndex];
-    const firstName = row[firstNameIndex];
-    const nickname = (nicknameIndex !== -1 && row[nicknameIndex]) ? row[nicknameIndex] : ''; 
+  for (let i = 0; i < numRows; i++) {
+    const email = emails[i];
+    const lastName = lastNames[i];
+    const firstName = firstNames[i];
+    const nickname = nicknameIndex !== -1 ? (nicknames[i] || '') : '';
     if (email && lastName && firstName) {
       const fullName = `${lastName} ${firstName}`;
       nameMap[email] = nickname ? `${fullName} (${nickname})` : fullName;
     }
-  });
+  }
   cache.put(ROSTER_CONFIG.CACHE_KEY, JSON.stringify(nameMap), 21600);
   return nameMap;
 }

--- a/src/Page.html
+++ b/src/Page.html
@@ -132,6 +132,18 @@
                 }
             });
             window.addEventListener('resize', this.debounce(() => this.adjustLayout(), 100));
+            this.elements.answersContainer.addEventListener('click', (e) => {
+                const likeBtn = e.target.closest('.like-btn');
+                if (likeBtn) {
+                    e.stopPropagation();
+                    this.handleLike(likeBtn.dataset.rowIndex);
+                    return;
+                }
+                const card = e.target.closest('.answer-card');
+                if (card) {
+                    this.showAnswerModal(card.dataset.rowIndex);
+                }
+            });
         }
 
         adjustLayout() {
@@ -202,7 +214,7 @@
             if (this.pollingInterval) {
                 clearInterval(this.pollingInterval);
             }
-            this.pollingInterval = setInterval(() => this.loadSheetData(false), 15000);
+            this.pollingInterval = setInterval(() => this.loadSheetData(false), 30000);
         }
 
         async loadSheetData(showLoading = true, isInitialLoad = false) {
@@ -225,7 +237,7 @@
                     this.elements.sheetNameText.textContent = 'シート: ' + data.sheetName;
                 }
 
-                if (JSON.stringify(this.state.currentAnswers) !== JSON.stringify(data.rows)) {
+                if (this.dataChanged(this.state.currentAnswers, data.rows)) {
                     this.state.currentAnswers = data.rows;
                     this.elements.headingLabel.textContent = data.header || '問題';
                     this.renderBoard(false, oldAnswers);
@@ -341,15 +353,6 @@
                 '<span class="like-count font-bold text-lg text-gray-200">' + (data.likes || 0) + '</span>' +
                 '</button>' +
                 '</div>';
-            
-            card.addEventListener('click', (e) => {
-                if (e.target.closest('.like-btn')) {
-                    e.stopPropagation();
-                    this.handleLike(data.rowIndex);
-                } else {
-                    this.showAnswerModal(data.rowIndex);
-                }
-            });
             
             return card;
         }
@@ -485,6 +488,19 @@
                 clearTimeout(timeout);
                 timeout = setTimeout(() => func.apply(this, args), delay);
             };
+        }
+
+        dataChanged(oldRows, newRows) {
+            if (oldRows.length !== newRows.length) return true;
+            for (let i = 0; i < oldRows.length; i++) {
+                const a = oldRows[i];
+                const b = newRows[i];
+                if (!a || !b) return true;
+                if (a.rowIndex !== b.rowIndex || a.likes !== b.likes || a.opinion !== b.opinion || a.reason !== b.reason) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         escapeHtml(str) {


### PR DESCRIPTION
## Summary
- optimize `getSheetData` and `getRosterMap` to fetch only required columns
- use direct row indices instead of `indexOf`
- introduce delegated click handling in the board
- reduce polling frequency to 30s and compare updates without JSON stringify

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca2bf7994832ba1df70a54ebd3439