### PR TITLE
Add admin view clarifications and isAdminUser tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ Administrators see a star button on each answer card allowing them to toggle thi
 
 ### Student view for administrators
 
-Administrators now automatically see the admin interface when opening the board.
-If needed, you can append `?admin=true` to the URL to force the admin view when
-sharing or projecting the board.
+Administrators automatically receive the admin interface whenever they open the
+board. Use `?admin=false` if you want to preview the student view. If you need
+to force the admin view when sharing or projecting the board, you can append
+`?admin=true` to the URL.
 
 ## Continuous Integration
 

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -202,7 +202,8 @@ function doGet(e) {
   template.showScoreSort = false; // 生徒用：スコア順表示なし
   template.showPublishControls = false; // 生徒用：公開終了ボタンなし
   template.displayMode = 'anonymous'; // 生徒用：匿名表示
-  
+  template.isAdminUser = isUserAdmin(); // 管理者判定
+
   return template.evaluate()
       .setTitle('StudyQuest - みんなのかいとうボード')
       .addMetaTag('viewport', 'width=device-width, initial-scale=1');

--- a/tests/doGetAdmin.test.js
+++ b/tests/doGetAdmin.test.js
@@ -28,3 +28,23 @@ test('non-admin users see access denied message', () => {
   const result = doGetAdmin({});
   expect(result.getContent()).toContain('アクセス拒否');
 });
+
+test('doGetAdmin sets isAdminUser true in template', () => {
+  global.PropertiesService = {
+    getScriptProperties: () => ({
+      getProperty: () => 'admin@example.com'
+    })
+  };
+  global.Session = { getActiveUser: () => ({ getEmail: () => 'admin@example.com' }) };
+  global.getActiveUserEmail = () => 'admin@example.com';
+
+  const output = { setTitle: jest.fn(() => output), addMetaTag: jest.fn(() => output) };
+  let template = { evaluate: () => output };
+  global.HtmlService = {
+    createTemplateFromFile: jest.fn(() => template)
+  };
+
+  doGetAdmin({});
+  const tpl = template;
+  expect(tpl.isAdminUser).toBe(true);
+});

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -62,3 +62,11 @@ test('admin=true enables admin view', () => {
   expect(template.displayMode).toBe('named');
 });
 
+test('doGet sets isAdminUser based on isUserAdmin when in student mode', () => {
+  const { getTemplate } = setup({ userEmail: 'user@example.com', adminEmails: 'admin@example.com' });
+  const e = { parameter: {} };
+  doGet(e);
+  const template = getTemplate();
+  expect(template.isAdminUser).toBe(false);
+});
+


### PR DESCRIPTION
## Summary
- clarify that admins always see the admin interface by default
- expose `isAdminUser` flag in `doGet`
- test `doGetAdmin` sets `isAdminUser` true
- test `doGet` outputs `isAdminUser` when not in admin mode

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852061fac2c832b86ca4460ba7420e9