### PR TITLE
Restrict reaction counts to admins

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -475,7 +475,7 @@
                 card.classList.add('reaction-popular');
             }
 
-            const showCount = isAdmin || window.showCounts;
+            const showCount = isAdmin;
             const reactionButtons = this.reactionTypes.map(rt => {
                 const rData = data.reactions ? data.reactions[rt.key] || { count: 0, reacted: false } : { count: 0, reacted: false };
                 const btnClass = rData.reacted ? 'liked' : '';
@@ -648,7 +648,7 @@
                 this.escapeHtml(data.reason || '') + '</p>';
                 this.elements.modalStudentName.textContent = isAdmin ? data.name : '';
 
-            const showCount = isAdmin || window.showCounts;
+            const showCount = isAdmin;
             const reactionButtons = this.reactionTypes.map(rt => {
                 const rData = data.reactions ? data.reactions[rt.key] || { count: 0, reacted: false } : { count: 0, reacted: false };
                 const btnClass = rData.reacted ? 'liked' : '';


### PR DESCRIPTION
## Summary
- show reaction counts only for admins in answer cards and modals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ffd3cfcb4832b9b249f39c2eed1b4