### PR TITLE
Clear active sheet when unpublishing

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -96,6 +96,7 @@ function publishApp(sheetName) {
 function unpublishApp() {
   const properties = PropertiesService.getScriptProperties();
   properties.setProperty(APP_PROPERTIES.IS_PUBLISHED, 'false');
+  properties.deleteProperty(APP_PROPERTIES.ACTIVE_SHEET);
   return 'アプリを非公開にしました。';
 }
 


### PR DESCRIPTION
## Summary
- update `unpublishApp()` so it also removes `ACTIVE_SHEET`
- keep Apps Script files in `src/` per repo guidelines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cfdf9f6dc832bb02decee5ced47fa