### PR TITLE
Hide counts from student view

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -235,7 +235,8 @@ function doGet(e) {
   template.userEmail = userEmail;
   template.isAdmin = userIsAdmin;
   template.adminMode = adminMode;
-  template.showCounts = adminMode && settings.reactionCountEnabled;
+  // Show reaction counts only to administrators similar to the unpublish button
+  template.showCounts = userIsAdmin && settings.reactionCountEnabled;
   template.scoreSortEnabled = adminMode && settings.scoreSortEnabled;
   return template.evaluate()
       .setTitle('StudyQuest - みんなのかいとうボード')


### PR DESCRIPTION
## Summary
- show reaction counts only when the viewer is an admin

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850aa50a010832bb398da9e00d527e3