### PR TITLE
Hide admin details for students

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -10,11 +10,11 @@
   <script>
     // Template variables from server
     window.isStudentMode = <?= typeof isStudentMode !== 'undefined' ? isStudentMode : 'true' ?>;
-    window.showCounts = <?= showCounts ? 'true' : 'false' ?>;
-    window.showAdminFeatures = <?= showAdminFeatures ? 'true' : 'false' ?>;
-    window.showHighlightToggle = <?= showHighlightToggle ? 'true' : 'false' ?>;
-    window.showScoreSort = <?= showScoreSort ? 'true' : 'false' ?>;
-    window.showPublishControls = <?= showPublishControls ? 'true' : 'false' ?>;
+      window.showCounts = <?= showCounts ?>;
+      window.showAdminFeatures = <?= showAdminFeatures ?>;
+      window.showHighlightToggle = <?= showHighlightToggle ?>;
+      window.showScoreSort = <?= showScoreSort ?>;
+      window.showPublishControls = <?= showPublishControls ?>;
     window.displayMode = '<?= displayMode || 'anonymous' ?>';
     window.isAdminUser = <?= typeof isAdminUser !== 'undefined' && isAdminUser ? 'true' : 'false' ?>;
   </script>
@@ -701,9 +701,9 @@
                 this.escapeHtml(data.reason || '') + '</p>' +
                 '</div>' +
                 '<div class="text-xs text-gray-400 pt-3 border-t-2 border-cyan-400/80 border-dashed flex justify-between items-center">' +
-                '<div><span class="font-bold text-sm text-gray-200">' + this.escapeHtml(data.name) + '</span></div>' +
+                (showAdminFeatures ? '<div><span class="font-bold text-sm text-gray-200">' + this.escapeHtml(data.name) + '</span></div>' : '') +
                 '<div class="flex gap-2">' + reactionButtons + highlightBtn + '</div>' +
-                '</div>'; 
+                '</div>';
 
             card.addEventListener('click', (e) => {
                 const reaction = e.target.closest('.reaction-btn');
@@ -845,7 +845,13 @@
                 '<p class="text-gray-100 whitespace-pre-wrap break-words mt-6 text-xl">' +
                 this.escapeHtml(data.reason || '') + '</p>';
                 
-            this.elements.modalStudentName.textContent = data.name;
+            if (showAdminFeatures) {
+                this.elements.modalStudentName.textContent = data.name;
+                this.elements.modalStudentName.parentElement.style.display = '';
+            } else {
+                this.elements.modalStudentName.textContent = '';
+                this.elements.modalStudentName.parentElement.style.display = 'none';
+            }
 
             // ★修正: モーダルでのリアクション数表示も管理者権限に基づく
             const shouldShowCount = showCounts;


### PR DESCRIPTION
## Summary
- hide name display when `showAdminFeatures` is false
- hide modal name if not admin
- keep existing tests passing
- fix admin features toggle

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851d6542ea0832ba2185f96b1a5b9af