### PR TITLE
Remove unused selectedHeader

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -411,7 +411,6 @@ function addReaction(rowIndex, reactionKey) {
       CURIOUS: headerIndices[COLUMN_HEADERS.CURIOUS] + 1,
     };
 
-    const selectedHeader = COLUMN_HEADERS[reactionKey];
     const selectedCol = colIndices[reactionKey];
 
     // Retrieve current lists for all reactions


### PR DESCRIPTION
## Summary
- clean up `addReaction` implementation by deleting the unused `selectedHeader` variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685090fb32fc832b82894abc6a1d88e9