### PR TITLE
Add answer sorting controls

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -129,16 +129,17 @@ function doGet() {
  * サーバー側で設定されたシートのデータを取得します。
  */
 
-function getPublishedSheetData(classFilter) {
+function getPublishedSheetData(classFilter, sortMode) {
+  sortMode = sortMode || 'score';
   const settings = getAppSettings();
   const sheetName = settings.activeSheetName;
-  
+
   if (!sheetName) {
     throw new Error('表示するシートが設定されていません。');
   }
-  
+
   // 既存のgetSheetDataロジックを再利用
-  const data = getSheetData(sheetName, classFilter);
+  const data = getSheetData(sheetName, classFilter, sortMode);
 
   // ★改善: フロントエンドでシート名を表示できるよう、レスポンスに含める
   return {
@@ -163,7 +164,8 @@ function getSheets() {
   }
 }
 
-function getSheetData(sheetName, classFilter) {
+function getSheetData(sheetName, classFilter, sortMode) {
+  sortMode = sortMode || 'score';
   try {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
     if (!sheet) throw new Error(`指定されたシート「${sheetName}」が見つかりません。`);
@@ -208,7 +210,17 @@ function getSheetData(sheetName, classFilter) {
       return null;
     }).filter(Boolean);
 
-    rows.sort((a, b) => b.score - a.score);
+    switch (sortMode) {
+      case 'newest':
+        rows.sort((a, b) => b.rowIndex - a.rowIndex);
+        break;
+      case 'random':
+        rows.sort(() => Math.random() - 0.5);
+        break;
+      default:
+        rows.sort((a, b) => b.score - a.score);
+        break;
+    }
     return { header: COLUMN_HEADERS.OPINION, rows: rows };
   } catch(e) {
     console.error(`getSheetData Error for sheet "${sheetName}":`, e);

--- a/src/Page.html
+++ b/src/Page.html
@@ -12,7 +12,7 @@
     .game-btn { transition: all 0.2s ease; border-bottom-width: 4px; text-shadow: 1px 1px 2px rgba(0,0,0,0.4); }
     .game-btn:not(:disabled):hover { transform: translateY(-2px) scale(1.02); box-shadow: 0 0 15px rgba(139, 233, 253, 0.4); }
     .game-btn:active:not(:disabled) { transform: translateY(2px); border-bottom-width: 2px; box-shadow: none; }
-    #classFilter { background-color: #2a2f4a; border: 1px solid #4a4f8a; color: #c0caf5; border-radius: 0.5rem; padding: 0.25rem 0.5rem; }
+    #classFilter, #sortMode { background-color: #2a2f4a; border: 1px solid #4a4f8a; color: #c0caf5; border-radius: 0.5rem; padding: 0.25rem 0.5rem; }
     :focus-visible { outline: 3px solid #8be9fd; outline-offset: 2px; border-radius: 4px; }
     header { position: sticky; top: 0; z-index: 5; }
     .answer-card { will-change: transform, opacity; }
@@ -30,6 +30,11 @@
         <div class="flex items-center gap-4 w-full lg:w-auto">
             <p id="answerCount" class="text-sm text-gray-400 flex items-center gap-2 flex-shrink-0"></p>
             <select id="classFilter" class="hidden text-sm"></select>
+            <select id="sortMode" class="text-sm">
+                <option value="score">スコア順</option>
+                <option value="newest">新着順</option>
+                <option value="random">ランダム</option>
+            </select>
         </div>
         <div class="flex-grow text-center w-full min-w-0">
              <p id="headingLabel" class="text-2xl md:text-3xl font-bold text-pink-400 leading-tight">データを読み込んでいます...</p>
@@ -88,6 +93,7 @@
                 modalStudentName: document.getElementById('modalStudentName'),
                 modalLikeBtn: document.getElementById('modalLikeBtn'),
                 classFilter: document.getElementById('classFilter'),
+                sortMode: document.getElementById('sortMode'),
                 footer: document.getElementById('controlsFooter'),
                 unpublishBtn: document.getElementById('unpublishBtn'),
             };
@@ -101,7 +107,7 @@
             this.pollingInterval = null;
             
             this.gas = {
-                getPublishedSheetData: (classFilter) => this.runGas('getPublishedSheetData', classFilter),
+                getPublishedSheetData: (classFilter, sortMode) => this.runGas('getPublishedSheetData', classFilter, sortMode),
                 addLike: (rowIndex) => this.runGas('addLike', rowIndex),
                 unpublishApp: () => this.runGas('unpublishApp')
             };
@@ -126,6 +132,7 @@
                 }
             });
             this.elements.classFilter.addEventListener('change', () => this.loadSheetData(true));
+            this.elements.sortMode.addEventListener('change', () => this.loadSheetData(true));
             document.addEventListener('keydown', (e) => {
                 if (e.key === 'Escape') {
                     this.hideAnswerModal();
@@ -210,6 +217,7 @@
             this.state.isLoading = true;
             
             const selectedClass = isInitialLoad ? 'すべて' : this.elements.classFilter.value;
+            const selectedSort = this.elements.sortMode.value;
             const oldAnswers = [...this.state.currentAnswers];
 
             if (showLoading) {
@@ -217,7 +225,7 @@
             }
             
             try {
-                const data = await this.gas.getPublishedSheetData(selectedClass);
+                const data = await this.gas.getPublishedSheetData(selectedClass, selectedSort);
                 this.adjustLayout();
                 
                 if (isInitialLoad) {
@@ -372,7 +380,14 @@
                         dataItem.likes = res.newScore;
                         dataItem.hasLiked = !dataItem.hasLiked;
                         dataItem.score = dataItem.reason.length * (1 + dataItem.likes * 0.05);
-                        this.state.currentAnswers.sort((a, b) => b.score - a.score);
+                        const mode = this.elements.sortMode.value;
+                        if (mode === 'newest') {
+                            this.state.currentAnswers.sort((a, b) => b.rowIndex - a.rowIndex);
+                        } else if (mode === 'random') {
+                            this.state.currentAnswers.sort(() => Math.random() - 0.5);
+                        } else {
+                            this.state.currentAnswers.sort((a, b) => b.score - a.score);
+                        }
                         this.updateLikeButtonUI(rowIndex, dataItem.likes, dataItem.hasLiked);
                         this.renderBoard(false, oldAnswers);
                     }


### PR DESCRIPTION
## Summary
- add sort mode support to GAS backend and sorting logic
- add dropdown in front-end for sorting options
- keep answers sorted when likes change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ce0e672b0832b86bdb297f0c95482