### PR TITLE
Add helper for active user email

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -43,6 +43,15 @@ const APP_PROPERTIES = {
   PUBLISH_TIMESTAMP: 'PUBLISH_TIMESTAMP'
 };
 
+// Helper to safely get the active user's email
+this.getActiveUserEmail = function() {
+  try {
+    return Session.getActiveUser().getEmail() || '';
+  } catch (e) {
+    return '';
+  }
+};
+
 /**
  * Save multiple script properties at once.
  * If a value is null or undefined the property is removed.
@@ -74,7 +83,7 @@ function getAdminSettings() {
   const adminEmails = adminEmailsRaw ? adminEmailsRaw.split(',').map(e => e.trim()).filter(Boolean) : [];
   let currentUser = '';
   try {
-   currentUser = Session.getActiveUser().getEmail();
+   currentUser = getActiveUserEmail();
   } catch (e) {}
   return {
     isPublished: properties.getProperty(APP_PROPERTIES.IS_PUBLISHED) === 'true',
@@ -172,7 +181,7 @@ function isUserAdmin() {
   const admins = getAdminEmails();
   let email = '';
   try {
-    email = Session.getActiveUser().getEmail();
+    email = getActiveUserEmail();
   } catch (e) {}
   return admins.includes(email);
 }
@@ -201,7 +210,7 @@ function doGet(e) {
   const settings = getAppSettings();
   let userEmail;
   try {
-    userEmail = Session.getActiveUser().getEmail();
+    userEmail = getActiveUserEmail();
   } catch (e) {
     userEmail = '匿名ユーザー';
   }
@@ -302,7 +311,7 @@ function getSheetData(sheetName, classFilter, sortMode, adminOverride) {
     const allValues = sheet.getDataRange().getValues();
     if (allValues.length < 1) return { header: "シートにデータがありません", rows: [] };
     
-    const userEmail = Session.getActiveUser().getEmail();
+    const userEmail = getActiveUserEmail();
     const headerIndices = getAndCacheHeaderIndices(sheetName, allValues[0]);
     const dataRows = allValues.slice(1);
 
@@ -393,7 +402,7 @@ function addReaction(rowIndex, reactionKey) {
     if (!lock.tryLock(10000)) {
       return { status: 'error', message: '他のユーザーが操作中です。しばらく待ってから再試行してください。' };
     }
-    const userEmail = Session.getActiveUser().getEmail();
+    const userEmail = getActiveUserEmail();
     if (!userEmail) return { status: 'error', message: 'ログインしていないため、操作できません。' };
     const settings = getAppSettings();
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(settings.activeSheetName);
@@ -571,5 +580,6 @@ if (typeof module !== 'undefined') {
     getSheetUpdates,
     saveDisplayMode,
     saveDeployId,
+    getActiveUserEmail: this.getActiveUserEmail,
   };
 }

--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -36,7 +36,7 @@ function buildSheet() {
 
 function setupMocks(userEmail, sheet) {
   global.LockService = { getScriptLock: () => ({ tryLock: jest.fn(() => true), releaseLock: jest.fn() }) };
-  global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
+  global.getActiveUserEmail = () => userEmail;
   global.PropertiesService = { getScriptProperties: () => ({ getProperty: () => 'Sheet1' }) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
@@ -45,7 +45,7 @@ function setupMocks(userEmail, sheet) {
 
 afterEach(() => {
   delete global.LockService;
-  delete global.Session;
+  delete global.getActiveUserEmail;
   delete global.PropertiesService;
   delete global.SpreadsheetApp;
 });

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -2,7 +2,7 @@ const { doGet } = require('../src/Code.gs');
 
 afterEach(() => {
   delete global.HtmlService;
-  delete global.Session;
+  delete global.getActiveUserEmail;
   delete global.PropertiesService;
 });
 
@@ -17,7 +17,7 @@ function setup({isPublished, userEmail='admin@example.com', adminEmails='admin@e
       }
     })
   };
-  global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
+  global.getActiveUserEmail = () => userEmail;
   const output = { setTitle: jest.fn(() => output), addMetaTag: jest.fn(() => output) };
   let template = { evaluate: () => output };
   global.HtmlService = {

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -24,14 +24,12 @@ function setup() {
       ]
     })
   };
-  global.Session = {
-    getActiveUser: () => ({ getEmail: () => 'a@example.com' })
-  };
+  global.getActiveUserEmail = () => 'a@example.com';
 }
 afterEach(() => {
   delete global.PropertiesService;
   delete global.SpreadsheetApp;
-  delete global.Session;
+  delete global.getActiveUserEmail;
 });
 
 test('getAdminSettings returns board state', () => {
@@ -52,6 +50,6 @@ test('getAdminSettings returns board state', () => {
 
 test('getAdminSettings throws for non-admin user', () => {
   setup();
-  global.Session = { getActiveUser: () => ({ getEmail: () => 'other@example.com' }) };
+  global.getActiveUserEmail = () => 'other@example.com';
   expect(() => getAdminSettings()).toThrow('管理者のみ実行できます');
 });

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -23,9 +23,7 @@ function setupMocks(rows, userEmail, adminEmails = '') {
   };
 
   // Mock other global services
-  global.Session = {
-    getActiveUser: () => ({ getEmail: () => userEmail })
-  };
+  global.getActiveUserEmail = () => userEmail;
   global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
   global.PropertiesService = {
     getScriptProperties: () => ({
@@ -40,7 +38,7 @@ function setupMocks(rows, userEmail, adminEmails = '') {
 
 afterEach(() => {
   delete global.SpreadsheetApp;
-  delete global.Session;
+  delete global.getActiveUserEmail;
   delete global.CacheService;
   delete global.PropertiesService;
 });

--- a/tests/getSheetUpdates.test.js
+++ b/tests/getSheetUpdates.test.js
@@ -16,7 +16,7 @@ function setupMocks(rows, userEmail) {
       }
     })
   };
-  global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
+  global.getActiveUserEmail = () => userEmail;
   global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
   global.PropertiesService = {
     getScriptProperties: () => ({
@@ -36,7 +36,7 @@ function setupMocks(rows, userEmail) {
 
 afterEach(() => {
   delete global.SpreadsheetApp;
-  delete global.Session;
+  delete global.getActiveUserEmail;
   delete global.CacheService;
   delete global.PropertiesService;
   delete global.Utilities;

--- a/tests/toggleHighlight.test.js
+++ b/tests/toggleHighlight.test.js
@@ -28,7 +28,7 @@ function setupMocks(sheet) {
       }
     })
   };
-  global.Session = { getActiveUser: () => ({ getEmail: () => 'admin@example.com' }) };
+  global.getActiveUserEmail = () => 'admin@example.com';
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
   };
@@ -38,7 +38,7 @@ afterEach(() => {
   delete global.LockService;
   delete global.PropertiesService;
   delete global.SpreadsheetApp;
-  delete global.Session;
+  delete global.getActiveUserEmail;
 });
 
 test('toggleHighlight flips stored value', () => {


### PR DESCRIPTION
## Summary
- add `getActiveUserEmail` helper and export it
- use `getActiveUserEmail()` instead of `Session.getActiveUser().getEmail()`
- adjust tests to stub `getActiveUserEmail`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a13dac20832b9fcf468b253a7578