### PR TITLE
Add score sort setting tests

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -36,7 +36,8 @@ const APP_PROPERTIES = {
   DISPLAY_MODE: 'DISPLAY_MODE',
   WEB_APP_URL: 'WEB_APP_URL',
   ADMIN_EMAILS: 'ADMIN_EMAILS',
-  REACTION_COUNT_ENABLED: 'REACTION_COUNT_ENABLED'
+  REACTION_COUNT_ENABLED: 'REACTION_COUNT_ENABLED',
+  SCORE_SORT_ENABLED: 'SCORE_SORT_ENABLED'
 };
 
 /**
@@ -91,7 +92,8 @@ function getAdminSettings() {
     displayMode: properties.getProperty(APP_PROPERTIES.DISPLAY_MODE) || 'anonymous',
     adminEmails: adminEmails,
     currentUserEmail: currentUser,
-    reactionCountEnabled: properties.getProperty(APP_PROPERTIES.REACTION_COUNT_ENABLED) === 'true'
+    reactionCountEnabled: properties.getProperty(APP_PROPERTIES.REACTION_COUNT_ENABLED) === 'true',
+    scoreSortEnabled: properties.getProperty(APP_PROPERTIES.SCORE_SORT_ENABLED) === 'true'
   };
 }
 
@@ -158,6 +160,12 @@ function saveReactionCountSetting(enabled) {
   return `リアクション数表示を${enabled ? '有効' : '無効'}にしました。`;
 }
 
+function saveScoreSortSetting(enabled) {
+  const value = enabled ? 'true' : 'false';
+  saveSettings({ [APP_PROPERTIES.SCORE_SORT_ENABLED]: value });
+  return `スコア順ソートを${enabled ? '有効' : '無効'}にしました。`;
+}
+
 function getAdminEmails() {
  const str = PropertiesService.getScriptProperties()
      .getProperty(APP_PROPERTIES.ADMIN_EMAILS) || '';
@@ -188,9 +196,7 @@ function doGet(e) {
   }
 
   const adminEmails = getAdminEmails();
-  const isAdmin =
-      e && e.parameter && e.parameter.admin === '1' &&
-      adminEmails.includes(userEmail);
+  const isAdmin = adminEmails.includes(userEmail);
   const view = e && e.parameter && e.parameter.view;
 
   if (isAdmin && view !== 'board') {
@@ -474,7 +480,8 @@ function getAppSettings() {
   return {
     isPublished: properties.getProperty(APP_PROPERTIES.IS_PUBLISHED) === 'true',
     activeSheetName: properties.getProperty(APP_PROPERTIES.ACTIVE_SHEET),
-    reactionCountEnabled: properties.getProperty(APP_PROPERTIES.REACTION_COUNT_ENABLED) === 'true'
+    reactionCountEnabled: properties.getProperty(APP_PROPERTIES.REACTION_COUNT_ENABLED) === 'true',
+    scoreSortEnabled: properties.getProperty(APP_PROPERTIES.SCORE_SORT_ENABLED) === 'true'
   };
 }
 
@@ -546,6 +553,7 @@ if (typeof module !== 'undefined') {
     addReaction,
     toggleHighlight,
     saveReactionCountSetting,
+    saveScoreSortSetting,
     getAppSettings,
     getWebAppUrl,
     saveWebAppUrl,

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -27,14 +27,14 @@ function setup({isPublished, userEmail='admin@example.com', adminEmails='admin@e
 
 test('admin view=board shows Page template even when unpublished', () => {
   const { output } = setup({ isPublished: false });
-  const e = { parameter: { admin: '1', view: 'board' } };
+  const e = { parameter: { view: 'board' } };
   doGet(e);
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
 });
 
 test('admin without board view shows Unpublished', () => {
   setup({ isPublished: true });
-  const e = { parameter: { admin: '1' } };
+  const e = { parameter: {} };
   doGet(e);
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Unpublished');
 });

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -9,6 +9,7 @@ function setup() {
           case 'DISPLAY_MODE': return 'named';
           case 'ADMIN_EMAILS': return 'a@example.com,b@example.com';
           case 'REACTION_COUNT_ENABLED': return 'true';
+          case 'SCORE_SORT_ENABLED': return 'false';
           default: return null;
         }
       }
@@ -42,6 +43,7 @@ afterEach(() => {
     displayMode: 'named',
     adminEmails: ['a@example.com','b@example.com'],
     currentUserEmail: 'a@example.com',
-    reactionCountEnabled: true
+    reactionCountEnabled: true,
+    scoreSortEnabled: false
   });
 });

--- a/tests/getAppSettings.test.js
+++ b/tests/getAppSettings.test.js
@@ -8,6 +8,7 @@ function setup() {
           case 'IS_PUBLISHED': return 'true';
           case 'ACTIVE_SHEET_NAME': return 'SheetA';
           case 'REACTION_COUNT_ENABLED': return 'false';
+          case 'SCORE_SORT_ENABLED': return 'true';
           default: return null;
         }
       }
@@ -25,6 +26,7 @@ test('getAppSettings includes reaction count flag', () => {
   expect(result).toEqual({
     isPublished: true,
     activeSheetName: 'SheetA',
-    reactionCountEnabled: false
+    reactionCountEnabled: false,
+    scoreSortEnabled: true
   });
 });

--- a/tests/saveScoreSortSetting.test.js
+++ b/tests/saveScoreSortSetting.test.js
@@ -1,0 +1,23 @@
+const { saveScoreSortSetting } = require('../src/Code.gs');
+
+function setup() {
+  const props = { setProperty: jest.fn(), deleteProperty: jest.fn() };
+  global.PropertiesService = { getScriptProperties: () => props };
+  return props;
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+});
+
+test('saveScoreSortSetting stores boolean state', () => {
+  const props = setup();
+  saveScoreSortSetting(true);
+  expect(props.setProperty).toHaveBeenCalledWith('SCORE_SORT_ENABLED', 'true');
+});
+
+test('saveScoreSortSetting handles false', () => {
+  const props = setup();
+  saveScoreSortSetting(false);
+  expect(props.setProperty).toHaveBeenCalledWith('SCORE_SORT_ENABLED', 'false');
+});


### PR DESCRIPTION
## Summary
- expose new `SCORE_SORT_ENABLED` setting
- allow admins without `admin=1` param
- add `saveScoreSortSetting` helper
- cover admin settings, app settings, and saveScoreSortSetting in tests
- update existing tests for admin flow

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e6c938348832b9b3ea68c71eea8c7