### PR TITLE
Add tests for toggleHighlight

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -386,7 +386,13 @@ function findHeaderIndices(sheetHeaders, requiredHeaders) {
 
 // Export for Jest testing
 if (typeof module !== 'undefined') {
-  module.exports = { COLUMN_HEADERS, findHeaderIndices, getSheetData, addReaction };
+  module.exports = {
+    COLUMN_HEADERS,
+    findHeaderIndices,
+    getSheetData,
+    addReaction,
+    toggleHighlight
+  };
 }
 
 function clearRosterCache() {

--- a/tests/toggleHighlight.test.js
+++ b/tests/toggleHighlight.test.js
@@ -1,0 +1,43 @@
+const { toggleHighlight, COLUMN_HEADERS } = require('../src/Code.gs');
+
+function buildSheet() {
+  const headerRow = [COLUMN_HEADERS.HIGHLIGHT];
+  let highlight = false;
+  return {
+    getLastColumn: () => headerRow.length,
+    getRange: jest.fn((row, col, numRows, numCols) => {
+      if (row === 1) {
+        return { getValues: () => [headerRow] };
+      }
+      return {
+        getValue: () => highlight,
+        setValue: (val) => { highlight = val; }
+      };
+    })
+  };
+}
+
+function setupMocks(sheet) {
+  global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
+  global.PropertiesService = { getScriptProperties: () => ({ getProperty: () => 'Sheet1' }) };
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
+  };
+}
+
+afterEach(() => {
+  delete global.LockService;
+  delete global.PropertiesService;
+  delete global.SpreadsheetApp;
+});
+
+test('toggleHighlight flips stored value', () => {
+  const sheet = buildSheet();
+  setupMocks(sheet);
+
+  const result1 = toggleHighlight(2);
+  expect(result1).toEqual({ status: 'ok', highlight: true });
+
+  const result2 = toggleHighlight(2);
+  expect(result2).toEqual({ status: 'ok', highlight: false });
+});


### PR DESCRIPTION
## Summary
- export `toggleHighlight` for jest tests
- add `tests/toggleHighlight.test.js` mirroring style of existing tests
- ensure npm tests pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d00acae00832bad14f233d10c01b5