### PR TITLE
Fix board state retrieval test

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -534,6 +534,7 @@ if (typeof module !== 'undefined') {
     COLUMN_HEADERS,
     findHeaderIndices,
     getSheetData,
+    getAdminSettings,
     addReaction,
     toggleHighlight,
     groupSimilarOpinions,

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -1,0 +1,45 @@
+const { getAdminSettings } = require('../src/Code.gs');
+function setup() {
+  global.PropertiesService = {
+    getScriptProperties: () => ({
+      getProperty: (key) => {
+        switch (key) {
+          case 'IS_PUBLISHED': return 'true';
+          case 'ACTIVE_SHEET_NAME': return 'SheetA';
+          case 'DISPLAY_MODE': return 'named';
+          case 'ADMIN_EMAILS': return 'a@example.com,b@example.com';
+          default: return null;
+        }
+      }
+    })
+  };
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({
+      getSheets: () => [
+        { getName: () => 'SheetA', isSheetHidden: () => false },
+        { getName: () => 'SheetB', isSheetHidden: () => false }
+      ]
+    })
+  };
+  global.Session = {
+    getActiveUser: () => ({ getEmail: () => 'a@example.com' })
+  };
+}
+afterEach(() => {
+  delete global.PropertiesService;
+  delete global.SpreadsheetApp;
+  delete global.Session;
+});
+
+ test('getAdminSettings returns board state', () => {
+   setup();
+   const result = getAdminSettings();
+   expect(result).toEqual({
+     isPublished: true,
+     activeSheetName: 'SheetA',
+     allSheets: ['SheetA','SheetB'],
+     displayMode: 'named',
+     adminEmails: ['a@example.com','b@example.com'],
+     currentUserEmail: 'a@example.com'
+   });
+ });


### PR DESCRIPTION
## Summary
- export `getAdminSettings` for node environment
- add a test for board state retrieval

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e253b7fd4832b9cd13b1f5bfa3be1