### PR TITLE
Ensure admin-only features and hide admin email list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,13 @@ subdirectories under `src`.**
 
 Add a column named `Highlight` to your spreadsheet (using a checkbox or TRUE/FALSE values).
 Rows marked as `TRUE` will appear with a yellow border on the board.
-When the board is opened with the `?admin=1` query parameter,
-a star button is shown on each answer card to toggle this flag.
-Use the "Open as administrator" link in the sheet selector sidebar to launch the board in this mode.
+Administrators see a star button on each answer card allowing them to toggle this flag.
 
 ## Admin access
 
 1. Open the sheet selector sidebar from the spreadsheet menu.
 2. Enter comma-separated administrator emails in the **管理者メールアドレス** field and click **保存**.
-3. Only these users will see the "管理者として開く" link and can append `?admin=1` to access admin features.
+3. Users listed here automatically see admin features (reaction counts, names and highlight controls) when viewing the board.
 
 ## Continuous Integration
 

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -77,6 +77,9 @@ function onOpen() {
  * @returns {object} - 現在の公開状態とシートのリスト
  */
 function getAdminSettings() {
+  if (!isUserAdmin()) {
+    throw new Error('管理者のみ実行できます。');
+  }
   const properties = PropertiesService.getScriptProperties();
   const allSheets = getSheets(); // 既存の関数を再利用
   const adminEmailsRaw = properties.getProperty(APP_PROPERTIES.ADMIN_EMAILS) || '';

--- a/src/Page.html
+++ b/src/Page.html
@@ -109,9 +109,7 @@
   <script>
     // 環境変数の安全な取得
     const userEmail = typeof window !== 'undefined' ? window.userEmail : "";
-    const urlParams = new URLSearchParams(window.location.search);
-    const adminMode = urlParams.get('admin') === '1';
-    const isAdmin = adminMode && typeof window !== 'undefined' ? Boolean(window.isAdminPage) : false;
+    const isAdmin = typeof window !== 'undefined' ? Boolean(window.isAdminPage) : false;
 
     class StudyQuestApp {
         constructor() {

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -33,9 +33,9 @@ afterEach(() => {
   delete global.Session;
 });
 
- test('getAdminSettings returns board state', () => {
-   setup();
-   const result = getAdminSettings();
+test('getAdminSettings returns board state', () => {
+  setup();
+  const result = getAdminSettings();
   expect(result).toEqual({
     isPublished: true,
     activeSheetName: 'SheetA',
@@ -46,4 +46,10 @@ afterEach(() => {
     reactionCountEnabled: true,
     scoreSortEnabled: false
   });
+});
+
+test('getAdminSettings throws for non-admin user', () => {
+  setup();
+  global.Session = { getActiveUser: () => ({ getEmail: () => 'other@example.com' }) };
+  expect(() => getAdminSettings()).toThrow('管理者のみ実行できます');
 });


### PR DESCRIPTION
## Summary
- admins no longer need `?admin=1` to see management controls
- restrict `getAdminSettings` so only admins can access it
- document automatic admin mode
- test non-admin access for `getAdminSettings`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e710c0ee8832b9734cff850c7aa89