### PR TITLE
Simplify admin view logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,9 @@ Administrators see a star button on each answer card allowing them to toggle thi
 
 ### Student view for administrators
 
-Administrators normally see the same student interface. To display admin
-features on demand, use the **管理者として開く** button in the sheet selector
-sidebar. The button opens the board with `mode=admin` automatically added to the
-URL. You can also manually append `mode=admin` when sharing the link or
-projecting the board.
+Administrators now automatically see the admin interface when opening the board.
+If needed, you can append `mode=admin` to the URL to force the admin view when
+sharing or projecting the board.
 
 ## Continuous Integration
 

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -217,12 +217,12 @@ function doGet(e) {
   const userIsAdmin = adminEmails.includes(userEmail);
   const view = e && e.parameter && e.parameter.view;
   const forceAdmin = e && e.parameter && e.parameter.mode === 'admin';
-  const isAdmin = userIsAdmin && forceAdmin;
+  const isAdmin = userIsAdmin || forceAdmin;
 
   if (!settings.isPublished && !(userIsAdmin && view === 'board')) {
     const template = HtmlService.createTemplateFromFile('Unpublished');
     template.userEmail = userEmail;
-    template.isAdmin = userIsAdmin;
+    template.isAdmin = isAdmin;
     return template.evaluate().setTitle('公開終了');
   }
 


### PR DESCRIPTION
## Summary
- show admin interface automatically when the viewer is an admin
- document the updated behaviour around `mode=admin`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ffc05a298832b877ad8e870b70af6