### PR TITLE
Improve reaction API consistency

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -415,7 +415,14 @@ function addReaction(rowIndex, reactionKey) {
       lists[key].cell.setValue(lists[key].arr.join(','));
     });
 
-    return { status: 'ok', reaction: reactionKey, newScore: lists[reactionKey].arr.length };
+    const reactions = {};
+    Object.keys(lists).forEach(key => {
+      reactions[key] = {
+        count: lists[key].arr.length,
+        reacted: lists[key].arr.includes(userEmail)
+      };
+    });
+    return { status: 'ok', reactions: reactions };
   } catch (error) {
     console.error('addReaction Error:', error);
     return { status: 'error', message: `エラーが発生しました: ${error.message}` };

--- a/src/Page.html
+++ b/src/Page.html
@@ -267,8 +267,11 @@
                         } else if (funcName === 'addReaction') {
                             resolve({
                                 status: 'ok',
-                                reaction: args[1] || 'UNDERSTAND',
-                                newScore: Math.floor(Math.random() * 10) + 1
+                                reactions: {
+                                    UNDERSTAND: { count: Math.floor(Math.random() * 5), reacted: false },
+                                    LIKE: { count: Math.floor(Math.random() * 5), reacted: false },
+                                    CURIOUS: { count: Math.floor(Math.random() * 5), reacted: true }
+                                }
                             });
                         } else if (funcName === 'unpublishApp') {
                             resolve('unpublished');
@@ -503,28 +506,12 @@
                 if (res && res.status === 'ok') {
                     const oldAnswers = [...this.state.currentAnswers];
                     const item = this.state.currentAnswers.find(i => i.rowIndex == rowIndex);
-                    if (item && item.reactions && item.reactions[reaction]) {
-                        const previous = this.reactionTypes
-                            .filter(rt => rt.key !== reaction && item.reactions[rt.key] && item.reactions[rt.key].reacted);
-
-                        const rData = item.reactions[reaction];
-                        const wasReacted = rData.reacted;
-                        rData.count = res.newScore;
-                        rData.reacted = !wasReacted;
-
-                        previous.forEach(rt => {
-                            const pr = item.reactions[rt.key];
-                            if (pr && pr.reacted) {
-                                pr.reacted = false;
-                                if (pr.count > 0) pr.count -= 1;
-                                this.updateReactionButtonUI(rowIndex, rt.key, pr.count, false);
-                            }
-                        });
+                    if (item && res.reactions) {
+                        item.reactions = res.reactions;
 
                         const total = Object.values(item.reactions).reduce((sum, r) => sum + r.count, 0);
                         item.score = item.reason.length * (1 + total * 0.05);
 
-                        // 並び替え機能のロジックをここに統合
                         const mode = this.elements.sortMode.value;
                         if (mode === 'newest') {
                             this.state.currentAnswers.sort((a, b) => b.rowIndex - a.rowIndex);
@@ -532,7 +519,11 @@
                             this.state.currentAnswers.sort(() => Math.random() - 0.5);
                         }
 
-                        this.updateReactionButtonUI(rowIndex, reaction, rData.count, rData.reacted);
+                        Object.keys(item.reactions).forEach(key => {
+                            const r = item.reactions[key];
+                            this.updateReactionButtonUI(rowIndex, key, r.count, r.reacted);
+                        });
+
                         this.renderBoard(false, oldAnswers);
                     }
                 } else if (res && res.message) {

--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -56,11 +56,13 @@ test('addReaction toggles user in list', () => {
 
   const result1 = addReaction(2, 'UNDERSTAND');
   expect(result1.status).toBe('ok');
-  expect(result1.newScore).toBe(2);
+  expect(result1.reactions.UNDERSTAND.count).toBe(2);
+  expect(result1.reactions.UNDERSTAND.reacted).toBe(true);
 
   const result2 = addReaction(2, 'UNDERSTAND');
   expect(result2.status).toBe('ok');
-  expect(result2.newScore).toBe(1);
+  expect(result2.reactions.UNDERSTAND.count).toBe(1);
+  expect(result2.reactions.UNDERSTAND.reacted).toBe(false);
 });
 
 test('addReaction switches reaction columns', () => {
@@ -71,11 +73,14 @@ test('addReaction switches reaction columns', () => {
   expect(res1.status).toBe('ok');
   expect(sheet.values.LIKE).toBe('c@example.com');
   expect(sheet.values.UNDERSTAND).toBe('a@example.com');
+  expect(res1.reactions.LIKE.reacted).toBe(true);
 
   const res2 = addReaction(2, 'CURIOUS');
   expect(res2.status).toBe('ok');
   expect(sheet.values.LIKE).toBe('');
   expect(sheet.values.CURIOUS).toBe('c@example.com');
+  expect(res2.reactions.LIKE.reacted).toBe(false);
+  expect(res2.reactions.CURIOUS.reacted).toBe(true);
 });
 
 test('addReaction errors when user email is empty', () => {


### PR DESCRIPTION
## Summary
- return all reaction states from `addReaction`
- update fake GAS shim and frontend logic to consume new reaction object
- adjust tests for new return value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed1476aa8832ba4a2e9f9d667da90