### PR TITLE
Fix reaction icons, CSS, and tests

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -50,8 +50,9 @@
       border-color: #8b5cf6;
       border-image: linear-gradient(to bottom, #f59e0b, #10b981, #3b82f6) 1;
     }
+    .reaction-bg-all {
       border-color: transparent;
-      border-image: linear-gradient(90deg,#ef4444,#fbbf24,#3b82f6) 1;
+      border-image: linear-gradient(90deg, #ef4444, #fbbf24, #3b82f6) 1;
     }
     #controlsFooter { pointer-events: none; }
     #controlsFooter > .glass-panel { pointer-events: auto; }
@@ -142,7 +143,7 @@
             this.reactionTypes = [
                 { key: 'UNDERSTAND', icon: 'lightbulb', label: 'なるほど！' },
                 { key: 'LIKE', icon: 'thumb-up', label: 'いいね！' },
-                { key: 'CURIOUS', icon: 'search', label: 'もっと知りたい！' }
+                { key: 'CURIOUS', icon: 'magnifying-glass-plus', label: 'もっと知りたい！' }
             ];
 
             this.gas = {
@@ -413,11 +414,6 @@
             card.className = 'answer-card relative glass-panel rounded-xl p-4 flex flex-col justify-between shadow-lg border-2 border-cyan-400/80 cursor-pointer opacity-0' + highlightClass;
             card.dataset.rowIndex = data.rowIndex;
 
-            const colors = {
-                LIKE: 'rgba(250,204,21,0.25)',
-                UNDERSTAND: 'rgba(163,230,53,0.25)',
-                CURIOUS: 'rgba(56,189,248,0.25)'
-            };
             const active = this.reactionTypes
                 .filter(rt => data.reactions && data.reactions[rt.key] && data.reactions[rt.key].count > 0)
                 .map(rt => rt.key);
@@ -426,15 +422,15 @@
                 if (active[0] === 'UNDERSTAND') card.classList.add('reaction-bg-understand');
                 if (active[0] === 'CURIOUS') card.classList.add('reaction-bg-curious');
             } else if (active.length > 1) {
-                card.classList.add('reaction-bg-mixed');
+                card.classList.add('reaction-bg-all');
             }
 
             const showCount = isAdmin;
             const reactionButtons = this.reactionTypes.map(rt => {
                 const rData = data.reactions ? data.reactions[rt.key] || { count: 0, reacted: false } : { count: 0, reacted: false };
                 const btnClass = rData.reacted ? 'liked' : '';
-                return '<button type="button" class="reaction-btn like-btn ' + btnClass + '" aria-label="' + rt.label + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '">' +
-                    this.getIcon(rt.icon, 'w-5 h-5') +
+                    return '<button type="button" class="reaction-btn like-btn ' + btnClass + '" aria-label="' + rt.label + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '">' +
+                    this.getIcon(rt.icon, 'w-5 h-5', rData.reacted) +
                     (showCount ? '<span class="reaction-count font-bold text-lg text-gray-200">' + rData.count + '</span>' : '') +
                     '</button>';
             }).join(' ');
@@ -546,6 +542,11 @@
                 if (countEl) {
                     countEl.textContent = count;
                 }
+                const rt = this.reactionTypes.find(r => r.key === reaction);
+                const svgEl = btn.querySelector('svg');
+                if (svgEl && rt) {
+                    svgEl.outerHTML = this.getIcon(rt.icon, svgEl.getAttribute('class') || 'w-5 h-5', reacted);
+                }
                 btn.classList.toggle('liked', reacted);
             });
         }
@@ -567,10 +568,10 @@
             const reactionButtons = this.reactionTypes.map(rt => {
                 const rData = data.reactions ? data.reactions[rt.key] || { count: 0, reacted: false } : { count: 0, reacted: false };
                 const btnClass = rData.reacted ? 'liked' : '';
-                return '<button type="button" class="reaction-btn like-btn ' + btnClass + ' flex items-center gap-2 text-lg" aria-label="' + rt.label + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '">' +
-                    this.getIcon(rt.icon, 'w-6 h-6') +
-                    (showCount ? '<span class="reaction-count font-bold text-xl text-gray-200">' + rData.count + '</span>' : '') +
-                    '</button>';
+                    return '<button type="button" class="reaction-btn like-btn ' + btnClass + ' flex items-center gap-2 text-lg" aria-label="' + rt.label + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '">' +
+                    this.getIcon(rt.icon, 'w-6 h-6', rData.reacted) +
+                    (showCount ? '<span class="reaction-count font-bold text-xl text-gray-200">' + rData.count + '</span>' : '') +
+                    '</button>';
             }).join('');
             
             this.elements.modalReactionButtons.innerHTML = reactionButtons;
@@ -642,19 +643,30 @@
             document.getElementById('footerIcon').innerHTML = this.getIcon('layout-grid', 'w-5 h-5');
         }
 
-        getIcon(name, classes = 'w-6 h-6') {
-            const icons = {
-                lightbulb: '<svg class="' + classes + '" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m12.728 0l-.707.707M12 21a9 9 0 110-18 9 9 0 010 18z" /></svg>',
-                heart: '<svg class="' + classes + '" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.318 6.318a4.5 4.5 0 016.364 0L12 7.5l1.318-1.182a4.5 4.5 0 116.364 6.364L12 21l-7.682-7.318a4.5 4.5 0 010-6.364z" /></svg>',
-                'thumb-up': '<svg class="' + classes + '" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M14 9V5a3 3 0 00-6 0v4H5a3 3 0 000 6h3v6h8l3-8v-4h-5z" /></svg>',
-                search: '<svg class="' + classes + '" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>',
-                star: '<svg class="' + classes + '" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.539 1.118l-3.975-2.888a1 1 0 00-1.175 0l-3.976 2.888c-.783.57-1.838-.196-1.539-1.118l1.518-4.674a1 1 0 00-.363-1.118L2.05 10.1c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" /></svg>',
-                users: '<svg class="' + classes + '" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm6-6a3 3 0 100-6 3 3 0 000 6z" /></svg>',
-                x: '<svg class="' + classes + '" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>',
-                'layout-grid': '<svg class="' + classes + '" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" /></svg>'
-            };
-            return icons[name] || '';
-        }
+        getIcon(name, classes = 'w-6 h-6', solid = false) {
+            const icons = {
+                lightbulb: {
+                    outline: '<svg class="' + classes + '" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2V.5M5.25 6.75L4.2 5.7M18.75 6.75l1.05-1.05M12 4a6 6 0 00-6 6c0 2.25 1 4.2 2.5 5.34V16.5h7v-1.16A6.002 6.002 0 0018 10a6 6 0 00-6-6zM9 16.5h6v4H9v-4zm0 1h6zm0 1h6zM10.5 11l.5 2h2l.5-2m-3 1h3" /></svg>',
+                    solid: '<svg class="' + classes + '" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2V.5M5.25 6.75L4.2 5.7M18.75 6.75l1.05-1.05" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path fill-rule="evenodd" clip-rule="evenodd" d="M12 4a6 6 0 00-6 6c0 2.25 1 4.2 2.5 5.34V16.5h7v-1.16A6.002 6.002 0 0018 10a6 6 0 00-6-6z M10.5 11.25 L11 13 L13 13 L13.5 11.25 H 10.5 Z" /><path d="M9 16.5h6v1H9z M9 18h6v1H9z M9 19.5h6v1H9z" /></svg>'
+                },
+                'thumb-up': {
+                    outline: '<svg class="' + classes + '" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2h0a3.13 3.13 0 0 1 3 3.88Z"/></svg>',
+                    solid: '<svg class="' + classes + '" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2h0a3.13 3.13 0 0 1 3 3.88Z M6.5 10v12h1V10h-1z" /></svg>'
+                },
+                'magnifying-glass-plus': {
+                    outline: '<svg class="' + classes + '" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607zM10.5 7.5v6m3-3h-6" /></svg>',
+                    solid: '<svg class="' + classes + '" viewBox="0 0 24 24" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z M9.75 7.5v2.25H7.5v1.5h2.25V13.5h1.5v-2.25H13.5v-1.5h-2.25V7.5h-1.5z" fill="currentColor" /><path d="M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15zM16.5 16.5l4.5 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg>'
+                },
+                star: '<svg class="' + classes + '" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.539 1.118l-3.975-2.888a1 1 0 00-1.175 0l-3.976 2.888c-.783.57-1.838-.196-1.539-1.118l1.518-4.674a1 1 0 00-.363-1.118L2.05 10.1c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" /></svg>',
+                users: '<svg class="' + classes + '" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm6-6a3 3 0 100-6 3 3 0 000 6z" /></svg>',
+                x: '<svg class="' + classes + '" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>',
+                'layout-grid': '<svg class="' + classes + '" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" /></svg>'
+            };
+            const icon = icons[name];
+            if (!icon) return '';
+            if (typeof icon === 'string') return icon;
+            return solid ? icon.solid : icon.outline;
+        }
         
         debounce(func, delay) {
             let timeout;

--- a/tests/iconState.test.js
+++ b/tests/iconState.test.js
@@ -1,10 +1,18 @@
 const { JSDOM } = require('jsdom');
 
+function getIcon(solid) {
+  return solid ? '<svg fill="currentColor"></svg>' : '<svg fill="none"></svg>';
+}
+
 function updateReactionButtonUI(rowIndex, reaction, count, reacted) {
   document.querySelectorAll(`[data-row-index="${rowIndex}"][data-reaction="${reaction}"]`).forEach(btn => {
     const countEl = btn.querySelector('.reaction-count');
     if (countEl) {
       countEl.textContent = count;
+    }
+    const svgEl = btn.querySelector('svg');
+    if (svgEl) {
+      svgEl.outerHTML = getIcon(reacted);
     }
     btn.classList.toggle('liked', reacted);
   });
@@ -24,10 +32,12 @@ test('updateReactionButtonUI applies solid icon when reacted', () => {
   updateReactionButtonUI(1, 'LIKE', 4, true);
   expect(btn.classList.contains('liked')).toBe(true);
   expect(btn.querySelector('.reaction-count').textContent).toBe('4');
+  expect(btn.querySelector('svg').getAttribute('fill')).toBe('currentColor');
 
   updateReactionButtonUI(1, 'LIKE', 1, false);
   expect(btn.classList.contains('liked')).toBe(false);
   expect(btn.querySelector('.reaction-count').textContent).toBe('1');
+  expect(btn.querySelector('svg').getAttribute('fill')).toBe('none');
 
   delete global.document;
 });


### PR DESCRIPTION
## Summary
- fix malformed CSS for reaction backgrounds
- add magnifying-glass-plus icons and swap icons on reaction state change
- remove unused colors map
- update test to verify icon swap logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e53ae7134832b92ed086e12c58bf3