### PR TITLE
Remove unused URL helpers

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -247,14 +247,6 @@ function doGet(e) {
 // =================================================================
 
 
-function getWebAppUrl() {
-  try {
-    return ScriptApp.getService().getUrl();
-  } catch (e) {
-    return '';
-  }
-}
-
 function saveWebAppUrl(url) {
   if (!url) {
     try {
@@ -264,10 +256,6 @@ function saveWebAppUrl(url) {
     }
   }
   saveSettings({ [APP_PROPERTIES.WEB_APP_URL]: url });
-}
-
-function getWebAppUrlFromProps() {
-  return PropertiesService.getScriptProperties().getProperty(APP_PROPERTIES.WEB_APP_URL) || '';
 }
 
 function getSheetUpdates(classFilter, sortMode, clientHashesJson, adminOverride) {
@@ -587,9 +575,7 @@ if (typeof module !== 'undefined') {
     saveReactionCountSetting,
     saveScoreSortSetting,
     getAppSettings,
-  getWebAppUrl,
   saveWebAppUrl,
-  getWebAppUrlFromProps,
   getSheetUpdates,
   saveDisplayMode,
   saveDeployId,


### PR DESCRIPTION
## Summary
- delete `getWebAppUrl` and `getWebAppUrlFromProps`
- drop their exports

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68500f9c6650832b8eb37a520589e4b8