### PR TITLE
Route admins automatically

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -188,7 +188,7 @@ function saveWebAppUrl(url) {
  */
 function doGet(e) {
   // Check if admin mode is requested
-  const isAdminMode = e.parameter.admin === 'true';
+  const isAdminMode = e.parameter.admin === 'true' || isUserAdmin();
   
   if (isAdminMode) {
     return doGetAdmin(e);
@@ -202,7 +202,6 @@ function doGet(e) {
   template.showScoreSort = false; // 生徒用：スコア順表示なし
   template.showPublishControls = false; // 生徒用：公開終了ボタンなし
   template.displayMode = 'anonymous'; // 生徒用：匿名表示
-  template.isAdminUser = isUserAdmin(); // 管理者かどうか
   
   return template.evaluate()
       .setTitle('StudyQuest - みんなのかいとうボード')

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -26,25 +26,31 @@ function setup({userEmail='admin@example.com', adminEmails='admin@example.com'})
   return { output, getTemplate: () => template };
 }
 
-test('admin view=board shows Page template', () => {
-  const { output } = setup({});
+test('admin user with view parameter sees admin view', () => {
+  const { getTemplate } = setup({});
   const e = { parameter: { view: 'board' } };
   doGet(e);
+  const template = getTemplate();
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
+  expect(template.displayMode).toBe('named');
 });
 
-test('admin default shows Page', () => {
-  setup({});
+test('non-admin default shows student view', () => {
+  const { getTemplate } = setup({ userEmail: 'user@example.com' });
   const e = { parameter: {} };
   doGet(e);
+  const template = getTemplate();
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
+  expect(template.displayMode).toBe('anonymous');
 });
 
-test('admin default uses Page template regardless of publish status', () => {
-  setup({});
+test('admin email automatically routes to admin view', () => {
+  const { getTemplate } = setup({});
   const e = { parameter: {} };
   doGet(e);
+  const template = getTemplate();
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
+  expect(template.displayMode).toBe('named');
 });
 
 test('admin=true enables admin view', () => {


### PR DESCRIPTION
## Summary
- route doGet to the admin view when the user is an admin
- remove isAdminUser flag from student template
- extend doGet tests for admin auto-routing and non-admin path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685205579668832ba2c244772f9840d5