### PR TITLE
Improve header matching

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -366,13 +366,20 @@ function getAndCacheHeaderIndices(sheetName, headerRow) {
 
 function findHeaderIndices(sheetHeaders, requiredHeaders) {
   const indices = {};
-  const trimmedSheetHeaders = sheetHeaders.map(h => (typeof h === 'string' ? h.trim() : h));
+  const normalize = h => (typeof h === 'string' ? h.replace(/\s+/g, '') : h);
+  const normalizedHeaders = sheetHeaders.map(normalize);
   const missingHeaders = [];
   requiredHeaders.forEach(headerName => {
-    const index = trimmedSheetHeaders.indexOf(headerName);
-    if (index !== -1) { indices[headerName] = index; } else { missingHeaders.push(headerName); }
+    const index = normalizedHeaders.indexOf(normalize(headerName));
+    if (index !== -1) {
+      indices[headerName] = index;
+    } else {
+      missingHeaders.push(headerName);
+    }
   });
-  if (missingHeaders.length > 0) { throw new Error(`必須ヘッダーが見つかりません: [${missingHeaders.join(', ')}]`); }
+  if (missingHeaders.length > 0) {
+    throw new Error(`必須ヘッダーが見つかりません: [${missingHeaders.join(', ')}]`);
+  }
   return indices;
 }
 

--- a/tests/findHeaderIndices.test.js
+++ b/tests/findHeaderIndices.test.js
@@ -9,3 +9,9 @@ test('findHeaderIndices returns indices for existing headers', () => {
 test('findHeaderIndices throws for missing headers', () => {
   expect(() => findHeaderIndices(['X'], ['X', 'Y'])).toThrow('必須ヘッダーが見つかりません');
 });
+
+test('findHeaderIndices ignores whitespace differences', () => {
+  const headers = ['A B', ' C\nD '];
+  const required = ['AB', 'CD'];
+  expect(findHeaderIndices(headers, required)).toEqual({ AB:0, CD:1 });
+});


### PR DESCRIPTION
## Summary
- make header name detection ignore whitespace differences
- add regression test for header whitespace

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cf35839e0832b8aed8241adc7054b