### PR TITLE
Implement admin board role selection

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <base target="_top">
+    <title>管理者パネル</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-800 text-white flex items-center justify-center h-screen">
+    <div class="text-center p-4">
+        <h1 class="text-3xl font-bold mb-6">管理者パネル</h1>
+        <div class="flex flex-col gap-4 mb-8">
+            <button id="open-admin" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">管理者としてボードを開く</button>
+            <button id="open-student" class="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded">生徒としてボードを開く</button>
+        </div>
+        <div id="admin-panel" class="mt-6 p-6 bg-gray-700 rounded-xl max-w-sm mx-auto shadow-lg border border-gray-600">
+            <h2 class="text-lg font-bold mb-4 text-yellow-300">公開設定</h2>
+            <p class="text-sm text-gray-300 mb-4">表示するシートを選択して公開してください。</p>
+            <div class="flex flex-col gap-4">
+                <select id="sheet-selector" class="w-full p-2 rounded bg-gray-800 border border-gray-600 text-white focus:ring-2 focus:ring-yellow-400 focus:outline-none">
+                    <option>シートを読み込み中...</option>
+                </select>
+                <button id="publish-btn" class="w-full bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-bold py-2 px-4 rounded transition disabled:opacity-50">
+                    このシートで公開する
+                </button>
+            </div>
+            <p id="message-area" class="mt-4 text-sm h-5"></p>
+        </div>
+    </div>
+
+    <script>
+        const isAdmin = true;
+        document.getElementById('open-admin').addEventListener('click', () => {
+            window.top.location.href = '?view=board&role=admin';
+        });
+        document.getElementById('open-student').addEventListener('click', () => {
+            window.top.location.href = '?view=board&role=student';
+        });
+
+        const sheetSelector = document.getElementById('sheet-selector');
+        const publishBtn = document.getElementById('publish-btn');
+        const messageArea = document.getElementById('message-area');
+        google.script.run.withSuccessHandler(populateSheets).withFailureHandler(showError).getSheets();
+
+        function populateSheets(sheetNames) {
+            sheetSelector.innerHTML = '<option value="">-- シートを選択してください --</option>';
+            if (sheetNames && sheetNames.length > 0) {
+                sheetNames.forEach(name => {
+                    const option = document.createElement('option');
+                    option.value = name;
+                    option.textContent = name;
+                    sheetSelector.appendChild(option);
+                });
+            } else {
+                sheetSelector.innerHTML = '<option>表示できるシートがありません</option>';
+                publishBtn.disabled = true;
+            }
+        }
+
+        function showError(error) {
+            messageArea.textContent = `エラー: ${error.message}`;
+            messageArea.className = 'mt-4 text-sm h-5 text-red-400';
+        }
+
+        publishBtn.addEventListener('click', () => {
+            const selectedSheet = sheetSelector.value;
+            if (!selectedSheet) {
+                messageArea.textContent = 'シートを選択してください。';
+                messageArea.className = 'mt-4 text-sm h-5 text-yellow-300';
+                return;
+            }
+            publishBtn.disabled = true;
+            publishBtn.textContent = '公開処理中...';
+            messageArea.textContent = '';
+            google.script.run.withSuccessHandler(onPublishSuccess).withFailureHandler(onPublishError).publishApp(selectedSheet);
+        });
+
+        function onPublishSuccess(message) {
+            messageArea.textContent = `${message} ページを更新します...`;
+            messageArea.className = 'mt-4 text-sm h-5 text-green-400';
+            setTimeout(() => { window.top.location.reload(); }, 500);
+        }
+        function onPublishError(error) {
+            showError(error);
+            publishBtn.disabled = false;
+            publishBtn.textContent = 'このシートで公開する';
+        }
+    </script>
+</body>
+</html>

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -200,12 +200,14 @@ function doGet(e) {
   const adminEmails = getAdminEmails();
   const isAdmin = adminEmails.includes(userEmail);
   const view = e && e.parameter && e.parameter.view;
+  const role = e && e.parameter && e.parameter.role;
 
   if (isAdmin && view !== 'board') {
-    const template = HtmlService.createTemplateFromFile('Unpublished');
+    const template = HtmlService.createTemplateFromFile('AdminPanel');
     template.userEmail = userEmail;
-    template.isAdmin = isAdmin;
-    return template.evaluate().setTitle('公開終了');
+    template.isAdmin = true;
+    template.isPublished = settings.isPublished;
+    return template.evaluate().setTitle('管理者パネル');
   }
 
   if (!settings.isPublished && !(isAdmin && view === 'board')) {
@@ -222,7 +224,7 @@ function doGet(e) {
   // ★変更: Page.html にもメールアドレスを渡す
   const template = HtmlService.createTemplateFromFile('Page');
   template.userEmail = userEmail; // この行を追加
-  template.isAdmin = isAdmin;
+  template.isAdmin = isAdmin && role !== 'student';
   template.showCounts = settings.reactionCountEnabled;
   return template.evaluate()
       .setTitle('StudyQuest - みんなのかいとうボード')

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -32,10 +32,10 @@ test('admin view=board shows Page template even when unpublished', () => {
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
 });
 
-test('admin without board view shows Unpublished', () => {
+test('admin without board view shows AdminPanel', () => {
   setup({ isPublished: true });
   const e = { parameter: {} };
   doGet(e);
-  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Unpublished');
+  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('AdminPanel');
 });
 


### PR DESCRIPTION
## Summary
- add new AdminPanel page with buttons to open board as admin or student
- update doGet to show AdminPanel for admins and handle role parameter
- adjust unit test for new admin panel behavior

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e921146a0832ba242ed89585f95f3