### PR TITLE
Refactor display mode handling

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -196,7 +196,6 @@ function doGet(e) {
   
   // Default student view
   const template = HtmlService.createTemplateFromFile('Page');
-  template.isStudentMode = true;
   template.showCounts = false; // 生徒用：リアクション数非表示
   template.showAdminFeatures = false; // 生徒用：管理機能非表示
   template.showHighlightToggle = false; // 生徒用：ハイライト切り替えなし
@@ -229,7 +228,6 @@ function doGetAdmin(e) {
   
   // Admin view with all features
   const template = HtmlService.createTemplateFromFile('Page');
-  template.isStudentMode = false;
   template.showCounts = true; // 管理者用：リアクション数表示
   template.showAdminFeatures = true; // 管理者用：管理機能表示
   template.showHighlightToggle = true; // 管理者用：ハイライト切り替えあり

--- a/src/Page.html
+++ b/src/Page.html
@@ -9,7 +9,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
   <script>
     // Template variables from server
-    window.isStudentMode = <?= typeof isStudentMode !== 'undefined' ? isStudentMode : true ?>;
       window.showCounts = <?= showCounts ?>;
       window.showAdminFeatures = <?= showAdminFeatures ?>;
       window.showHighlightToggle = <?= showHighlightToggle ?>;
@@ -162,13 +161,13 @@
 
   <script>
     // 環境変数の安全な取得
-    const isStudentMode = typeof window !== 'undefined' ? Boolean(window.isStudentMode) : true;
     const showCounts = typeof window !== 'undefined' ? Boolean(window.showCounts) : false;
     const showAdminFeatures = typeof window !== 'undefined' ? Boolean(window.showAdminFeatures) : false;
     const showHighlightToggle = typeof window !== 'undefined' ? Boolean(window.showHighlightToggle) : false;
     const showScoreSort = typeof window !== 'undefined' ? Boolean(window.showScoreSort) : false;
     const showPublishControls = typeof window !== 'undefined' ? Boolean(window.showPublishControls) : false;
     const displayMode = typeof window !== 'undefined' ? window.displayMode : 'anonymous';
+    const isAdminMode = displayMode === 'named';
     const isAdminUser = typeof window !== 'undefined' ? Boolean(window.isAdminUser) : false;
 
     class StudyQuestApp {
@@ -247,7 +246,7 @@
         initializeGasInterface() {
 
             this.gas = {
-                getData: (sheetName, classFilter, sortMode) => this.runGas('getSheetDataForDisplay', sheetName, classFilter, sortMode, !isStudentMode),
+                getData: (sheetName, classFilter, sortMode) => this.runGas('getSheetDataForDisplay', sheetName, classFilter, sortMode, isAdminMode),
                 addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction),
                 toggleHighlight: (rowIndex) => this.runGas('toggleHighlight', rowIndex)
             };


### PR DESCRIPTION
## Summary
- remove `isStudentMode` flag from backend templates
- derive admin mode based on `displayMode` in the frontend
- call `getSheetDataForDisplay` with `isAdminMode`

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6852000d5950832bb77e50fa533335cc