### PR TITLE
Add reaction count setting tests

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -35,7 +35,8 @@ const APP_PROPERTIES = {
   IS_PUBLISHED: 'IS_PUBLISHED',
   DISPLAY_MODE: 'DISPLAY_MODE',
   WEB_APP_URL: 'WEB_APP_URL',
-  ADMIN_EMAILS: 'ADMIN_EMAILS'
+  ADMIN_EMAILS: 'ADMIN_EMAILS',
+  REACTION_COUNT_ENABLED: 'REACTION_COUNT_ENABLED'
 };
 
 /**
@@ -100,7 +101,8 @@ function getAdminSettings() {
     allSheets: allSheets,
     displayMode: properties.getProperty(APP_PROPERTIES.DISPLAY_MODE) || 'anonymous',
     adminEmails: adminEmails,
-    currentUserEmail: currentUser
+    currentUserEmail: currentUser,
+    reactionCountEnabled: properties.getProperty(APP_PROPERTIES.REACTION_COUNT_ENABLED) === 'true'
   };
 }
 
@@ -161,6 +163,12 @@ function saveAdminEmails(emails) {
   return '管理者メールアドレスを更新しました。';
 }
 
+function saveReactionCountSetting(enabled) {
+  const value = enabled ? 'true' : 'false';
+  saveSettings({ [APP_PROPERTIES.REACTION_COUNT_ENABLED]: value });
+  return `リアクション数表示を${enabled ? '有効' : '無効'}にしました。`;
+}
+
 function getAdminEmails() {
  const str = PropertiesService.getScriptProperties()
      .getProperty(APP_PROPERTIES.ADMIN_EMAILS) || '';
@@ -194,9 +202,9 @@ function doGet(e) {
   const isAdmin =
       e && e.parameter && e.parameter.admin === '1' &&
       adminEmails.includes(userEmail);
+  const view = e && e.parameter && e.parameter.view;
 
-
-  if (isAdmin && e && e.parameter && e.parameter.groups === '1') {
+  if (isAdmin && view === 'groups') {
     const t = HtmlService.createTemplateFromFile('OpinionGroups');
     return t.evaluate()
             .setTitle('意見のグループ化')
@@ -513,7 +521,8 @@ function getAppSettings() {
   const properties = PropertiesService.getScriptProperties();
   return {
     isPublished: properties.getProperty(APP_PROPERTIES.IS_PUBLISHED) === 'true',
-    activeSheetName: properties.getProperty(APP_PROPERTIES.ACTIVE_SHEET)
+    activeSheetName: properties.getProperty(APP_PROPERTIES.ACTIVE_SHEET),
+    reactionCountEnabled: properties.getProperty(APP_PROPERTIES.REACTION_COUNT_ENABLED) === 'true'
   };
 }
 
@@ -583,6 +592,9 @@ if (typeof module !== 'undefined') {
     getAdminSettings,
     addReaction,
     toggleHighlight,
+    saveReactionCountSetting,
+    getAppSettings,
+    doGet,
     groupSimilarOpinions,
     getWebAppUrl,
     saveWebAppUrl,

--- a/tests/doGet.test.js
+++ b/tests/doGet.test.js
@@ -1,0 +1,40 @@
+const { doGet } = require('../src/Code.gs');
+
+function setup() {
+  global.PropertiesService = {
+    getScriptProperties: () => ({
+      getProperty: (key) => {
+        switch (key) {
+          case 'IS_PUBLISHED': return 'true';
+          case 'ACTIVE_SHEET_NAME': return 'Sheet1';
+          case 'ADMIN_EMAILS': return 'admin@example.com';
+          default: return null;
+        }
+      }
+    })
+  };
+  global.Session = { getActiveUser: () => ({ getEmail: () => 'admin@example.com' }) };
+  const htmlOutput = {};
+  global.HtmlService = {
+    createTemplateFromFile: jest.fn(() => ({
+      evaluate: jest.fn(() => ({
+        setTitle: jest.fn(() => ({ addMetaTag: jest.fn(() => htmlOutput) }))
+      }))
+    })),
+    createHtmlOutput: jest.fn(() => htmlOutput),
+    createHtmlOutputFromFile: jest.fn(() => ({ evaluate: jest.fn(() => htmlOutput) }))
+  };
+  return { htmlOutput };
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+  delete global.Session;
+  delete global.HtmlService;
+});
+
+test('doGet respects view parameter for admin groups', () => {
+  setup();
+  doGet({ parameter: { admin: '1', view: 'groups' } });
+  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('OpinionGroups');
+});

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -8,6 +8,7 @@ function setup() {
           case 'ACTIVE_SHEET_NAME': return 'SheetA';
           case 'DISPLAY_MODE': return 'named';
           case 'ADMIN_EMAILS': return 'a@example.com,b@example.com';
+          case 'REACTION_COUNT_ENABLED': return 'true';
           default: return null;
         }
       }
@@ -34,12 +35,13 @@ afterEach(() => {
  test('getAdminSettings returns board state', () => {
    setup();
    const result = getAdminSettings();
-   expect(result).toEqual({
-     isPublished: true,
-     activeSheetName: 'SheetA',
-     allSheets: ['SheetA','SheetB'],
-     displayMode: 'named',
-     adminEmails: ['a@example.com','b@example.com'],
-     currentUserEmail: 'a@example.com'
-   });
- });
+  expect(result).toEqual({
+    isPublished: true,
+    activeSheetName: 'SheetA',
+    allSheets: ['SheetA','SheetB'],
+    displayMode: 'named',
+    adminEmails: ['a@example.com','b@example.com'],
+    currentUserEmail: 'a@example.com',
+    reactionCountEnabled: true
+  });
+});

--- a/tests/getAppSettings.test.js
+++ b/tests/getAppSettings.test.js
@@ -1,0 +1,30 @@
+const { getAppSettings } = require('../src/Code.gs');
+
+function setup() {
+  global.PropertiesService = {
+    getScriptProperties: () => ({
+      getProperty: (key) => {
+        switch (key) {
+          case 'IS_PUBLISHED': return 'true';
+          case 'ACTIVE_SHEET_NAME': return 'SheetA';
+          case 'REACTION_COUNT_ENABLED': return 'false';
+          default: return null;
+        }
+      }
+    })
+  };
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+});
+
+test('getAppSettings includes reaction count flag', () => {
+  setup();
+  const result = getAppSettings();
+  expect(result).toEqual({
+    isPublished: true,
+    activeSheetName: 'SheetA',
+    reactionCountEnabled: false
+  });
+});

--- a/tests/saveReactionCountSetting.test.js
+++ b/tests/saveReactionCountSetting.test.js
@@ -1,0 +1,23 @@
+const { saveReactionCountSetting } = require('../src/Code.gs');
+
+function setup() {
+  const props = { setProperty: jest.fn(), deleteProperty: jest.fn() };
+  global.PropertiesService = { getScriptProperties: () => props };
+  return props;
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+});
+
+test('saveReactionCountSetting stores boolean state', () => {
+  const props = setup();
+  saveReactionCountSetting(true);
+  expect(props.setProperty).toHaveBeenCalledWith('REACTION_COUNT_ENABLED', 'true');
+});
+
+test('saveReactionCountSetting handles false', () => {
+  const props = setup();
+  saveReactionCountSetting(false);
+  expect(props.setProperty).toHaveBeenCalledWith('REACTION_COUNT_ENABLED', 'false');
+});


### PR DESCRIPTION
## Summary
- expose new reaction count setting helpers
- add reaction count setting export
- include reactionCountEnabled in admin and app settings
- respect `view` parameter in `doGet`
- add unit tests for reaction count settings, app/admin settings, and doGet

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e5f7c31fc832b944b6b758ca35818