### PR TITLE
Add tests for sheet data and like logic

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -317,7 +317,7 @@ function findHeaderIndices(sheetHeaders, requiredHeaders) {
 
 // Export for Jest testing
 if (typeof module !== 'undefined') {
-  module.exports = { findHeaderIndices };
+  module.exports = { findHeaderIndices, getSheetData, addLike };
 }
 
 function clearRosterCache() {

--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -1,0 +1,56 @@
+const { addLike } = require('../src/Code.gs');
+
+// headers copied from Code.gs
+const HEADERS = {
+  EMAIL: 'メールアドレス',
+  CLASS: 'クラスを選択してください。',
+  OPINION: 'これまでの学んだことや、経験したことから、根からとり入れた水は、植物のからだのどこを通るのか予想しましょう。',
+  REASON: '予想したわけを書きましょう。',
+  LIKES: 'いいね！'
+};
+
+function buildSheet() {
+  const headerRow = [HEADERS.EMAIL, HEADERS.CLASS, HEADERS.OPINION, HEADERS.REASON, HEADERS.LIKES];
+  let likeValue = 'a@example.com';
+  return {
+    getLastColumn: () => headerRow.length,
+    getRange: jest.fn((row, col, numRows, numCols) => {
+      if (row === 1) {
+        return { getValues: () => [headerRow] };
+      }
+      return {
+        getValue: () => likeValue,
+        setValue: (val) => { likeValue = val; }
+      };
+    })
+  };
+}
+
+function setupMocks(userEmail, sheet) {
+  global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
+  global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
+  global.PropertiesService = { getScriptProperties: () => ({ getProperty: () => 'Sheet1' }) };
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
+  };
+}
+
+afterEach(() => {
+  delete global.LockService;
+  delete global.Session;
+  delete global.PropertiesService;
+  delete global.SpreadsheetApp;
+});
+
+ test('addLike toggles user in list', () => {
+  const sheet = buildSheet();
+  setupMocks('b@example.com', sheet);
+
+  const result1 = addLike(2);
+  expect(result1.status).toBe('ok');
+  expect(result1.newScore).toBe(2);
+
+  const result2 = addLike(2);
+  expect(result2.status).toBe('ok');
+  expect(result2.newScore).toBe(1);
+});

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -1,0 +1,64 @@
+const { getSheetData } = require('../src/Code.gs');
+
+// Japanese column headers copied from Code.gs
+const HEADERS = {
+  EMAIL: 'メールアドレス',
+  CLASS: 'クラスを選択してください。',
+  OPINION: 'これまでの学んだことや、経験したことから、根からとり入れた水は、植物のからだのどこを通るのか予想しましょう。',
+  REASON: '予想したわけを書きましょう。',
+  LIKES: 'いいね！'
+};
+
+function setupMocks(rows, userEmail) {
+  const rosterHeaders = ['姓', '名', 'ニックネーム', 'Googleアカウント'];
+  const rosterRows = [
+    ['A', 'Alice', '', 'a@example.com'],
+    ['B', 'Bob', '', 'b@example.com']
+  ];
+
+  // Mock SpreadsheetApp
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({
+      getSheetByName: (name) => {
+        if (name === 'Sheet1') {
+          return { getDataRange: () => ({ getValues: () => rows }) };
+        }
+        if (name === 'sheet 1') {
+          return { getDataRange: () => ({ getValues: () => [rosterHeaders, ...rosterRows] }) };
+        }
+        return null;
+      }
+    })
+  };
+
+  // Mock other global services
+  global.Session = {
+    getActiveUser: () => ({ getEmail: () => userEmail })
+  };
+  global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
+}
+
+afterEach(() => {
+  delete global.SpreadsheetApp;
+  delete global.Session;
+  delete global.CacheService;
+});
+
+test('getSheetData filters and scores rows', () => {
+  const data = [
+    [HEADERS.EMAIL, HEADERS.CLASS, HEADERS.OPINION, HEADERS.REASON, HEADERS.LIKES],
+    ['a@example.com', '1-1', 'Opinion1', 'Reason1', 'b@example.com'],
+    ['b@example.com', '1-1', 'Opinion2', 'Reason2', ''],
+    ['', '', '', '', ''] // ignored
+  ];
+  setupMocks(data, 'b@example.com');
+
+  const result = getSheetData('Sheet1');
+
+  expect(result.header).toBe(HEADERS.OPINION);
+  expect(result.rows).toHaveLength(2);
+  expect(result.rows[0].name).toBe('A Alice');
+  expect(result.rows[0].hasLiked).toBe(true);
+  expect(result.rows[1].name).toBe('B Bob');
+  expect(result.rows[1].hasLiked).toBe(false);
+});


### PR DESCRIPTION
## Summary
- export `getSheetData` and `addLike`
- add Jest tests for `getSheetData`
- add Jest tests for `addLike`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ce207b744832b9b044dae034bc503