### PR TITLE
Fix heading update when sheet data empty

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -246,9 +246,10 @@
                     this.elements.sheetNameText.textContent = 'シート: ' + data.sheetName;
                 }
 
-                if (JSON.stringify(this.state.currentAnswers) !== JSON.stringify(data.rows)) {
-                    this.state.currentAnswers = data.rows;
-                    this.elements.headingLabel.textContent = data.header || '問題';
+                const changed = JSON.stringify(this.state.currentAnswers) !== JSON.stringify(data.rows);
+                this.state.currentAnswers = data.rows;
+                this.elements.headingLabel.textContent = data.header || '問題';
+                if (changed || oldAnswers.length === 0) {
                     this.renderBoard(false, oldAnswers);
                 }
             } catch (error) {


### PR DESCRIPTION
## Summary
- ensure heading updates even if sheet has no rows
- re-render board on initial load for empty sheets

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ceff6633c832ba848d0eefea92bc7