### PR TITLE
Show highlight styles only for admins

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -381,7 +381,7 @@
 
         createAnswerCard(data) {
             const card = document.createElement('div');
-            const highlightClass = data.highlight ? ' highlighted' : '';
+            const highlightClass = (isAdmin && data.highlight) ? ' highlighted' : '';
             card.className = 'answer-card relative glass-panel rounded-xl p-4 flex flex-col justify-between shadow-lg border-2 border-cyan-400/80 cursor-pointer opacity-0' + highlightClass;
             card.dataset.rowIndex = data.rowIndex;
 
@@ -402,7 +402,7 @@
                     '</button>';
             }
 
-            const badge = data.highlight ? '<span class="highlight-badge">' + this.getIcon('star', 'w-5 h-5 fill-yellow-400 stroke-yellow-400') + '</span>' : '';
+            const badge = (isAdmin && data.highlight) ? '<span class="highlight-badge">' + this.getIcon('star', 'w-5 h-5 fill-yellow-400 stroke-yellow-400') + '</span>' : '';
 
             card.innerHTML =
                 badge +


### PR DESCRIPTION
## Summary
- adjust `createAnswerCard` to apply highlight style and badge only for admins

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d1cda1c5c832b9625c03114c13668