### PR TITLE
Add display mode toggle for names

### DIFF
--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -27,6 +27,21 @@
         </div>
       </div>
 
+      <!-- Display Mode -->
+      <div class="mb-6">
+        <h4 class="font-semibold text-gray-700 mb-3">表示設定</h4>
+        <div class="bg-white p-3 rounded-lg shadow-md flex flex-col gap-2">
+          <div>
+            <input type="radio" id="mode-anonymous" name="displayMode" value="anonymous" checked>
+            <label for="mode-anonymous" class="ml-1">匿名で表示（生徒間の画面では名前を非表示）</label>
+          </div>
+          <div>
+            <input type="radio" id="mode-named" name="displayMode" value="named">
+            <label for="mode-named" class="ml-1">名前を表示（全ての画面で名前を表示）</label>
+          </div>
+        </div>
+      </div>
+
       <!-- Actions -->
       <div>
         <h3 class="font-semibold text-gray-700 mb-3">2. 操作を選択</h3>
@@ -51,15 +66,29 @@
         publishBtn: document.getElementById('publish-btn'),
         unpublishBtn: document.getElementById('unpublish-btn'),
         messageArea: document.getElementById('message-area'),
-        webAppLink: document.getElementById('webapp-link')
+        webAppLink: document.getElementById('webapp-link'),
+        modeAnonymous: document.getElementById('mode-anonymous'),
+        modeNamed: document.getElementById('mode-named')
       };
 
       let selectedSheet = null;
+      let displayMode = 'anonymous';
 
       document.addEventListener('DOMContentLoaded', () => {
         loadInitialState();
         elements.publishBtn.addEventListener('click', publish);
         elements.unpublishBtn.addEventListener('click', unpublish);
+        elements.modeNamed.addEventListener('click', () => {
+          if (!confirm('注意：生徒の心理的安全性を考慮し、通常は匿名表示を推奨します。本当に名前を表示しますか？')) {
+            elements.modeAnonymous.checked = true;
+            displayMode = 'anonymous';
+          } else {
+            displayMode = 'named';
+          }
+        });
+        elements.modeAnonymous.addEventListener('click', () => {
+          displayMode = 'anonymous';
+        });
       });
 
       function loadInitialState() {
@@ -76,6 +105,12 @@
 
       function updateUI(status) {
         selectedSheet = status.activeSheetName;
+        displayMode = status.displayMode || 'anonymous';
+        if (displayMode === 'named') {
+          elements.modeNamed.checked = true;
+        } else {
+          elements.modeAnonymous.checked = true;
+        }
         
         if (status.isPublished && status.activeSheetName) {
           elements.statusText.innerHTML = `公開中: <span class="font-bold text-green-700">${status.activeSheetName}</span>`;
@@ -130,6 +165,9 @@
           return;
         }
         setLoading(true, "公開処理中...");
+        google.script.run
+          .withFailureHandler(showError)
+          .saveDisplayMode(displayMode);
         google.script.run
           .withSuccessHandler((msg) => {
             showMessage(msg, 'green');

--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -1,7 +1,7 @@
-const { addLike, COLUMN_HEADERS } = require('../src/Code.gs');
+const { addReaction, COLUMN_HEADERS } = require('../src/Code.gs');
 
 function buildSheet() {
-  const headerRow = [COLUMN_HEADERS.EMAIL, COLUMN_HEADERS.CLASS, COLUMN_HEADERS.OPINION, COLUMN_HEADERS.REASON, COLUMN_HEADERS.LIKES];
+  const headerRow = [COLUMN_HEADERS.EMAIL, COLUMN_HEADERS.CLASS, COLUMN_HEADERS.OPINION, COLUMN_HEADERS.REASON, COLUMN_HEADERS.UNDERSTAND];
   let likeValue = 'a@example.com';
   return {
     getLastColumn: () => headerRow.length,
@@ -33,23 +33,23 @@ afterEach(() => {
   delete global.SpreadsheetApp;
 });
 
-test('addLike toggles user in list', () => {
+test('addReaction toggles user in list', () => {
   const sheet = buildSheet();
   setupMocks('b@example.com', sheet);
 
-  const result1 = addLike(2);
+  const result1 = addReaction(2, 'UNDERSTAND');
   expect(result1.status).toBe('ok');
   expect(result1.newScore).toBe(2);
 
-  const result2 = addLike(2);
+  const result2 = addReaction(2, 'UNDERSTAND');
   expect(result2.status).toBe('ok');
   expect(result2.newScore).toBe(1);
 });
 
-test('addLike errors when user email is empty', () => {
+test('addReaction errors when user email is empty', () => {
   const sheet = buildSheet();
   setupMocks('', sheet);
 
-  const result = addLike(2);
+  const result = addReaction(2, 'UNDERSTAND');
   expect(result.status).toBe('error');
 });

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -27,20 +27,31 @@ function setupMocks(rows, userEmail) {
     getActiveUser: () => ({ getEmail: () => userEmail })
   };
   global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
+  global.PropertiesService = { getScriptProperties: () => ({ getProperty: () => 'named' }) };
 }
 
 afterEach(() => {
   delete global.SpreadsheetApp;
   delete global.Session;
   delete global.CacheService;
+  delete global.PropertiesService;
 });
 
 test('getSheetData filters and scores rows', () => {
   const data = [
-    [COLUMN_HEADERS.EMAIL, COLUMN_HEADERS.CLASS, COLUMN_HEADERS.OPINION, COLUMN_HEADERS.REASON, COLUMN_HEADERS.LIKES],
-    ['a@example.com', '1-1', 'Opinion1', 'Reason1', 'b@example.com'],
-    ['b@example.com', '1-1', 'Opinion2', 'Reason2', ''],
-    ['', '', '', '', ''] // ignored
+    [
+      COLUMN_HEADERS.EMAIL,
+      COLUMN_HEADERS.CLASS,
+      COLUMN_HEADERS.OPINION,
+      COLUMN_HEADERS.REASON,
+      COLUMN_HEADERS.UNDERSTAND,
+      COLUMN_HEADERS.SUPPORT,
+      COLUMN_HEADERS.CURIOUS,
+      COLUMN_HEADERS.HIGHLIGHT
+    ],
+    ['a@example.com', '1-1', 'Opinion1', 'Reason1', 'b@example.com', '', '', 'false'],
+    ['b@example.com', '1-1', 'Opinion2', 'Reason2', '', '', '', 'false'],
+    ['', '', '', '', '', '', '', ''] // ignored
   ];
   setupMocks(data, 'b@example.com');
 
@@ -49,16 +60,25 @@ test('getSheetData filters and scores rows', () => {
   expect(result.header).toBe(COLUMN_HEADERS.OPINION);
   expect(result.rows).toHaveLength(2);
   expect(result.rows[0].name).toBe('A Alice');
-  expect(result.rows[0].hasLiked).toBe(true);
+  expect(result.rows[0].reactions.UNDERSTAND.reacted).toBe(true);
   expect(result.rows[1].name).toBe('B Bob');
-  expect(result.rows[1].hasLiked).toBe(false);
+  expect(result.rows[1].reactions.UNDERSTAND.reacted).toBe(false);
 });
 
 test('getSheetData sorts by newest when specified', () => {
   const data = [
-    [COLUMN_HEADERS.EMAIL, COLUMN_HEADERS.CLASS, COLUMN_HEADERS.OPINION, COLUMN_HEADERS.REASON, COLUMN_HEADERS.LIKES],
-    ['first@example.com', '1-1', 'Old', 'A', ''],
-    ['second@example.com', '1-1', 'New', 'B', '']
+    [
+      COLUMN_HEADERS.EMAIL,
+      COLUMN_HEADERS.CLASS,
+      COLUMN_HEADERS.OPINION,
+      COLUMN_HEADERS.REASON,
+      COLUMN_HEADERS.UNDERSTAND,
+      COLUMN_HEADERS.SUPPORT,
+      COLUMN_HEADERS.CURIOUS,
+      COLUMN_HEADERS.HIGHLIGHT
+    ],
+    ['first@example.com', '1-1', 'Old', 'A', '', '', '', 'false'],
+    ['second@example.com', '1-1', 'New', 'B', '', '', '', 'false']
   ];
   setupMocks(data, '');
 


### PR DESCRIPTION
## Summary
- allow selecting display mode (anonymous or named) in admin panel
- store the choice in Apps Script properties
- return names based on the saved display mode
- adjust tests to work with reaction-based columns

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ceb342b88832bb447b41485d9185d