### PR TITLE
Add deployment URL updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ your GAS project.
 - `npm run push` – Upload code in `src/` to the GAS project.
 - `npm run pull` – Download the latest code from GAS.
 - `npm run open` – Open the GAS project in your browser.
+- `npm run update-url` – Save the latest web app URL to script properties.
 
 ## Running tests
 After installing dependencies (`npm install`), run `npm test` to execute Jest tests.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "push": "clasp push",
     "pull": "clasp pull",
     "open": "clasp open",
-    "test": "jest"
+    "test": "jest",
+    "update-url": "node scripts/updateWebAppUrl.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/updateWebAppUrl.js
+++ b/scripts/updateWebAppUrl.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const {google} = require('googleapis');
+
+async function main() {
+  const clasp = JSON.parse(fs.readFileSync('.clasp.json', 'utf8'));
+  const auth = new google.auth.GoogleAuth({
+    scopes: [
+      'https://www.googleapis.com/auth/script.projects',
+      'https://www.googleapis.com/auth/script.deployments'
+    ]
+  });
+  const authClient = await auth.getClient();
+  const script = google.script({version: 'v1', auth: authClient});
+  const res = await script.projects.deployments.list({
+    scriptId: clasp.scriptId,
+  });
+  const deployments = res.data.deployments || [];
+  if (!deployments.length) {
+    throw new Error('No deployments found');
+  }
+  const webAppUrl = deployments
+    .flatMap(d => d.entryPoints || [])
+    .find(e => e.webApp)?.webApp?.url;
+  if (!webAppUrl) {
+    throw new Error('Web app URL not found in deployments');
+  }
+  await script.scripts.run({
+    scriptId: clasp.scriptId,
+    requestBody: {
+      function: 'saveWebAppUrl',
+      parameters: [webAppUrl],
+    }
+  });
+  console.log('Saved Web App URL:', webAppUrl);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -33,7 +33,8 @@ const SCORING_CONFIG = {
 const APP_PROPERTIES = {
   ACTIVE_SHEET: 'ACTIVE_SHEET_NAME',
   IS_PUBLISHED: 'IS_PUBLISHED',
-  DISPLAY_MODE: 'DISPLAY_MODE'
+  DISPLAY_MODE: 'DISPLAY_MODE',
+  WEB_APP_URL: 'WEB_APP_URL'
 };
 
 
@@ -188,6 +189,21 @@ function getWebAppUrl() {
   } catch (e) {
     return '';
   }
+}
+
+function saveWebAppUrl(url) {
+  if (!url) {
+    try {
+      url = ScriptApp.getService().getUrl();
+    } catch (e) {
+      url = '';
+    }
+  }
+  PropertiesService.getScriptProperties().setProperty(APP_PROPERTIES.WEB_APP_URL, url);
+}
+
+function getWebAppUrlFromProps() {
+  return PropertiesService.getScriptProperties().getProperty(APP_PROPERTIES.WEB_APP_URL) || '';
 }
 
 
@@ -440,6 +456,8 @@ if (typeof module !== 'undefined') {
     toggleHighlight,
     logDebug,
     getWebAppUrl,
+    saveWebAppUrl,
+    getWebAppUrlFromProps,
   };
 }
 


### PR DESCRIPTION
## Summary
- store a new `WEB_APP_URL` script property
- add helper functions `saveWebAppUrl` and `getWebAppUrlFromProps`
- provide Node script `updateWebAppUrl.js` to fetch the current web app URL via the Apps Script API and store it in script properties
- expose a new `npm run update-url` command
- document the command in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d1bb6f29c832baf3b9bb30ab7e6be