### PR TITLE
Update admin mode parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Administrators see a star button on each answer card allowing them to toggle thi
 
 ### Student view for administrators
 
-Administrators can force the standard student interface by appending `mode=student`
-to the web app URL. This is useful when projecting the board while keeping admin
-features on your personal device.
+Administrators normally see the same student interface. To enable admin
+features, append `mode=admin` to the web app URL. This is useful when projecting
+the board while keeping the standard view elsewhere.
 
 ## Continuous Integration
 

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -47,12 +47,12 @@ test('admin default shows Unpublished when not published', () => {
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Unpublished');
 });
 
-test('mode=student forces non-admin view', () => {
+test('mode=admin enables admin view', () => {
   const { getTemplate } = setup({ isPublished: true });
-  const e = { parameter: { mode: 'student' } };
+  const e = { parameter: { mode: 'admin' } };
   doGet(e);
   const template = getTemplate();
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
-  expect(template.isAdmin).toBe(false);
+  expect(template.isAdmin).toBe(true);
 });
 


### PR DESCRIPTION
## Summary
- switch `doGet` to use `mode=admin` query param
- allow `getSheetData`, `getPublishedSheetData`, and `getSheetUpdates` to override admin detection
- document new `mode=admin` parameter
- update unit tests for admin mode flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f3a210ee8832bb4a2cc8b35ec9f33