### PR TITLE
Add multi-reaction support

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -11,7 +11,9 @@ const COLUMN_HEADERS = {
   CLASS: 'クラスを選択してください。',
   OPINION: 'これまでの学んだことや、経験したことから、根からとり入れた水は、植物のからだのどこを通るのか予想しましょう。',
   REASON: '予想したわけを書きましょう。',
-  LIKES: 'いいね！'
+  UNDERSTAND: 'なるほど！',
+  SUPPORT: '応援したい！',
+  CURIOUS: 'もっと知りたい！'
 };
 const ROSTER_CONFIG = {
   SHEET_NAME: 'sheet 1',
@@ -22,7 +24,7 @@ const ROSTER_CONFIG = {
   HEADER_EMAIL: 'Googleアカウント'
 };
 const SCORING_CONFIG = {
-  LIKE_MULTIPLIER_FACTOR: 0.05 // 1いいね！ごとにスコアが5%増加
+  LIKE_MULTIPLIER_FACTOR: 0.05 // 各リアクション1件ごとにスコアが5%増加
 };
 const APP_PROPERTIES = {
   ACTIVE_SHEET: 'ACTIVE_SHEET_NAME',
@@ -187,12 +189,23 @@ function getSheetData(sheetName, classFilter) {
       const opinion = row[headerIndices[COLUMN_HEADERS.OPINION]];
 
       if (email && opinion) {
-        const likersString = row[headerIndices[COLUMN_HEADERS.LIKES]] || '';
-        const likers = likersString ? likersString.toString().split(',').filter(Boolean) : [];
+        const understandStr = row[headerIndices[COLUMN_HEADERS.UNDERSTAND]] || '';
+        const supportStr = row[headerIndices[COLUMN_HEADERS.SUPPORT]] || '';
+        const curiousStr = row[headerIndices[COLUMN_HEADERS.CURIOUS]] || '';
+        const understandArr = understandStr ? understandStr.toString().split(',').filter(Boolean) : [];
+        const supportArr = supportStr ? supportStr.toString().split(',').filter(Boolean) : [];
+        const curiousArr = curiousStr ? curiousStr.toString().split(',').filter(Boolean) : [];
         const reason = row[headerIndices[COLUMN_HEADERS.REASON]] || '';
-        const likes = likers.length;
+
+        const reactions = {
+          UNDERSTAND: { count: understandArr.length, reacted: userEmail ? understandArr.includes(userEmail) : false },
+          SUPPORT: { count: supportArr.length, reacted: userEmail ? supportArr.includes(userEmail) : false },
+          CURIOUS: { count: curiousArr.length, reacted: userEmail ? curiousArr.includes(userEmail) : false },
+        };
+
+        const totalReactions = reactions.UNDERSTAND.count + reactions.SUPPORT.count + reactions.CURIOUS.count;
         const baseScore = reason.length;
-        const likeMultiplier = 1 + (likes * SCORING_CONFIG.LIKE_MULTIPLIER_FACTOR);
+        const likeMultiplier = 1 + (totalReactions * SCORING_CONFIG.LIKE_MULTIPLIER_FACTOR);
         const totalScore = baseScore * likeMultiplier;
         return {
           rowIndex: dataRows.indexOf(row) + 2,
@@ -200,8 +213,7 @@ function getSheetData(sheetName, classFilter) {
           class: row[headerIndices[COLUMN_HEADERS.CLASS]] || '未分類',
           opinion: opinion,
           reason: reason,
-          likes: likes,
-          hasLiked: userEmail ? likers.includes(userEmail) : false,
+          reactions: reactions,
           score: totalScore
         };
       }
@@ -216,7 +228,7 @@ function getSheetData(sheetName, classFilter) {
   }
 }
 
-function addLike(rowIndex) {
+function addReaction(rowIndex, reactionKey) {
   const lock = LockService.getScriptLock();
   lock.waitLock(10000);
   try {
@@ -227,18 +239,21 @@ function addLike(rowIndex) {
     if (!sheet) throw new Error(`シート '${settings.activeSheetName}' が見つかりません。`);
 
     const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-    const headerIndices = findHeaderIndices(headerRow, [COLUMN_HEADERS.LIKES]);
-    const likesColIndex = headerIndices[COLUMN_HEADERS.LIKES] + 1;
+    if (!COLUMN_HEADERS[reactionKey]) {
+      throw new Error(`Unknown reaction: ${reactionKey}`);
+    }
+    const headerIndices = findHeaderIndices(headerRow, [COLUMN_HEADERS[reactionKey]]);
+    const colIndex = headerIndices[COLUMN_HEADERS[reactionKey]] + 1;
 
-    const likeCell = sheet.getRange(rowIndex, likesColIndex);
-    const likersString = likeCell.getValue().toString();
+    const cell = sheet.getRange(rowIndex, colIndex);
+    const likersString = cell.getValue().toString();
     let likers = likersString ? likersString.split(',').filter(Boolean) : [];
     const userIndex = likers.indexOf(userEmail);
     if (userIndex > -1) { likers.splice(userIndex, 1); } else { likers.push(userEmail); }
-    likeCell.setValue(likers.join(','));
-    return { status: 'ok', newScore: likers.length };
+    cell.setValue(likers.join(','));
+    return { status: 'ok', reaction: reactionKey, newScore: likers.length };
   } catch (error) {
-    console.error('addLike Error:', error);
+    console.error('addReaction Error:', error);
     return { status: 'error', message: `エラーが発生しました: ${error.message}` };
   } finally {
     lock.releaseLock();

--- a/src/Page.html
+++ b/src/Page.html
@@ -49,10 +49,7 @@
           <div id="modalAnswer" class="flex-grow min-h-[200px] mb-4 overflow-y-auto pr-4"></div>
           <div class="text-xs text-gray-400 pt-4 border-t-2 border-dashed border-cyan-400/80 flex justify-between items-center">
               <div><span id="modalStudentName" class="font-bold text-2xl text-gray-200"></span></div>
-              <button type="button" id="modalLikeBtn" class="like-btn flex items-center gap-1.5 transition-colors" aria-label="いいね">
-                  <span id="modalLikeBtnIcon" class="w-7 h-7"></span>
-                  <span id="modalLikeCount" class="like-count font-bold text-2xl text-gray-200">0</span>
-              </button>
+              <div id="modalReactionButtons" class="flex gap-3"></div>
           </div>
       </div>
   </div>
@@ -86,7 +83,7 @@
                 answerModalCard: document.getElementById('answerModalCard'),
                 modalAnswer: document.getElementById('modalAnswer'),
                 modalStudentName: document.getElementById('modalStudentName'),
-                modalLikeBtn: document.getElementById('modalLikeBtn'),
+                modalReactionButtons: document.getElementById('modalReactionButtons'),
                 classFilter: document.getElementById('classFilter'),
                 footer: document.getElementById('controlsFooter'),
                 unpublishBtn: document.getElementById('unpublishBtn'),
@@ -100,9 +97,15 @@
             
             this.pollingInterval = null;
             
+            this.reactionTypes = [
+                { key: 'UNDERSTAND', icon: 'lightbulb', label: 'なるほど！' },
+                { key: 'SUPPORT', icon: 'heart', label: '応援したい！' },
+                { key: 'CURIOUS', icon: 'search', label: 'もっと知りたい！' }
+            ];
+
             this.gas = {
                 getPublishedSheetData: (classFilter) => this.runGas('getPublishedSheetData', classFilter),
-                addLike: (rowIndex) => this.runGas('addLike', rowIndex),
+                addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction),
                 unpublishApp: () => this.runGas('unpublishApp')
             };
             
@@ -171,8 +174,11 @@
                                     class: '3年A組',
                                     opinion: 'これは素晴らしいアイデアだと思います。',
                                     reason: '理由は簡潔で分かりやすく、実現可能性が高いからです。',
-                                    likes: 5,
-                                    hasLiked: false
+                                    reactions: {
+                                        UNDERSTAND: { count: 5, reacted: false },
+                                        SUPPORT: { count: 2, reacted: false },
+                                        CURIOUS: { count: 1, reacted: false }
+                                    }
                                 },
                                 {
                                     rowIndex: 2,
@@ -180,14 +186,18 @@
                                     class: '3年B組',
                                     opinion: '少し改善の余地があると考えます。',
                                     reason: 'より多くの人の意見を聞く必要があると思います。',
-                                    likes: 3,
-                                    hasLiked: true
+                                    reactions: {
+                                        UNDERSTAND: { count: 3, reacted: true },
+                                        SUPPORT: { count: 0, reacted: false },
+                                        CURIOUS: { count: 0, reacted: false }
+                                    }
                                 }
                             ]
                         });
-                    } else if (funcName === 'addLike') {
+                    } else if (funcName === 'addReaction') {
                         resolve({
                             status: 'ok',
+                            reaction: args[1] || 'UNDERSTAND',
                             newScore: Math.floor(Math.random() * 10) + 1
                         });
                     } else if (funcName === 'unpublishApp') {
@@ -309,9 +319,11 @@
                     
                     const oldData = oldRowsMap.get(rowIndex);
                     const newData = newRows.find(r => String(r.rowIndex) === rowIndex);
-                    if (oldData && newData && oldData.likes !== newData.likes) {
-                        gsap.fromTo(card, 
-                            { backgroundColor: 'rgba(250, 204, 21, 0.4)' }, 
+                    const oldTotal = oldData ? Object.values(oldData.reactions || {}).reduce((s, r) => s + r.count, 0) : 0;
+                    const newTotal = newData ? Object.values(newData.reactions || {}).reduce((s, r) => s + r.count, 0) : 0;
+                    if (oldData && newData && oldTotal !== newTotal) {
+                        gsap.fromTo(card,
+                            { backgroundColor: 'rgba(250, 204, 21, 0.4)' },
                             { backgroundColor: 'rgba(26, 27, 38, 0.7)', duration: 0.8, ease: 'expo.out' }
                         );
                     }
@@ -323,39 +335,43 @@
             const card = document.createElement('div');
             card.className = 'answer-card glass-panel rounded-xl p-4 flex flex-col justify-between shadow-lg border-2 border-cyan-400/80 cursor-pointer opacity-0';
             card.dataset.rowIndex = data.rowIndex;
-            
-            const likeIcon = this.getIcon('thumbs-up', 'w-5 h-5');
-            const hasLikedClass = data.hasLiked ? 'liked' : '';
-            
-            card.innerHTML = 
+
+            const reactionButtons = this.reactionTypes.map(rt => {
+                const rData = data.reactions ? data.reactions[rt.key] || { count: 0, reacted: false } : { count: 0, reacted: false };
+                const btnClass = rData.reacted ? 'liked' : '';
+                return '<button type="button" class="reaction-btn like-btn ' + btnClass + '" aria-label="' + rt.label + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '">' +
+                    this.getIcon(rt.icon, 'w-5 h-5') +
+                    '<span class="reaction-count font-bold text-lg text-gray-200">' + rData.count + '</span>' +
+                    '</button>';
+            }).join(' ');
+
+            card.innerHTML =
                 '<div class="flex-grow mb-3 answer-preview">' +
-                '<p class="opinion-text text-cyan-200 whitespace-pre-wrap break-words text-xl md:text-2xl font-semibold leading-tight">' + 
+                '<p class="opinion-text text-cyan-200 whitespace-pre-wrap break-words text-xl md:text-2xl font-semibold leading-tight">' +
                 this.escapeHtml(data.opinion || '') + '</p>' +
-                '<p class="text-gray-100 whitespace-pre-wrap break-words mt-4">' + 
+                '<p class="text-gray-100 whitespace-pre-wrap break-words mt-4">' +
                 this.escapeHtml(data.reason || '') + '</p>' +
                 '</div>' +
                 '<div class="text-xs text-gray-400 pt-3 border-t-2 border-cyan-400/80 border-dashed flex justify-between items-center">' +
                 '<div><span class="font-bold text-sm text-gray-200">' + this.escapeHtml(data.name) + '</span></div>' +
-                '<button type="button" class="like-btn flex items-center gap-1.5 ' + hasLikedClass + '" aria-label="いいね" data-row-index="' + data.rowIndex + '">' +
-                likeIcon +
-                '<span class="like-count font-bold text-lg text-gray-200">' + (data.likes || 0) + '</span>' +
-                '</button>' +
+                '<div class="flex gap-2">' + reactionButtons + '</div>' +
                 '</div>';
-            
+
             card.addEventListener('click', (e) => {
-                if (e.target.closest('.like-btn')) {
+                const btn = e.target.closest('.reaction-btn');
+                if (btn) {
                     e.stopPropagation();
-                    this.handleLike(data.rowIndex);
+                    this.handleReaction(data.rowIndex, btn.dataset.reaction);
                 } else {
                     this.showAnswerModal(data.rowIndex);
                 }
             });
-            
+
             return card;
         }
 
-        async handleLike(rowIndex) {
-            const btns = document.querySelectorAll('[data-row-index="' + rowIndex + '"].like-btn');
+        async handleReaction(rowIndex, reaction) {
+            const btns = document.querySelectorAll('[data-row-index="' + rowIndex + '"][data-reaction="' + reaction + '"]');
             btns.forEach(btn => {
                 gsap.fromTo(btn,
                     { scale: 1 },
@@ -364,36 +380,35 @@
             });
 
             try {
-                const res = await this.gas.addLike(rowIndex);
+                const res = await this.gas.addReaction(rowIndex, reaction);
                 if (res && res.status === 'ok') {
                     const oldAnswers = [...this.state.currentAnswers];
-                    const dataItem = this.state.currentAnswers.find(item => item.rowIndex == rowIndex);
-                    if (dataItem) {
-                        dataItem.likes = res.newScore;
-                        dataItem.hasLiked = !dataItem.hasLiked;
-                        dataItem.score = dataItem.reason.length * (1 + dataItem.likes * 0.05);
+                    const item = this.state.currentAnswers.find(i => i.rowIndex == rowIndex);
+                    if (item && item.reactions && item.reactions[reaction]) {
+                        const rData = item.reactions[reaction];
+                        rData.count = res.newScore;
+                        rData.reacted = !rData.reacted;
+                        const total = Object.values(item.reactions).reduce((sum, r) => sum + r.count, 0);
+                        item.score = item.reason.length * (1 + total * 0.05);
                         this.state.currentAnswers.sort((a, b) => b.score - a.score);
-                        this.updateLikeButtonUI(rowIndex, dataItem.likes, dataItem.hasLiked);
+                        this.updateReactionButtonUI(rowIndex, reaction, rData.count, rData.reacted);
                         this.renderBoard(false, oldAnswers);
                     }
                 } else if (res && res.message) {
                     alert(res.message);
                 }
             } catch (error) {
-                console.error('Failed to add like:', error);
+                console.error('Failed to add reaction:', error);
             }
         }
 
-        updateLikeButtonUI(rowIndex, likes, hasLiked) {
-            document.querySelectorAll('[data-row-index="' + rowIndex + '"]').forEach(el => {
-                const btn = el.querySelector('.like-btn') || el;
-                if (btn.classList.contains('like-btn')) {
-                    const likeCountEl = btn.querySelector('.like-count');
-                    if (likeCountEl) {
-                        likeCountEl.textContent = likes;
-                    }
-                    btn.classList.toggle('liked', hasLiked);
+        updateReactionButtonUI(rowIndex, reaction, count, reacted) {
+            document.querySelectorAll('[data-row-index="' + rowIndex + '"][data-reaction="' + reaction + '"]').forEach(btn => {
+                const countEl = btn.querySelector('.reaction-count');
+                if (countEl) {
+                    countEl.textContent = count;
                 }
+                btn.classList.toggle('liked', reacted);
             });
         }
         
@@ -410,18 +425,20 @@
                 this.escapeHtml(data.reason || '') + '</p>';
             
             this.elements.modalStudentName.textContent = data.name;
-            this.elements.modalLikeBtn.dataset.rowIndex = rowIndex;
-            this.updateLikeButtonUI(rowIndex, data.likes, data.hasLiked);
-            
-            if (!this.elements.modalLikeBtn.dataset.listenerAttached) {
-                this.elements.modalLikeBtn.addEventListener('click', () => {
-                    const id = this.elements.modalLikeBtn.dataset.rowIndex;
-                    if (id) {
-                        this.handleLike(id);
-                    }
+            this.elements.modalReactionButtons.innerHTML = this.reactionTypes.map(rt => {
+                const rData = data.reactions ? data.reactions[rt.key] || { count: 0, reacted: false } : { count: 0, reacted: false };
+                const cls = rData.reacted ? 'liked' : '';
+                return '<button type="button" class="reaction-btn like-btn ' + cls + '" data-row-index="' + rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.label + '">' +
+                    this.getIcon(rt.icon, 'w-7 h-7') +
+                    '<span class="reaction-count font-bold text-2xl text-gray-200">' + rData.count + '</span>' +
+                    '</button>';
+            }).join(' ');
+            this.elements.modalReactionButtons.querySelectorAll('button').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    const r = btn.dataset.reaction;
+                    if (r) this.handleReaction(rowIndex, r);
                 });
-                this.elements.modalLikeBtn.dataset.listenerAttached = 'true';
-            }
+            });
             
             this.elements.answerModalContainer.classList.remove('hidden');
             gsap.to(this.elements.answerModalContainer, { opacity: 1, duration: 0.3 });
@@ -470,7 +487,10 @@
             const icons = {
                 'book-open-check': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H2v15h7c1.7 0 3 1.3 3 3V7c0-2.2-1.8-4-4-4Z"/><path d="m16 12 2 2 4-4"/><path d="M22 6V3h-6c-2.2 0-4 1.8-4 4v14c0-1.7 1.3-3 3-3h7V6Z"/></svg>',
                 'x': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>',
-                'thumbs-up': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2h0a3.13 3.13 0 0 1 3 3.88Z"/></svg>',
+                'heart': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.8 4.6c-1.1-1.1-2.9-1.1-4 0L12 9.4 7.2 4.6c-1.1-1.1-2.9-1.1-4 0s-1.1 2.9 0 4L12 21l8.8-12.4c1.1-1.1 1.1-2.9 0-4z"/></svg>',
+                'lightbulb': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M12 2a7 7 0 0 0-7 7 7 7 0 0 0 4 6v1h6v-1a7 7 0 0 0 4-6 7 7 0 0 0-7-7z"/></svg>',
+                'search': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>',
+                'smile': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9" y2="9"/><line x1="15" y1="9" x2="15" y2="9"/></svg>',
                 'grid-2x2': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 12h18"/><path d="M12 3v18"/></svg>',
                 'users': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>',
             };
@@ -479,7 +499,6 @@
         
         renderIcons() {
             document.getElementById('answerModalCloseBtn').innerHTML = this.getIcon('x', 'w-6 h-6');
-            document.getElementById('modalLikeBtnIcon').innerHTML = this.getIcon('thumbs-up');
             document.getElementById('footerIcon').innerHTML = this.getIcon('grid-2x2');
         }
 


### PR DESCRIPTION
## Summary
- extend `COLUMN_HEADERS` with new reactions "なるほど！", "応援したい！", and "もっと知りたい！"
- calculate counts for the new reactions in `getSheetData`
- remove the old "いいね！" reaction and update UI reaction buttons
- add SVG icons for lightbulb and search

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cdd851e5c832bbbe0459e0da984a6