### PR TITLE
Add reaction count setting

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -35,7 +35,8 @@ const APP_PROPERTIES = {
   IS_PUBLISHED: 'IS_PUBLISHED',
   DISPLAY_MODE: 'DISPLAY_MODE',
   WEB_APP_URL: 'WEB_APP_URL',
-  ADMIN_EMAILS: 'ADMIN_EMAILS'
+  ADMIN_EMAILS: 'ADMIN_EMAILS',
+  SHOW_REACTION_COUNT: 'SHOW_REACTION_COUNT'
 };
 
 /**
@@ -100,7 +101,8 @@ function getAdminSettings() {
     allSheets: allSheets,
     displayMode: properties.getProperty(APP_PROPERTIES.DISPLAY_MODE) || 'anonymous',
     adminEmails: adminEmails,
-    currentUserEmail: currentUser
+    currentUserEmail: currentUser,
+    showReactionCount: properties.getProperty(APP_PROPERTIES.SHOW_REACTION_COUNT) === 'true'
   };
 }
 
@@ -161,6 +163,12 @@ function saveAdminEmails(emails) {
   return '管理者メールアドレスを更新しました。';
 }
 
+function saveReactionCountSetting(show) {
+  const value = show ? 'true' : 'false';
+  saveSettings({ [APP_PROPERTIES.SHOW_REACTION_COUNT]: value });
+  return 'リアクション数表示設定を更新しました。';
+}
+
 function getAdminEmails() {
  const str = PropertiesService.getScriptProperties()
      .getProperty(APP_PROPERTIES.ADMIN_EMAILS) || '';
@@ -218,6 +226,7 @@ function doGet(e) {
   const template = HtmlService.createTemplateFromFile('Page');
   template.userEmail = userEmail; // この行を追加
   template.isAdmin = isAdmin;
+  template.showCounts = settings.showReactionCount;
   return template.evaluate()
       .setTitle('StudyQuest - みんなのかいとうボード')
       .addMetaTag('viewport', 'width=device-width, initial-scale=1');
@@ -513,7 +522,8 @@ function getAppSettings() {
   const properties = PropertiesService.getScriptProperties();
   return {
     isPublished: properties.getProperty(APP_PROPERTIES.IS_PUBLISHED) === 'true',
-    activeSheetName: properties.getProperty(APP_PROPERTIES.ACTIVE_SHEET)
+    activeSheetName: properties.getProperty(APP_PROPERTIES.ACTIVE_SHEET),
+    showReactionCount: properties.getProperty(APP_PROPERTIES.SHOW_REACTION_COUNT) === 'true'
   };
 }
 

--- a/src/Page.html
+++ b/src/Page.html
@@ -10,6 +10,7 @@
   <script>
     window.userEmail = "<?= userEmail ?>";
     window.isAdminPage = <?= isAdmin ? 'true' : 'false' ?>;
+    window.showCounts = <?= showCounts ? 'true' : 'false' ?>;
   </script>
   <style>
     body { color: #c0caf5; }
@@ -436,7 +437,7 @@
                 card.classList.add('reaction-popular');
             }
 
-            const showCount = isAdmin;
+            const showCount = isAdmin || window.showCounts;
             const reactionButtons = this.reactionTypes.map(rt => {
                 const rData = data.reactions ? data.reactions[rt.key] || { count: 0, reacted: false } : { count: 0, reacted: false };
                 const btnClass = rData.reacted ? 'liked' : '';
@@ -589,7 +590,7 @@
                 this.escapeHtml(data.reason || '') + '</p>';
                 this.elements.modalStudentName.textContent = isAdmin ? data.name : '';
 
-            const showCount = isAdmin;
+            const showCount = isAdmin || window.showCounts;
             const reactionButtons = this.reactionTypes.map(rt => {
                 const rData = data.reactions ? data.reactions[rt.key] || { count: 0, reacted: false } : { count: 0, reacted: false };
                 const btnClass = rData.reacted ? 'liked' : '';

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -8,6 +8,7 @@ function setup() {
           case 'ACTIVE_SHEET_NAME': return 'SheetA';
           case 'DISPLAY_MODE': return 'named';
           case 'ADMIN_EMAILS': return 'a@example.com,b@example.com';
+          case 'SHOW_REACTION_COUNT': return 'true';
           default: return null;
         }
       }
@@ -37,9 +38,10 @@ afterEach(() => {
    expect(result).toEqual({
      isPublished: true,
      activeSheetName: 'SheetA',
-     allSheets: ['SheetA','SheetB'],
-     displayMode: 'named',
-     adminEmails: ['a@example.com','b@example.com'],
-     currentUserEmail: 'a@example.com'
-   });
+    allSheets: ['SheetA','SheetB'],
+    displayMode: 'named',
+    adminEmails: ['a@example.com','b@example.com'],
+    currentUserEmail: 'a@example.com',
+    showReactionCount: true
+  });
  });


### PR DESCRIPTION
## Summary
- store SHOW_REACTION_COUNT app property
- saveReactionCountSetting helper for updating reaction count visibility
- return reaction count setting from getAdminSettings/getAppSettings
- expose showCounts to the frontend
- update Page.html to use showCounts for reaction display
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e5f469684832baa0ad2e53113349e