### PR TITLE
アプリ管理機能の改善: DEPLOY_ID対応とリアクション表示制御

### DIFF
--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -53,6 +53,18 @@
           <div id="unpublish-help" class="text-xs text-gray-500 hidden">
             現在公開中のアプリを非公開にします
           </div>
+          
+          <button 
+            id="open-app-btn" 
+            class="w-full text-white font-bold py-2 px-4 rounded-lg bg-green-500 hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-75 transition disabled:bg-green-300 disabled:cursor-not-allowed"
+            aria-describedby="open-app-help"
+            disabled>
+            <span id="open-app-icon" class="inline-block mr-2">🚀</span>
+            アプリを開く
+          </button>
+          <div id="open-app-help" class="text-xs text-gray-500 hidden">
+            公開中のアプリを新しいタブで開きます
+          </div>
         </div>
       </div>
       
@@ -66,6 +78,7 @@
         sheetList: document.getElementById('sheet-list'),
         publishBtn: document.getElementById('publish-btn'),
         unpublishBtn: document.getElementById('unpublish-btn'),
+        openAppBtn: document.getElementById('open-app-btn'),
         messageArea: document.getElementById('message-area')
       };
 
@@ -75,6 +88,7 @@
         loadInitialState();
         elements.publishBtn.addEventListener('click', publish);
         elements.unpublishBtn.addEventListener('click', unpublish);
+        elements.openAppBtn.addEventListener('click', openApp);
       });
 
       function loadInitialState() {
@@ -94,13 +108,19 @@
           elements.statusText.setAttribute('aria-label', `アプリは現在公開中です。公開中のシート: ${status.activeSheetName}`);
           elements.unpublishBtn.disabled = false;
           elements.unpublishBtn.setAttribute('aria-label', `${status.activeSheetName}の公開を終了する`);
+          elements.openAppBtn.disabled = !status.deployId; // DEPLOY_IDがある場合のみ有効
+          elements.openAppBtn.setAttribute('aria-label', `${status.activeSheetName}のアプリを開く`);
           document.getElementById('unpublish-help').classList.remove('hidden');
+          document.getElementById('open-app-help').classList.remove('hidden');
         } else {
           elements.statusText.textContent = '現在、アプリは非公開です。';
           elements.statusText.setAttribute('aria-label', 'アプリは現在非公開状態です');
           elements.unpublishBtn.disabled = true;
           elements.unpublishBtn.removeAttribute('aria-label');
+          elements.openAppBtn.disabled = true;
+          elements.openAppBtn.removeAttribute('aria-label');
           document.getElementById('unpublish-help').classList.add('hidden');
+          document.getElementById('open-app-help').classList.add('hidden');
         }
         
         elements.sheetList.innerHTML = '';
@@ -162,6 +182,15 @@
           .unpublishApp();
       }
 
+      function openApp() {
+        google.script.run
+          .withSuccessHandler(() => {
+            showMessage('アプリを開いています...', 'blue');
+          })
+          .withFailureHandler(showError)
+          .openPublishedApp();
+      }
+
 
       function showMessage(msg, color = 'red') {
         const colorClasses = { red: 'text-red-600', green: 'text-green-600', blue: 'text-blue-600' };
@@ -194,20 +223,24 @@
       function setLoading(isLoading, msg = "") {
         elements.publishBtn.disabled = isLoading;
         elements.unpublishBtn.disabled = isLoading;
+        elements.openAppBtn.disabled = isLoading;
         
         // Update ARIA attributes for screen readers
         elements.publishBtn.setAttribute('aria-busy', isLoading.toString());
         elements.unpublishBtn.setAttribute('aria-busy', isLoading.toString());
+        elements.openAppBtn.setAttribute('aria-busy', isLoading.toString());
         
         if (isLoading) {
           showMessage(msg, 'blue');
           // Add loading icons
           document.getElementById('publish-icon').textContent = '⏳';
           document.getElementById('unpublish-icon').textContent = '⏳';
+          document.getElementById('open-app-icon').textContent = '⏳';
         } else {
           // Restore original icons
           document.getElementById('publish-icon').textContent = '📊';
           document.getElementById('unpublish-icon').textContent = '🔒';
+          document.getElementById('open-app-icon').textContent = '🚀';
         }
       }
     </script>


### PR DESCRIPTION
## 主な変更点

### 🔧 DEPLOY_ID対応
- openPublishedApp関数: DEPLOY_IDベースのURL生成に変更
- generateWebAppUrl関数: 新しいURL生成ロジックを追加
- WEB_APP_URL定数を削除し、DEPLOY_IDを使用

### 🎛️ リアクション表示制御
- REACTION_COUNT_ENABLED=falseの時: カウント機能は維持、数字のみ非表示
- 既存のshowCounts変数が正しく動作することを確認

### 🚀 SheetSelector機能拡張
- 「アプリを開く」ボタンを追加
- DEPLOY_IDの有無による状態管理
- アクセシビリティ対応とローディング状態の改善

### 🔗 URL生成方式
- 旧: WEB_APP_URLプロパティに依存
- 新: DEPLOY_IDから動的生成 (https://script.google.com/macros/s/{DEPLOY_ID}/exec)

🤖 Generated with [Claude Code](https://claude.ai/code)