### PR TITLE
Add admin board open options

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -183,23 +183,18 @@ function doGet(e) {
     userEmail = '匿名ユーザー';
   }
   const adminEmails = getAdminEmails();
-  const isAdmin = adminEmails.includes(userEmail);
+  const userIsAdmin = adminEmails.includes(userEmail);
   const view = e && e.parameter && e.parameter.view;
+  const role = e && e.parameter && e.parameter.role;
+  const isAdmin = userIsAdmin && role !== 'student';
 
-  if (isAdmin && view !== 'board') {
+  if (!settings.isPublished && !(userIsAdmin && view === 'board')) {
     const template = HtmlService.createTemplateFromFile('Unpublished');
     template.userEmail = userEmail;
-    template.isAdmin = isAdmin;
+    template.isAdmin = userIsAdmin;
     return template.evaluate().setTitle('公開終了');
   }
 
-  if (!settings.isPublished && !(isAdmin && view === 'board')) {
-    const template = HtmlService.createTemplateFromFile('Unpublished');
-    template.userEmail = userEmail;
-    template.isAdmin = isAdmin;
-    return template.evaluate().setTitle('公開終了');
-  }
-  
   if (!settings.activeSheetName) {
     return HtmlService.createHtmlOutput('エラー: 表示するシートが設定されていません。スプレッドシートの「アプリ管理」メニューから設定してください。').setTitle('エラー');
   }

--- a/src/Unpublished.html
+++ b/src/Unpublished.html
@@ -22,6 +22,12 @@
                 <button id="publish-btn" class="w-full bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-bold py-2 px-4 rounded transition disabled:opacity-50">
                     このシートで公開する
                 </button>
+                <button id="open-admin-btn" class="w-full bg-green-500 hover:bg-green-600 text-gray-900 font-bold py-2 px-4 rounded transition">
+                    管理者としてボードを開く
+                </button>
+                <button id="open-student-btn" class="w-full bg-blue-500 hover:bg-blue-600 text-gray-900 font-bold py-2 px-4 rounded transition">
+                    生徒としてボードを開く
+                </button>
             </div>
             <p id="message-area" class="mt-4 text-sm h-5"></p>
         </div>
@@ -84,11 +90,10 @@
             });
 
             function onPublishSuccess(message) {
-                messageArea.textContent = `${message} ページを更新します...`;
+                messageArea.textContent = message;
                 messageArea.className = 'mt-4 text-sm h-5 text-green-400';
-                setTimeout(() => {
-                    window.top.location.reload();
-                }, 500);
+                publishBtn.disabled = false;
+                publishBtn.textContent = 'このシートで公開する';
             }
 
             function onPublishError(error) {
@@ -96,6 +101,14 @@
                 publishBtn.disabled = false;
                 publishBtn.textContent = 'このシートで公開する';
             }
+
+            document.getElementById('open-admin-btn').addEventListener('click', () => {
+                window.top.location.href = '?view=board&role=admin';
+            });
+
+            document.getElementById('open-student-btn').addEventListener('click', () => {
+                window.top.location.href = '?view=board&role=student';
+            });
         }
     </script>
 </body>

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -32,8 +32,15 @@ test('admin view=board shows Page template even when unpublished', () => {
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
 });
 
-test('admin without board view shows Unpublished', () => {
+test('admin default shows Page when published', () => {
   setup({ isPublished: true });
+  const e = { parameter: {} };
+  doGet(e);
+  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
+});
+
+test('admin default shows Unpublished when not published', () => {
+  setup({ isPublished: false });
   const e = { parameter: {} };
   doGet(e);
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Unpublished');


### PR DESCRIPTION
## Summary
- provide buttons to open board as admin or as student
- show publish status message without auto reload
- allow admins to view board by default when published
- update view logic and tests for new behaviour

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e94d4d2b0832b885d59d64c3db306