### PR TITLE
Remove roster cache reset function

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -68,7 +68,6 @@ function onOpen() {
       .createMenu('アプリ管理')
       .addItem('管理パネルを開く', 'showAdminSidebar')
       .addSeparator()
-      .addItem('名簿キャッシュをリセット', 'clearRosterCache')
       .addToUi();
 
 }
@@ -563,14 +562,3 @@ if (typeof module !== 'undefined') {
     getWebAppUrlFromProps,
   };
 }
-
-function clearRosterCache() {
-  const cache = CacheService.getScriptCache();
-  const cacheKey = CACHE_KEYS.ROSTER;
-  cache.remove(cacheKey);
-  console.log(`名簿キャッシュ（キー: ${cacheKey}）を削除しました。`);
-  try {
-    SpreadsheetApp.getUi().alert('名簿のキャッシュをリセットしました。');
-  } catch (e) { /* no-op */ }
-}
-


### PR DESCRIPTION
## Summary
- remove menu entry for roster cache reset
- delete `clearRosterCache` function

## Testing
- `npm test`
- `npm run pull` *(fails: No credentials found)*
- `npm run push` *(fails: No credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6bca0b60832bbecf20d156357f2e