### PR TITLE
Fix OpinionGroups rendering for text output

### DIFF
--- a/src/OpinionGroups.html
+++ b/src/OpinionGroups.html
@@ -12,6 +12,12 @@
     google.script.run.withSuccessHandler(render).groupSimilarOpinions();
     function render(groups) {
       const container = document.getElementById('groups');
+      if (typeof groups === 'string') {
+        container.innerHTML = '<pre class="whitespace-pre-wrap">' +
+          groups +
+          '</pre>';
+        return;
+      }
       if (!groups || !groups.length) {
         container.innerHTML = '<p>結果がありません。</p>';
         return;


### PR DESCRIPTION
## Summary
- display string summaries in OpinionGroups.html
- keep list layout when array results are returned

## Testing
- `npm test`
- `npm run push` *(fails: No credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_684df1a060a4832bbde08e3e2d1c6118