### PR TITLE
Add student view option for admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Administrators see a star button on each answer card allowing them to toggle thi
 2. Enter comma-separated administrator emails in the **管理者メールアドレス** field and click **保存**.
 3. Users listed here automatically see admin features (reaction counts, names and highlight controls) when viewing the board.
 
+### Student view for administrators
+
+Administrators can force the standard student interface by appending `mode=student`
+to the web app URL. This is useful when projecting the board while keeping admin
+features on your personal device.
+
 ## Continuous Integration
 
 A GitHub Actions workflow automatically pushes code to the Apps Script project whenever files in `src/` change. To enable it, add your service account credentials JSON as the `CLASP_CREDENTIALS` secret in the repository settings.

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -176,7 +176,8 @@ function doGet(e) {
   const adminEmails = getAdminEmails();
   const userIsAdmin = adminEmails.includes(userEmail);
   const view = e && e.parameter && e.parameter.view;
-  const isAdmin = userIsAdmin;
+  const forceStudent = e && e.parameter && e.parameter.mode === 'student';
+  const isAdmin = userIsAdmin && !forceStudent;
 
   if (!settings.isPublished && !(userIsAdmin && view === 'board')) {
     const template = HtmlService.createTemplateFromFile('Unpublished');

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -19,10 +19,11 @@ function setup({isPublished, userEmail='admin@example.com', adminEmails='admin@e
   };
   global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
   const output = { setTitle: jest.fn(() => output), addMetaTag: jest.fn(() => output) };
+  let template = { evaluate: () => output };
   global.HtmlService = {
-    createTemplateFromFile: jest.fn(() => ({ evaluate: () => output }))
+    createTemplateFromFile: jest.fn(() => template)
   };
-  return { output };
+  return { output, getTemplate: () => template };
 }
 
 test('admin view=board shows Page template even when unpublished', () => {
@@ -44,5 +45,14 @@ test('admin default shows Unpublished when not published', () => {
   const e = { parameter: {} };
   doGet(e);
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Unpublished');
+});
+
+test('mode=student forces non-admin view', () => {
+  const { getTemplate } = setup({ isPublished: true });
+  const e = { parameter: { mode: 'student' } };
+  doGet(e);
+  const template = getTemplate();
+  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
+  expect(template.isAdmin).toBe(false);
 });
 


### PR DESCRIPTION
## Summary
- allow admins to disable admin features by adding `mode=student` in the URL
- document the new student view parameter
- test that `doGet` respects the `mode=student` parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ee6b400a0832bae607acc84320903