### PR TITLE
Update Web App URL retrieval

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -325,8 +325,20 @@ function clearRosterCache() {
 function getWebAppUrl() {
   try {
     const scriptId = ScriptApp.getScriptId();
-    const url = scriptId ? `https://script.google.com/macros/s/${scriptId}/exec` : '';
-    return url;
+    const list = Script.Deployments.list(scriptId);
+    const deployments = (list && list.deployments) || [];
+    deployments.sort(function(a, b) {
+      return new Date(b.updateTime) - new Date(a.updateTime);
+    });
+    const target = deployments.find(function(d) {
+      return d.entryPoints && d.entryPoints.some(function(p) {
+        return p.webApp;
+      });
+    });
+    if (!target) {
+      throw new Error('Web App deployment not found');
+    }
+    return "https://script.google.com/macros/s/" + target.deploymentId + "/exec";
   } catch (e) {
     console.error('getWebAppUrl Error:', e);
     throw new Error('ウェブアプリのURLを取得できませんでした。');

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -1,7 +1,9 @@
 {
   "timeZone": "Asia/Tokyo",
   "dependencies": {
-    "enabledAdvancedServices": []
+    "enabledAdvancedServices": [
+      {"userSymbol": "Script", "serviceId": "script", "version": "v1"}
+    ]
   },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",


### PR DESCRIPTION
## Summary
- enable the Script API
- fetch the latest web app deployment in `getWebAppUrl`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd66c65b0832bb301995abfe6e3fd