### PR TITLE
Add admin param override

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,14 @@ Administrators see a star button on each answer card allowing them to toggle thi
 
 ### Student view for administrators
 
-Administrators automatically receive the admin interface whenever they open the
-board. Use `?admin=false` if you want to preview the student view. If you need
-to force the admin view when sharing or projecting the board, you can append
-`?admin=true` to the URL.
+Administrators automatically see the admin interface whenever they open the
+board. You can override this behavior with URL parameters:
+
+- `?admin=false` &ndash; forces the student view, even if you are an admin.
+- `?admin=true` &ndash; forces the admin view regardless of your account.
+
+When neither parameter is present, the app falls back to your normal admin
+status.
 
 ## Continuous Integration
 

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -187,8 +187,16 @@ function saveWebAppUrl(url) {
  * @returns {HtmlOutput} Student interface
  */
 function doGet(e) {
-  // Check if admin mode is requested
-  const isAdminMode = e.parameter.admin === 'true' || isUserAdmin();
+  // Determine admin mode based on URL parameter or user status
+  let isAdminMode;
+  const adminParam = String(e.parameter.admin).toLowerCase();
+  if (adminParam === 'false') {
+    isAdminMode = false; // Force student view
+  } else if (adminParam === 'true') {
+    isAdminMode = true; // Force admin view
+  } else {
+    isAdminMode = isUserAdmin();
+  }
   
   if (isAdminMode) {
     return doGetAdmin(e);

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -62,6 +62,15 @@ test('admin=true enables admin view', () => {
   expect(template.displayMode).toBe('named');
 });
 
+test('admin=false forces student view even for admins', () => {
+  const { getTemplate } = setup({});
+  const e = { parameter: { admin: 'false' } };
+  doGet(e);
+  const template = getTemplate();
+  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
+  expect(template.displayMode).toBe('anonymous');
+});
+
 test('doGet sets isAdminUser based on isUserAdmin when in student mode', () => {
   const { getTemplate } = setup({ userEmail: 'user@example.com', adminEmails: 'admin@example.com' });
   const e = { parameter: {} };


### PR DESCRIPTION
## Summary
- allow `?admin=` query parameter to override automatic admin detection
- clarify override behavior in README
- test admin=false mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852504e61f4832ba19a7d7eeb015c8c