### PR TITLE
Add tests for display mode and deploy ID settings

### DIFF
--- a/tests/saveDeployId.test.js
+++ b/tests/saveDeployId.test.js
@@ -1,0 +1,23 @@
+const { saveDeployId } = require('../src/Code.gs');
+
+function setup() {
+  const props = { setProperty: jest.fn(), deleteProperty: jest.fn() };
+  global.PropertiesService = { getScriptProperties: () => props };
+  return props;
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+});
+
+test('saveDeployId stores trimmed id', () => {
+  const props = setup();
+  saveDeployId('  abc123  ');
+  expect(props.setProperty).toHaveBeenCalledWith('DEPLOY_ID', 'abc123');
+});
+
+test('saveDeployId handles empty value', () => {
+  const props = setup();
+  saveDeployId('');
+  expect(props.setProperty).toHaveBeenCalledWith('DEPLOY_ID', '');
+});

--- a/tests/saveDisplayMode.test.js
+++ b/tests/saveDisplayMode.test.js
@@ -1,0 +1,23 @@
+const { saveDisplayMode } = require('../src/Code.gs');
+
+function setup() {
+  const props = { setProperty: jest.fn(), deleteProperty: jest.fn() };
+  global.PropertiesService = { getScriptProperties: () => props };
+  return props;
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+});
+
+test('saveDisplayMode stores named mode', () => {
+  const props = setup();
+  saveDisplayMode('named');
+  expect(props.setProperty).toHaveBeenCalledWith('DISPLAY_MODE', 'named');
+});
+
+test('saveDisplayMode defaults to anonymous', () => {
+  const props = setup();
+  saveDisplayMode('other');
+  expect(props.setProperty).toHaveBeenCalledWith('DISPLAY_MODE', 'anonymous');
+});


### PR DESCRIPTION
## Summary
- add test coverage for `saveDisplayMode`
- add test coverage for `saveDeployId`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f60e3a05c832ba7c805fda8f1cd21