### PR TITLE
Add saveWebAppUrl support

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -49,7 +49,8 @@ const SCORING_CONFIG = {
 };
 const APP_PROPERTIES = {
   DEPLOY_ID: 'DEPLOY_ID',
-  ADMIN_EMAILS: 'ADMIN_EMAILS' // 管理者メールアドレスのリスト（カンマ区切り）
+  ADMIN_EMAILS: 'ADMIN_EMAILS', // 管理者メールアドレスのリスト（カンマ区切り）
+  WEB_APP_URL: 'WEB_APP_URL'
 };
 
 /**
@@ -162,6 +163,17 @@ function saveDeployId(id) {
   const value = id ? String(id).trim() : '';
   saveSettings({ [APP_PROPERTIES.DEPLOY_ID]: value });
   return 'デプロイIDを更新しました。';
+}
+
+/**
+ * Save the published Web App URL to script properties
+ * @param {string} url - Web app URL
+ * @returns {string} Status message
+ */
+function saveWebAppUrl(url) {
+  const value = url ? String(url).trim() : '';
+  saveSettings({ [APP_PROPERTIES.WEB_APP_URL]: value });
+  return 'Web App URL を保存しました。';
 }
 
 
@@ -843,6 +855,7 @@ if (typeof module !== 'undefined') {
     generateWebAppUrl,
     generateAdminUrl,
     saveDeployId,
+    saveWebAppUrl,
     showSheetSelector,
     onOpen,
     openPublishedApp,

--- a/tests/saveWebAppUrl.test.js
+++ b/tests/saveWebAppUrl.test.js
@@ -1,0 +1,24 @@
+const { saveWebAppUrl } = require('../src/Code.gs');
+
+function setup() {
+  const props = { setProperties: jest.fn(), deleteProperty: jest.fn() };
+  global.PropertiesService = { getScriptProperties: () => props };
+  return props;
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+});
+
+test('saveWebAppUrl stores trimmed url', () => {
+  const props = setup();
+  saveWebAppUrl('  https://example.com/app  ');
+  expect(props.setProperties).toHaveBeenCalledWith({ WEB_APP_URL: 'https://example.com/app' });
+});
+
+test('saveWebAppUrl handles empty value', () => {
+  const props = setup();
+  saveWebAppUrl('');
+  expect(props.setProperties).toHaveBeenCalledWith({ WEB_APP_URL: '' });
+});
+

--- a/tests/updateWebAppUrl.test.js
+++ b/tests/updateWebAppUrl.test.js
@@ -1,0 +1,46 @@
+jest.mock('fs');
+jest.mock('googleapis');
+
+const fs = require('fs');
+const { google } = require('googleapis');
+
+test('updateWebAppUrl calls saveWebAppUrl', async () => {
+  fs.readFileSync.mockReturnValue('{"scriptId":"123"}');
+
+  const runMock = jest.fn().mockResolvedValue({});
+  const listMock = jest.fn().mockResolvedValue({
+    data: {
+      deployments: [
+        { entryPoints: [{ webApp: { url: 'https://example.com' } }] }
+      ]
+    }
+  });
+
+  google.auth = {
+    GoogleAuth: jest.fn().mockImplementation(() => ({
+      getClient: jest.fn().mockResolvedValue('client')
+    }))
+  };
+  google.script = jest.fn(() => ({
+    projects: { deployments: { list: listMock } },
+    scripts: { run: runMock }
+  }));
+
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+  require('../scripts/updateWebAppUrl.js');
+  await new Promise(setImmediate);
+
+  expect(runMock).toHaveBeenCalledWith({
+    scriptId: '123',
+    requestBody: { function: 'saveWebAppUrl', parameters: ['https://example.com'] }
+  });
+  expect(exitSpy).not.toHaveBeenCalled();
+
+  console.log.mockRestore();
+  console.error.mockRestore();
+  exitSpy.mockRestore();
+});
+


### PR DESCRIPTION
## Summary
- store deployed web app URL in Apps Script properties via new `saveWebAppUrl`
- export the function for tests
- test `saveWebAppUrl` and Node script that calls it

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851eff8f1ac832b835eec29a4411231