### PR TITLE
Switch default sorting to newest and remove score option

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -163,7 +163,7 @@ function doGet(e) {
  */
 
 function getPublishedSheetData(classFilter, sortMode, isAdmin) {
-  sortMode = sortMode || 'score';
+  sortMode = sortMode || 'newest';
   const settings = getAppSettings();
   const sheetName = settings.activeSheetName;
 
@@ -221,7 +221,7 @@ function getSheets() {
 }
 
 function getSheetData(sheetName, classFilter, sortMode, isAdmin) {
-  sortMode = sortMode || 'score';
+  sortMode = sortMode || 'newest';
   try {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
     if (!sheet) throw new Error(`指定されたシート「${sheetName}」が見つかりません。`);

--- a/src/Page.html
+++ b/src/Page.html
@@ -38,8 +38,7 @@
             <p id="answerCount" class="text-sm text-gray-400 flex items-center gap-2 flex-shrink-0"></p>
             <select id="classFilter" class="hidden text-sm"></select>
             <select id="sortMode" class="text-sm">
-                <option value="score">スコア順</option>
-                <option value="newest">新着順</option>
+                <option value="newest" selected>新着順</option>
                 <option value="random">ランダム</option>
             </select>
         </div>
@@ -465,8 +464,6 @@
                             this.state.currentAnswers.sort((a, b) => b.rowIndex - a.rowIndex);
                         } else if (mode === 'random') {
                             this.state.currentAnswers.sort(() => Math.random() - 0.5);
-                        } else { // 'score' or default
-                            this.state.currentAnswers.sort((a, b) => b.score - a.score);
                         }
 
                         this.updateReactionButtonUI(rowIndex, reaction, rData.count, rData.reacted);

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -55,7 +55,7 @@ test('getSheetData filters and scores rows', () => {
   ];
   setupMocks(data, 'b@example.com');
 
-  const result = getSheetData('Sheet1', undefined, undefined, true);
+  const result = getSheetData('Sheet1', undefined, 'score', true);
 
   expect(result.header).toBe(COLUMN_HEADERS.OPINION);
   expect(result.rows).toHaveLength(2);


### PR DESCRIPTION
## Summary
- drop スコア順 from the page selector
- default sort mode is now `newest` in the client and server
- update `handleReaction` to only handle `newest` or `random`
- adjust tests for new default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d8ec6bfd0832bbcca327597f436b4