### PR TITLE
Improve user info retrieval and caching

### DIFF
--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -18,7 +18,7 @@ function buildSheet() {
 }
 
 function setupMocks(userEmail, sheet) {
-  global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
+  global.LockService = { getScriptLock: () => ({ tryLock: jest.fn(() => true), releaseLock: jest.fn() }) };
   global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
   global.PropertiesService = { getScriptProperties: () => ({ getProperty: () => 'Sheet1' }) };
   global.SpreadsheetApp = {


### PR DESCRIPTION
## Summary
- ensure `Session.getActiveUser()` errors are handled gracefully in `doGet`
- add `CACHE_KEYS` constant and update cache functions
- enhance locking logic in `addReaction`
- adjust unit tests for new locking implementation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d14506a20832bad173aa8716c2e89