### PR TITLE
Add getPublishedSheetData tests

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -148,7 +148,10 @@ function doGet() {
 
 function getPublishedSheetData(classFilter, sortMode) {
   sortMode = sortMode || 'score';
-  const settings = getAppSettings();
+  const useExports = typeof module !== 'undefined' && module.exports;
+  const settings = useExports && module.exports.getAppSettings !== getAppSettings
+      ? module.exports.getAppSettings()
+      : getAppSettings();
   const sheetName = settings.activeSheetName;
 
   if (!sheetName) {
@@ -156,7 +159,9 @@ function getPublishedSheetData(classFilter, sortMode) {
   }
 
   // 既存のgetSheetDataロジックを再利用
-  const data = getSheetData(sheetName, classFilter, sortMode);
+  const data = useExports && module.exports.getSheetData !== getSheetData
+      ? module.exports.getSheetData(sheetName, classFilter, sortMode)
+      : getSheetData(sheetName, classFilter, sortMode);
 
   // ★改善: フロントエンドでシート名を表示できるよう、レスポンスに含める
   return {
@@ -386,7 +391,14 @@ function findHeaderIndices(sheetHeaders, requiredHeaders) {
 
 // Export for Jest testing
 if (typeof module !== 'undefined') {
-  module.exports = { COLUMN_HEADERS, findHeaderIndices, getSheetData, addReaction };
+  module.exports = {
+    COLUMN_HEADERS,
+    findHeaderIndices,
+    getSheetData,
+    addReaction,
+    getPublishedSheetData,
+    getAppSettings
+  };
 }
 
 function clearRosterCache() {

--- a/tests/getPublishedSheetData.test.js
+++ b/tests/getPublishedSheetData.test.js
@@ -1,0 +1,15 @@
+const code = require('../src/Code.gs');
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('getPublishedSheetData forwards parameters and returns data', () => {
+  jest.spyOn(code, 'getAppSettings').mockReturnValue({ activeSheetName: 'Sheet1' });
+  jest.spyOn(code, 'getSheetData').mockReturnValue({ header: 'HEADER', rows: [1, 2, 3] });
+
+  const result = code.getPublishedSheetData('classA', 'newest');
+
+  expect(code.getSheetData).toHaveBeenCalledWith('Sheet1', 'classA', 'newest');
+  expect(result).toEqual({ sheetName: 'Sheet1', header: 'HEADER', rows: [1, 2, 3] });
+});


### PR DESCRIPTION
## Summary
- export `getPublishedSheetData` and `getAppSettings`
- allow dependency injection in `getPublishedSheetData` for tests
- add `tests/getPublishedSheetData.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d00bd79ac832ba7725546b4849d39