### PR TITLE
Fix full page reload for sidebar

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -454,7 +454,7 @@
                     if (confirm('公開を終了しますか？')) {
                         this.gas.unpublishApp()
                             .then(() => {
-                                window.location.reload();
+                                window.top.location.reload();
                             })
                             .catch(err => alert(err.message || 'エラーが発生しました'));
                     }

--- a/src/Unpublished.html
+++ b/src/Unpublished.html
@@ -88,7 +88,7 @@
                 messageArea.textContent = `${message} ページを更新します...`;
                 messageArea.className = 'mt-4 text-sm h-5 text-green-400';
                 setTimeout(() => {
-                    window.location.reload();
+                    window.top.location.reload();
                 }, 500);
             }
 


### PR DESCRIPTION
## Summary
- reload top-level window after unpublishing or publishing so sidebar contents fully refresh

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc181fa88832ba0532fda38a49598