### PR TITLE
Add admin email management

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -34,7 +34,8 @@ const APP_PROPERTIES = {
   ACTIVE_SHEET: 'ACTIVE_SHEET_NAME',
   IS_PUBLISHED: 'IS_PUBLISHED',
   DISPLAY_MODE: 'DISPLAY_MODE',
-  WEB_APP_URL: 'WEB_APP_URL'
+  WEB_APP_URL: 'WEB_APP_URL',
+  ADMIN_EMAILS: 'ADMIN_EMAILS'
 };
 
 
@@ -72,11 +73,14 @@ function showAdminSidebar() {
 function getAdminSettings() {
   const properties = PropertiesService.getScriptProperties();
   const allSheets = getSheets(); // 既存の関数を再利用
+  const adminEmailsRaw = properties.getProperty(APP_PROPERTIES.ADMIN_EMAILS) || '';
+  const adminEmails = adminEmailsRaw ? adminEmailsRaw.split(',').map(e => e.trim()).filter(Boolean) : [];
   return {
     isPublished: properties.getProperty(APP_PROPERTIES.IS_PUBLISHED) === 'true',
     activeSheetName: properties.getProperty(APP_PROPERTIES.ACTIVE_SHEET),
     allSheets: allSheets,
-    displayMode: properties.getProperty(APP_PROPERTIES.DISPLAY_MODE) || 'anonymous'
+    displayMode: properties.getProperty(APP_PROPERTIES.DISPLAY_MODE) || 'anonymous',
+    adminEmails: adminEmails
   };
 }
 
@@ -116,6 +120,18 @@ function saveDisplayMode(mode) {
   properties.setProperty(APP_PROPERTIES.DISPLAY_MODE, value);
   logDebug(`Display mode set to ${value}`);
   return `表示モードを${value === 'named' ? '記名' : '匿名'}に設定しました。`;
+}
+
+/**
+ * 管理者メールアドレスを保存します。
+ * @param {string} emails - カンマ区切りのメールアドレス文字列
+ */
+function saveAdminEmails(emails) {
+  const properties = PropertiesService.getScriptProperties();
+  const value = (emails || '').split(',').map(e => e.trim()).filter(Boolean).join(',');
+  properties.setProperty(APP_PROPERTIES.ADMIN_EMAILS, value);
+  logDebug(`Admin emails updated: ${value}`);
+  return '管理者メールアドレスを更新しました。';
 }
 
 

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -41,6 +41,15 @@
         </div>
       </div>
 
+      <!-- Admin Emails -->
+      <div class="mb-6">
+        <h4 class="font-semibold text-gray-700 mb-3">管理者メールアドレス</h4>
+        <div class="bg-white p-3 rounded-lg shadow-md flex flex-col gap-2">
+          <textarea id="admin-emails" rows="3" class="w-full p-2 border rounded-md"></textarea>
+          <button id="save-admin-emails-btn" class="w-full text-white font-bold py-2 px-4 rounded-lg bg-green-500 hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-75">保存</button>
+        </div>
+      </div>
+
       <!-- Actions -->
       <div>
         <h3 class="font-semibold text-gray-700 mb-3">2. 操作を選択</h3>
@@ -74,7 +83,9 @@
         modeAnonymous: document.getElementById('mode-anonymous'),
         modeNamed: document.getElementById('mode-named'),
         openAdmin: document.getElementById('open-admin'),
-        openGroups: document.getElementById('open-groups')
+        openGroups: document.getElementById('open-groups'),
+        adminEmails: document.getElementById('admin-emails'),
+        saveAdminEmailsBtn: document.getElementById('save-admin-emails-btn')
       };
 
       let selectedSheet = null;
@@ -84,6 +95,7 @@
         loadInitialState();
         elements.publishBtn.addEventListener('click', publish);
         elements.unpublishBtn.addEventListener('click', unpublish);
+        elements.saveAdminEmailsBtn.addEventListener('click', saveAdminEmails);
         elements.modeNamed.addEventListener('click', () => {
           if (!confirm('注意：生徒の心理的安全性を考慮し、通常は匿名表示を推奨します。本当に名前を表示しますか？')) {
             elements.modeAnonymous.checked = true;
@@ -156,6 +168,7 @@
         }
 
         elements.publishBtn.disabled = !selectedSheet || (status.isPublished && selectedSheet === status.activeSheetName);
+        elements.adminEmails.value = (status.adminEmails || []).join(', ');
         setLoading(false);
       }
 
@@ -189,6 +202,18 @@
           })
           .withFailureHandler(showError)
           .unpublishApp();
+      }
+
+      function saveAdminEmails() {
+        setLoading(true, "保存中...");
+        const emails = elements.adminEmails.value;
+        google.script.run
+          .withSuccessHandler((msg) => {
+            showMessage(msg, 'green');
+            setLoading(false);
+          })
+          .withFailureHandler(showError)
+          .saveAdminEmails(emails);
       }
 
       function setLoading(isLoading, msg = "") {


### PR DESCRIPTION
## Summary
- extend `APP_PROPERTIES` with `ADMIN_EMAILS`
- provide `saveAdminEmails` and expose admin list via `getAdminSettings`
- display admin email list in the admin panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dfa442478832ba66a9c07ff6fe355