### PR TITLE
Update display mode logic with admin flag

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -161,7 +161,7 @@ function doGet(e) {
  * サーバー側で設定されたシートのデータを取得します。
  */
 
-function getPublishedSheetData(classFilter, sortMode, forceNamed) {
+function getPublishedSheetData(classFilter, sortMode, isAdmin) {
   sortMode = sortMode || 'score';
   const settings = getAppSettings();
   const sheetName = settings.activeSheetName;
@@ -171,8 +171,7 @@ function getPublishedSheetData(classFilter, sortMode, forceNamed) {
   }
 
   // 既存のgetSheetDataロジックを再利用
-  const displayModeOverride = forceNamed ? 'named' : null;
-  const data = getSheetData(sheetName, classFilter, sortMode, displayModeOverride);
+  const data = getSheetData(sheetName, classFilter, sortMode, !!isAdmin);
 
   // ★改善: フロントエンドでシート名を表示できるよう、レスポンスに含める
   return {
@@ -205,7 +204,7 @@ function getSheets() {
   }
 }
 
-function getSheetData(sheetName, classFilter, sortMode, forceDisplayMode) {
+function getSheetData(sheetName, classFilter, sortMode, isAdmin) {
   sortMode = sortMode || 'score';
   try {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
@@ -220,8 +219,8 @@ function getSheetData(sheetName, classFilter, sortMode, forceDisplayMode) {
   const emailToNameMap = getRosterMap();
   let displayMode = PropertiesService.getScriptProperties()
       .getProperty(APP_PROPERTIES.DISPLAY_MODE) || 'anonymous';
-  if (forceDisplayMode === 'named') {
-    displayMode = 'named';
+  if (!isAdmin) {
+    displayMode = 'anonymous';
   }
 
     const filteredRows = dataRows.filter(row => {

--- a/src/Page.html
+++ b/src/Page.html
@@ -118,7 +118,7 @@
             ];
 
             this.gas = {
-                getPublishedSheetData: (classFilter, sortMode, forceNamed) => this.runGas('getPublishedSheetData', classFilter, sortMode, forceNamed),
+                getPublishedSheetData: (classFilter, sortMode, isAdmin) => this.runGas('getPublishedSheetData', classFilter, sortMode, isAdmin),
                 addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction),
                 toggleHighlight: (rowIndex) => this.runGas('toggleHighlight', rowIndex),
                 unpublishApp: () => this.runGas('unpublishApp')

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -55,7 +55,7 @@ test('getSheetData filters and scores rows', () => {
   ];
   setupMocks(data, 'b@example.com');
 
-  const result = getSheetData('Sheet1');
+  const result = getSheetData('Sheet1', undefined, undefined, true);
 
   expect(result.header).toBe(COLUMN_HEADERS.OPINION);
   expect(result.rows).toHaveLength(2);
@@ -82,7 +82,28 @@ test('getSheetData sorts by newest when specified', () => {
   ];
   setupMocks(data, '');
 
-  const result = getSheetData('Sheet1', undefined, 'newest');
+  const result = getSheetData('Sheet1', undefined, 'newest', true);
 
   expect(result.rows.map(r => r.rowIndex)).toEqual([3, 2]);
+});
+
+test('getSheetData forces anonymous mode for non-admin', () => {
+  const data = [
+    [
+      COLUMN_HEADERS.EMAIL,
+      COLUMN_HEADERS.CLASS,
+      COLUMN_HEADERS.OPINION,
+      COLUMN_HEADERS.REASON,
+      COLUMN_HEADERS.UNDERSTAND,
+      COLUMN_HEADERS.SUPPORT,
+      COLUMN_HEADERS.CURIOUS,
+      COLUMN_HEADERS.HIGHLIGHT
+    ],
+    ['a@example.com', '1-1', 'Opinion1', 'Reason1', '', '', '', 'false']
+  ];
+  setupMocks(data, 'a@example.com');
+
+  const result = getSheetData('Sheet1', undefined, undefined, false);
+
+  expect(result.rows[0].name).toBe('匿名');
 });


### PR DESCRIPTION
## Summary
- change `getPublishedSheetData` and `getSheetData` to take an `isAdmin` flag
- force anonymous display for non‑admins
- update client call in `Page.html`
- adjust and extend tests for the new parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d1cf57584832b8108cc6282eb46b0