### PR TITLE
Handle admin view parameter in doGet

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -194,6 +194,7 @@ function doGet(e) {
   const isAdmin =
       e && e.parameter && e.parameter.admin === '1' &&
       adminEmails.includes(userEmail);
+  const view = e && e.parameter && e.parameter.view;
 
 
   if (isAdmin && e && e.parameter && e.parameter.groups === '1') {
@@ -203,7 +204,14 @@ function doGet(e) {
             .addMetaTag('viewport', 'width=device-width, initial-scale=1');
   }
 
-  if (!settings.isPublished) {
+  if (isAdmin && view !== 'board') {
+    const template = HtmlService.createTemplateFromFile('Unpublished');
+    template.userEmail = userEmail;
+    template.isAdmin = isAdmin;
+    return template.evaluate().setTitle('公開終了');
+  }
+
+  if (!settings.isPublished && !(isAdmin && view === 'board')) {
     const template = HtmlService.createTemplateFromFile('Unpublished');
     template.userEmail = userEmail;
     template.isAdmin = isAdmin;
@@ -581,6 +589,7 @@ if (typeof module !== 'undefined') {
     findHeaderIndices,
     getSheetData,
     getAdminSettings,
+    doGet,
     addReaction,
     toggleHighlight,
     groupSimilarOpinions,

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -1,0 +1,41 @@
+const { doGet } = require('../src/Code.gs');
+
+afterEach(() => {
+  delete global.HtmlService;
+  delete global.Session;
+  delete global.PropertiesService;
+});
+
+function setup({isPublished, userEmail='admin@example.com', adminEmails='admin@example.com'}) {
+  global.PropertiesService = {
+    getScriptProperties: () => ({
+      getProperty: (key) => {
+        if (key === 'IS_PUBLISHED') return isPublished ? 'true' : 'false';
+        if (key === 'ACTIVE_SHEET_NAME') return 'Sheet1';
+        if (key === 'ADMIN_EMAILS') return adminEmails;
+        return null;
+      }
+    })
+  };
+  global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
+  const output = { setTitle: jest.fn(() => output), addMetaTag: jest.fn(() => output) };
+  global.HtmlService = {
+    createTemplateFromFile: jest.fn(() => ({ evaluate: () => output }))
+  };
+  return { output };
+}
+
+test('admin view=board shows Page template even when unpublished', () => {
+  const { output } = setup({ isPublished: false });
+  const e = { parameter: { admin: '1', view: 'board' } };
+  doGet(e);
+  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
+});
+
+test('admin without board view shows Unpublished', () => {
+  setup({ isPublished: true });
+  const e = { parameter: { admin: '1' } };
+  doGet(e);
+  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Unpublished');
+});
+


### PR DESCRIPTION
## Summary
- allow unit tests to call `doGet`
- add logic for `admin` and `view` query params
- test view logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e5f366b64832b96c306a5a27e14ee