### PR TITLE
Drop admin query parameter

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -197,10 +197,7 @@ function doGet(e) {
     userEmail = '匿名ユーザー';
   }
 
-  const adminEmails = getAdminEmails();
-  const isAdmin =
-      e && e.parameter && e.parameter.admin === '1' &&
-      adminEmails.includes(userEmail);
+  const isAdmin = isUserAdmin();
   const view = e && e.parameter && e.parameter.view;
 
   if (isAdmin && view !== 'board') {

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -27,14 +27,14 @@ function setup({isPublished, userEmail='admin@example.com', adminEmails='admin@e
 
 test('admin view=board shows Page template even when unpublished', () => {
   const { output } = setup({ isPublished: false });
-  const e = { parameter: { admin: '1', view: 'board' } };
+  const e = { parameter: { view: 'board' } };
   doGet(e);
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
 });
 
 test('admin without board view shows Unpublished', () => {
   setup({ isPublished: true });
-  const e = { parameter: { admin: '1' } };
+  const e = {};
   doGet(e);
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Unpublished');
 });


### PR DESCRIPTION
## Summary
- determine admin rights in `doGet` solely via `isUserAdmin`
- update `doGetView` tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e6ca25afc832ba703c8dc087859e3