### PR TITLE
Use Japanese label for SUPPORT reaction

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -12,7 +12,7 @@ const COLUMN_HEADERS = {
   OPINION: 'これまでの学んだことや、経験したことから、根からとり入れた水は、植物のからだのどこを通るのか予想しましょう。',
   REASON: '予想したわけを書きましょう。',
   UNDERSTAND: 'なるほど！',
-  SUPPORT: '応援したい！',
+  SUPPORT: 'いいね！',
   CURIOUS: 'もっと知りたい！',
   HIGHLIGHT: 'Highlight'
 };

--- a/src/Page.html
+++ b/src/Page.html
@@ -113,7 +113,7 @@
             
             this.reactionTypes = [
                 { key: 'UNDERSTAND', icon: 'lightbulb', label: 'なるほど！' },
-                { key: 'SUPPORT', icon: 'heart', label: '応援したい！' },
+                { key: 'SUPPORT', icon: 'heart', label: 'いいね！' },
                 { key: 'CURIOUS', icon: 'search', label: 'もっと知りたい！' }
             ];
 


### PR DESCRIPTION
## Summary
- update SUPPORT column header constant to いいね！
- display いいね！ for the SUPPORT reaction button on the webpage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d8ee21dc8832b9de5ce72c4d990e5