### PR TITLE
Add admin mode URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ subdirectories under `src`.**
 
 Add a column named `Highlight` to your spreadsheet (using a checkbox or TRUE/FALSE values).
 Rows marked as `TRUE` will appear with a yellow border on the board.
-When viewing the board as an administrator (your Google account name contains `t`),
+When the board is opened with the `?admin=1` query parameter,
 a star button is shown on each answer card to toggle this flag.
+Use the "Open as administrator" link in the sheet selector sidebar to launch the board in this mode.
 
 
 ## Continuous Integration

--- a/src/Page.html
+++ b/src/Page.html
@@ -9,6 +9,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
   <script>
     window.userEmail = "<?= userEmail ?>";
+    window.isAdminPage = <?= isAdmin ? 'true' : 'false' ?>;
   </script>
   <style>
     body { color: #c0caf5; }
@@ -76,7 +77,7 @@
   <script>
     // 環境変数の安全な取得
     const userEmail = typeof window !== 'undefined' ? window.userEmail : "";
-    const isAdmin = userEmail.split('@')[0].includes('t');
+    const isAdmin = typeof window !== 'undefined' ? Boolean(window.isAdminPage) : false;
 
     class StudyQuestApp {
         constructor() {
@@ -117,7 +118,7 @@
             ];
 
             this.gas = {
-                getPublishedSheetData: (classFilter, sortMode) => this.runGas('getPublishedSheetData', classFilter, sortMode),
+                getPublishedSheetData: (classFilter, sortMode, forceNamed) => this.runGas('getPublishedSheetData', classFilter, sortMode, forceNamed),
                 addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction),
                 toggleHighlight: (rowIndex) => this.runGas('toggleHighlight', rowIndex),
                 unpublishApp: () => this.runGas('unpublishApp')
@@ -270,7 +271,7 @@
             }
             
             try {
-                const data = await this.gas.getPublishedSheetData(selectedClass, selectedSort);
+                const data = await this.gas.getPublishedSheetData(selectedClass, selectedSort, isAdmin);
                 this.adjustLayout();
                 
                 if (isInitialLoad) {

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -55,6 +55,9 @@
       </div>
       
       <div id="message-area" class="mt-4 text-center text-sm h-5"></div>
+      <div class="mt-6 text-right">
+        <a id="open-admin" href="#" target="_blank" class="text-blue-600 underline">管理者として開く</a>
+      </div>
 
     </div>
 
@@ -66,7 +69,8 @@
         unpublishBtn: document.getElementById('unpublish-btn'),
         messageArea: document.getElementById('message-area'),
         modeAnonymous: document.getElementById('mode-anonymous'),
-        modeNamed: document.getElementById('mode-named')
+        modeNamed: document.getElementById('mode-named'),
+        openAdmin: document.getElementById('open-admin')
       };
 
       let selectedSheet = null;
@@ -87,6 +91,11 @@
         elements.modeAnonymous.addEventListener('click', () => {
           displayMode = 'anonymous';
         });
+        google.script.run.withSuccessHandler(url => {
+          if (url) {
+            elements.openAdmin.href = url + '?admin=1';
+          }
+        }).getWebAppUrl();
       });
 
       function loadInitialState() {

--- a/src/Unpublished.html
+++ b/src/Unpublished.html
@@ -29,10 +29,9 @@
 
     <script>
         const userEmail = "<?= userEmail ?>";
-        const emailName = userEmail.split('@')[0];
+        const isAdmin = <?= isAdmin ? 'true' : 'false' ?>;
 
-        // メールアドレスのネーム部分に 't' が含まれているかチェック
-        if (emailName.includes('t')) {
+        if (isAdmin) {
             const adminPanel = document.getElementById('admin-panel');
             adminPanel.classList.remove('hidden');
 


### PR DESCRIPTION
## Summary
- allow open as admin by passing `?admin=1`
- expose `getWebAppUrl` and update board logic to honor admin param
- add link in sheet selector to open board in admin mode
- update README about admin access

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d194f47d0832bb8527a630e8c8a52