### PR TITLE
Add admin settings fields

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -36,6 +36,7 @@ const APP_PROPERTIES = {
   IS_PUBLISHED: 'IS_PUBLISHED',
   DISPLAY_MODE: 'DISPLAY_MODE',
   WEB_APP_URL: 'WEB_APP_URL',
+  DEPLOY_ID: 'DEPLOY_ID',
   ADMIN_EMAILS: 'ADMIN_EMAILS',
   REACTION_COUNT_ENABLED: 'REACTION_COUNT_ENABLED',
   SCORE_SORT_ENABLED: 'SCORE_SORT_ENABLED'
@@ -81,6 +82,7 @@ function getAdminSettings() {
     displayMode: properties.getProperty(APP_PROPERTIES.DISPLAY_MODE) || 'anonymous',
     adminEmails: adminEmails,
     currentUserEmail: currentUser,
+    deployId: properties.getProperty(APP_PROPERTIES.DEPLOY_ID) || '',
     reactionCountEnabled: properties.getProperty(APP_PROPERTIES.REACTION_COUNT_ENABLED) === 'true',
     scoreSortEnabled: properties.getProperty(APP_PROPERTIES.SCORE_SORT_ENABLED) === 'true'
   };
@@ -143,6 +145,18 @@ function saveScoreSortSetting(enabled) {
   const value = enabled ? 'true' : 'false';
   saveSettings({ [APP_PROPERTIES.SCORE_SORT_ENABLED]: value });
   return `スコア順ソートを${enabled ? '有効' : '無効'}にしました。`;
+}
+
+function saveDisplayMode(mode) {
+  const value = mode === 'named' ? 'named' : 'anonymous';
+  saveSettings({ [APP_PROPERTIES.DISPLAY_MODE]: value });
+  return `表示モードを${value === 'named' ? '実名' : '匿名'}にしました。`;
+}
+
+function saveDeployId(id) {
+  const value = id ? String(id).trim() : '';
+  saveSettings({ [APP_PROPERTIES.DEPLOY_ID]: value });
+  return 'デプロイIDを更新しました。';
 }
 
 function getAdminEmails() {
@@ -570,9 +584,11 @@ if (typeof module !== 'undefined') {
     saveReactionCountSetting,
     saveScoreSortSetting,
     getAppSettings,
-    getWebAppUrl,
+  getWebAppUrl,
   saveWebAppUrl,
   getWebAppUrlFromProps,
   getSheetUpdates,
+  saveDisplayMode,
+  saveDeployId,
   };
 }

--- a/src/Unpublished.html
+++ b/src/Unpublished.html
@@ -19,6 +19,16 @@
                 <select id="sheet-selector" class="w-full p-2 rounded bg-gray-800 border border-gray-600 text-white focus:ring-2 focus:ring-yellow-400 focus:outline-none">
                     <option>シートを読み込み中...</option>
                 </select>
+                <input id="admin-emails" type="text" placeholder="admin@example.com" class="w-full p-2 rounded bg-gray-800 border border-gray-600 text-white" />
+                <select id="display-mode" class="w-full p-2 rounded bg-gray-800 border border-gray-600 text-white">
+                    <option value="anonymous">匿名表示</option>
+                    <option value="named">実名表示</option>
+                </select>
+                <label class="text-left text-sm flex items-center gap-2">
+                    <input id="reaction-toggle" type="checkbox" class="accent-yellow-500" />
+                    <span>リアクション数を表示</span>
+                </label>
+                <input id="deploy-id" type="text" placeholder="Deploy ID" class="w-full p-2 rounded bg-gray-800 border border-gray-600 text-white" />
                 <button id="publish-btn" class="w-full bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-bold py-2 px-4 rounded transition disabled:opacity-50">
                     このシートで公開する
                 </button>
@@ -41,12 +51,22 @@
             const sheetSelector = document.getElementById('sheet-selector');
             const publishBtn = document.getElementById('publish-btn');
             const messageArea = document.getElementById('message-area');
+            const adminEmailsInput = document.getElementById('admin-emails');
+            const displayModeSelect = document.getElementById('display-mode');
+            const reactionToggle = document.getElementById('reaction-toggle');
+            const deployIdInput = document.getElementById('deploy-id');
 
             // シートリストを取得してプルダウンを生成
             google.script.run
                 .withSuccessHandler(populateSheets)
                 .withFailureHandler(showError)
                 .getSheets();
+
+            // 現在の設定を取得
+            google.script.run
+                .withSuccessHandler(populateSettings)
+                .withFailureHandler(showError)
+                .getAdminSettings();
 
             function populateSheets(sheetNames) {
                 sheetSelector.innerHTML = '<option value="">-- シートを選択してください --</option>';
@@ -66,6 +86,18 @@
             function showError(error) {
                 messageArea.textContent = `エラー: ${error.message}`;
                 messageArea.className = 'mt-4 text-sm h-5 text-red-400';
+            }
+
+            function showMessage(msg) {
+                messageArea.textContent = msg;
+                messageArea.className = 'mt-4 text-sm h-5 text-green-400';
+            }
+
+            function populateSettings(settings) {
+                adminEmailsInput.value = (settings.adminEmails || []).join(',');
+                displayModeSelect.value = settings.displayMode || 'anonymous';
+                reactionToggle.checked = settings.reactionCountEnabled;
+                deployIdInput.value = settings.deployId || '';
             }
 
             publishBtn.addEventListener('click', () => {
@@ -98,6 +130,34 @@
                 publishBtn.disabled = false;
                 publishBtn.textContent = 'このシートで公開する';
             }
+
+            adminEmailsInput.addEventListener('change', () => {
+                google.script.run
+                    .withSuccessHandler(showMessage)
+                    .withFailureHandler(showError)
+                    .saveAdminEmails(adminEmailsInput.value);
+            });
+
+            displayModeSelect.addEventListener('change', () => {
+                google.script.run
+                    .withSuccessHandler(showMessage)
+                    .withFailureHandler(showError)
+                    .saveDisplayMode(displayModeSelect.value);
+            });
+
+            reactionToggle.addEventListener('change', () => {
+                google.script.run
+                    .withSuccessHandler(showMessage)
+                    .withFailureHandler(showError)
+                    .saveReactionCountSetting(reactionToggle.checked);
+            });
+
+            deployIdInput.addEventListener('change', () => {
+                google.script.run
+                    .withSuccessHandler(showMessage)
+                    .withFailureHandler(showError)
+                    .saveDeployId(deployIdInput.value);
+            });
 
             document.getElementById('open-admin-btn').addEventListener('click', () => {
                 window.top.location.href = '?view=board&mode=admin';

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -10,6 +10,7 @@ function setup() {
           case 'ADMIN_EMAILS': return 'a@example.com,b@example.com';
           case 'REACTION_COUNT_ENABLED': return 'true';
           case 'SCORE_SORT_ENABLED': return 'false';
+          case 'DEPLOY_ID': return 'deploy123';
           default: return null;
         }
       }
@@ -43,6 +44,7 @@ test('getAdminSettings returns board state', () => {
     displayMode: 'named',
     adminEmails: ['a@example.com','b@example.com'],
     currentUserEmail: 'a@example.com',
+    deployId: 'deploy123',
     reactionCountEnabled: true,
     scoreSortEnabled: false
   });


### PR DESCRIPTION
## Summary
- enable storing deployment ID in script properties
- add functions to save display mode and deploy ID
- extend unpublished page's admin controls for these settings
- update getAdminSettings and its tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f5dd4e72c832ba57238cd22d3dd52