### PR TITLE
Remove debug log & web app URL

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -399,16 +399,6 @@ function logDebug(message) {
   } catch (e) {}
 }
 
-function getDebugLog() {
-  if (typeof PropertiesService === 'undefined') return [];
-  try {
-    const props = PropertiesService.getScriptProperties();
-    const raw = props.getProperty('DEBUG_LOG') || '[]';
-    return JSON.parse(raw);
-  } catch (e) {
-    return [];
-  }
-}
 
 // Export for Jest testing
 if (typeof module !== 'undefined') {
@@ -419,7 +409,6 @@ if (typeof module !== 'undefined') {
     addReaction,
     toggleHighlight,
     logDebug,
-    getDebugLog,
   };
 }
 
@@ -434,29 +423,3 @@ function clearRosterCache() {
   } catch (e) { /* no-op */ }
 }
 
-/**
- * 公開中のウェブアプリのURLを取得します。
- * @return {string} ウェブアプリのURL
- */
-function getWebAppUrl() {
-  try {
-    const scriptId = ScriptApp.getScriptId();
-    const list = Script.Deployments.list(scriptId);
-    const deployments = (list && list.deployments) || [];
-    deployments.sort(function(a, b) {
-      return new Date(b.updateTime) - new Date(a.updateTime);
-    });
-    const target = deployments.find(function(d) {
-      return d.entryPoints && d.entryPoints.some(function(p) {
-        return p.webApp;
-      });
-    });
-    if (!target) {
-      throw new Error('Web App deployment not found');
-    }
-    return "https://script.google.com/macros/s/" + target.deploymentId + "/exec";
-  } catch (e) {
-    console.error('getWebAppUrl Error:', e);
-    throw new Error('ウェブアプリのURLを取得できませんでした。');
-  }
-}

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -16,7 +16,6 @@
       <div class="mb-6 p-4 rounded-lg bg-white shadow-md">
         <h3 class="font-semibold text-gray-700 mb-2">現在の状態</h3>
         <p id="status-text" class="text-gray-600">状態を読み込み中...</p>
-        <p id="webapp-link" class="text-blue-600 text-sm mt-2"></p>
       </div>
 
       <!-- Sheet Selection -->
@@ -57,11 +56,6 @@
       
       <div id="message-area" class="mt-4 text-center text-sm h-5"></div>
 
-      <div id="debug-container" class="mt-6">
-        <h3 class="font-semibold text-gray-700 mb-2">デバッグログ</h3>
-        <div id="debug-log" class="bg-black text-green-300 text-xs font-mono p-2 rounded-lg h-32 overflow-y-auto"></div>
-      </div>
-
     </div>
 
     <script>
@@ -71,10 +65,8 @@
         publishBtn: document.getElementById('publish-btn'),
         unpublishBtn: document.getElementById('unpublish-btn'),
         messageArea: document.getElementById('message-area'),
-        webAppLink: document.getElementById('webapp-link'),
         modeAnonymous: document.getElementById('mode-anonymous'),
-        modeNamed: document.getElementById('mode-named'),
-        debugLog: document.getElementById('debug-log')
+        modeNamed: document.getElementById('mode-named')
       };
 
       let selectedSheet = null;
@@ -82,7 +74,6 @@
 
       document.addEventListener('DOMContentLoaded', () => {
         loadInitialState();
-        loadDebugLog();
         elements.publishBtn.addEventListener('click', publish);
         elements.unpublishBtn.addEventListener('click', unpublish);
         elements.modeNamed.addEventListener('click', () => {
@@ -104,10 +95,6 @@
           .withSuccessHandler(updateUI)
           .withFailureHandler(showError)
           .getAdminSettings();
-        google.script.run
-          .withSuccessHandler(updateWebAppUrl)
-          .withFailureHandler(() => {})
-          .getWebAppUrl();
       }
 
       function updateUI(status) {
@@ -158,28 +145,6 @@
         setLoading(false);
       }
 
-      function updateWebAppUrl(url) {
-        if (url) {
-          elements.webAppLink.innerHTML = `<a href="${url}" target="_blank" class="underline">公開中のページを開く</a>`;
-        } else {
-          elements.webAppLink.textContent = 'ウェブアプリがデプロイされていません';
-        }
-      }
-
-      function loadDebugLog() {
-        google.script.run
-          .withSuccessHandler(lines => {
-            elements.debugLog.innerHTML = '';
-            lines.forEach(line => {
-              const div = document.createElement('div');
-              div.textContent = line;
-              elements.debugLog.appendChild(div);
-            });
-            elements.debugLog.scrollTop = elements.debugLog.scrollHeight;
-          })
-          .withFailureHandler(() => {})
-          .getDebugLog();
-      }
 
       function publish() {
         if (!selectedSheet) {
@@ -193,7 +158,6 @@
               .withSuccessHandler((msg) => {
                 showMessage(msg, 'green');
                 loadInitialState();
-                loadDebugLog();
               })
               .withFailureHandler(showError)
               .publishApp(selectedSheet);
@@ -208,7 +172,6 @@
           .withSuccessHandler((msg) => {
             showMessage(msg, 'green');
             loadInitialState();
-            loadDebugLog();
           })
           .withFailureHandler(showError)
           .unpublishApp();
@@ -231,7 +194,6 @@
       function showError(error) {
         showMessage(error.message, 'red');
         setLoading(false);
-        loadDebugLog();
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- drop `getWebAppUrl` and `getDebugLog` functions
- remove admin panel sections for web‑app link and debug log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d10dc1888832b93500ad6346cd31d