### PR TITLE
Remove initial opacity from card

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -454,7 +454,7 @@
         createAnswerCard(data) {
             const card = document.createElement('div');
             const highlightClass = (isAdmin && data.highlight) ? ' highlighted' : '';
-            card.className = 'answer-card relative glass-panel rounded-xl p-4 flex flex-col justify-between shadow-lg border-2 border-cyan-400/80 cursor-pointer opacity-0' + highlightClass;
+            card.className = 'answer-card relative glass-panel rounded-xl p-4 flex flex-col justify-between shadow-lg border-2 border-cyan-400/80 cursor-pointer' + highlightClass;
             card.dataset.rowIndex = data.rowIndex;
 
             const active = this.reactionTypes


### PR DESCRIPTION
## Summary
- reveal cards immediately by removing `opacity-0` from card class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ee35f1a60832bbcd6b36a65c9bb32