### PR TITLE
Fix email injection and stray text

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -7,6 +7,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- deferを削除してGSAPを即座に利用可能にする -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+  <script>
+    window.userEmail = "<?= userEmail ?>";
+  </script>
   <style>
     body { color: #c0caf5; }
     .glass-panel { background: rgba(26, 27, 38, 0.7); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255, 255, 255, 0.1); }
@@ -72,7 +75,7 @@
 
   <script>
     // 環境変数の安全な取得
-    const userEmail = typeof window !== 'undefined' && window.userEmail ? window.userEmail : "test@example.com";
+    const userEmail = typeof window !== 'undefined' ? window.userEmail : "";
     const isAdmin = userEmail.split('@')[0].includes('t');
 
     class StudyQuestApp {
@@ -637,4 +640,3 @@
 </body>
 </html>
 
-ソース


### PR DESCRIPTION
## Summary
- pass `userEmail` from server to client in Page.html
- remove default fallback email
- delete stray Japanese text after closing `</html>` tag

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d164a62dc832bb530ebe50db0224b