### PR TITLE
Fix SheetSelector webapp URL

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -324,8 +324,9 @@ function clearRosterCache() {
  */
 function getWebAppUrl() {
   try {
-    const url = ScriptApp.getService().getUrl();
-    return url || '';
+    const scriptId = ScriptApp.getScriptId();
+    const url = scriptId ? `https://script.google.com/macros/s/${scriptId}/exec` : '';
+    return url;
   } catch (e) {
     console.error('getWebAppUrl Error:', e);
     throw new Error('ウェブアプリのURLを取得できませんでした。');


### PR DESCRIPTION
## Summary
- ensure getWebAppUrl returns the latest `/exec` deployment URL

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd351c06c832b8933ae240875c0ef