### PR TITLE
Fix open-admin button to open board in admin mode

### DIFF
--- a/src/Unpublished.html
+++ b/src/Unpublished.html
@@ -100,7 +100,7 @@
             }
 
             document.getElementById('open-admin-btn').addEventListener('click', () => {
-                window.top.location.href = '?view=board';
+                window.top.location.href = '?view=board&mode=admin';
             });
         }
     </script>


### PR DESCRIPTION
## Summary
- ensure the Unpublished page's **ボードを開く** button grants admin mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f4e4e2cf8832ba080387e4de64614