### PR TITLE
Add tests for sheet data and like logic

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -317,7 +317,7 @@ function findHeaderIndices(sheetHeaders, requiredHeaders) {
 
 // Export for Jest testing
 if (typeof module !== 'undefined') {
-  module.exports = { findHeaderIndices };
+  module.exports = { COLUMN_HEADERS, findHeaderIndices, getSheetData, addLike };
 }
 
 function clearRosterCache() {

--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -1,0 +1,55 @@
+const { addLike, COLUMN_HEADERS } = require('../src/Code.gs');
+
+function buildSheet() {
+  const headerRow = [COLUMN_HEADERS.EMAIL, COLUMN_HEADERS.CLASS, COLUMN_HEADERS.OPINION, COLUMN_HEADERS.REASON, COLUMN_HEADERS.LIKES];
+  let likeValue = 'a@example.com';
+  return {
+    getLastColumn: () => headerRow.length,
+    getRange: jest.fn((row, col, numRows, numCols) => {
+      if (row === 1) {
+        return { getValues: () => [headerRow] };
+      }
+      return {
+        getValue: () => likeValue,
+        setValue: (val) => { likeValue = val; }
+      };
+    })
+  };
+}
+
+function setupMocks(userEmail, sheet) {
+  global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
+  global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
+  global.PropertiesService = { getScriptProperties: () => ({ getProperty: () => 'Sheet1' }) };
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
+  };
+}
+
+afterEach(() => {
+  delete global.LockService;
+  delete global.Session;
+  delete global.PropertiesService;
+  delete global.SpreadsheetApp;
+});
+
+test('addLike toggles user in list', () => {
+  const sheet = buildSheet();
+  setupMocks('b@example.com', sheet);
+
+  const result1 = addLike(2);
+  expect(result1.status).toBe('ok');
+  expect(result1.newScore).toBe(2);
+
+  const result2 = addLike(2);
+  expect(result2.status).toBe('ok');
+  expect(result2.newScore).toBe(1);
+});
+
+test('addLike errors when user email is empty', () => {
+  const sheet = buildSheet();
+  setupMocks('', sheet);
+
+  const result = addLike(2);
+  expect(result.status).toBe('error');
+});

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -1,0 +1,68 @@
+const { getSheetData, COLUMN_HEADERS } = require('../src/Code.gs');
+
+function setupMocks(rows, userEmail) {
+  const rosterHeaders = ['姓', '名', 'ニックネーム', 'Googleアカウント'];
+  const rosterRows = [
+    ['A', 'Alice', '', 'a@example.com'],
+    ['B', 'Bob', '', 'b@example.com']
+  ];
+
+  // Mock SpreadsheetApp
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({
+      getSheetByName: (name) => {
+        if (name === 'Sheet1') {
+          return { getDataRange: () => ({ getValues: () => rows }) };
+        }
+        if (name === 'sheet 1') {
+          return { getDataRange: () => ({ getValues: () => [rosterHeaders, ...rosterRows] }) };
+        }
+        return null;
+      }
+    })
+  };
+
+  // Mock other global services
+  global.Session = {
+    getActiveUser: () => ({ getEmail: () => userEmail })
+  };
+  global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
+}
+
+afterEach(() => {
+  delete global.SpreadsheetApp;
+  delete global.Session;
+  delete global.CacheService;
+});
+
+test('getSheetData filters and scores rows', () => {
+  const data = [
+    [COLUMN_HEADERS.EMAIL, COLUMN_HEADERS.CLASS, COLUMN_HEADERS.OPINION, COLUMN_HEADERS.REASON, COLUMN_HEADERS.LIKES],
+    ['a@example.com', '1-1', 'Opinion1', 'Reason1', 'b@example.com'],
+    ['b@example.com', '1-1', 'Opinion2', 'Reason2', ''],
+    ['', '', '', '', ''] // ignored
+  ];
+  setupMocks(data, 'b@example.com');
+
+  const result = getSheetData('Sheet1');
+
+  expect(result.header).toBe(COLUMN_HEADERS.OPINION);
+  expect(result.rows).toHaveLength(2);
+  expect(result.rows[0].name).toBe('A Alice');
+  expect(result.rows[0].hasLiked).toBe(true);
+  expect(result.rows[1].name).toBe('B Bob');
+  expect(result.rows[1].hasLiked).toBe(false);
+});
+
+test('getSheetData sorts by newest when specified', () => {
+  const data = [
+    [COLUMN_HEADERS.EMAIL, COLUMN_HEADERS.CLASS, COLUMN_HEADERS.OPINION, COLUMN_HEADERS.REASON, COLUMN_HEADERS.LIKES],
+    ['first@example.com', '1-1', 'Old', 'A', ''],
+    ['second@example.com', '1-1', 'New', 'B', '']
+  ];
+  setupMocks(data, '');
+
+  const result = getSheetData('Sheet1', undefined, 'newest');
+
+  expect(result.rows.map(r => r.rowIndex)).toEqual([3, 2]);
+});


### PR DESCRIPTION
## Summary
- export `COLUMN_HEADERS` for reuse in tests
- expand `getSheetData` tests, including newest sorting
- expand `addLike` tests and use shared constants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ce207b744832b9b044dae034bc503