### PR TITLE
Add highlight and reaction features

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -16,6 +16,15 @@
     :focus-visible { outline: 3px solid #8be9fd; outline-offset: 2px; border-radius: 4px; }
     header { position: sticky; top: 0; z-index: 5; }
     .answer-card { will-change: transform, opacity; }
+    .answer-card.highlighted { border-color: #facc15; box-shadow: 0 0 15px rgba(250,204,21,0.4); transform: scale(1.02); transition: all 0.3s ease; }
+    .answer-card:hover { transform: translateY(-4px) scale(1.02); box-shadow: 0 8px 25px rgba(139,233,253,0.3); }
+    .answer-card.highlighted:hover { transform: translateY(-4px) scale(1.04); }
+    .highlight-badge { position: absolute; top: -8px; right: -8px; }
+    .reaction-bg-like { border-color:#ef4444; border-image: linear-gradient(to bottom,#facc15,#fcd34d) 1; }
+    .reaction-bg-understand { border-color:#fbbf24; border-image: linear-gradient(to bottom,#a3e635,#bef264) 1; }
+    .reaction-bg-curious { border-color:#3b82f6; border-image: linear-gradient(to bottom,#38bdf8,#7dd3fc) 1; }
+    .reaction-bg-mixed { border-color:#8b5cf6; border-image: linear-gradient(to bottom,#f59e0b,#10b981,#3b82f6) 1; }
+    .reaction-bg-all { border-color:transparent; border-image: linear-gradient(90deg,#ef4444,#fbbf24,#3b82f6) 1; }
     .answer-preview { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; text-overflow: ellipsis; min-height: 120px; }
     .like-btn svg { transition: all 0.2s ease-in-out; color: #facc15; fill: none; }
     .like-btn.liked svg { stroke: transparent; fill: #facc15; transform: scale(1.1); }
@@ -65,6 +74,9 @@
   </footer>
 
   <script>
+    const displayMode = '<?= displayMode ?>';
+    const showAdminFeatures = <?= showAdminFeatures ? 'true' : 'false' ?>;
+    const showHighlightToggle = <?= showHighlightToggle ? 'true' : 'false' ?>;
     class StudyQuestApp {
         constructor() {
             this.elements = {
@@ -94,10 +106,21 @@
             };
             
             this.pollingInterval = null;
+
+            this.showHighlightToggle = showHighlightToggle;
+            this.showAdminFeatures = showAdminFeatures;
+            this.displayMode = displayMode;
+            this.reactionTypes = [
+                { key: 'LIKE', icon: 'thumbs-up' },
+                { key: 'UNDERSTAND', icon: 'book-open-check' },
+                { key: 'CURIOUS', icon: 'help-circle' }
+            ];
             
             this.gas = {
                 getPublishedSheetData: (classFilter) => this.runGas('getPublishedSheetData', classFilter),
-                addLike: (rowIndex) => this.runGas('addLike', rowIndex)
+                addLike: (rowIndex) => this.runGas('addReaction', rowIndex, 'LIKE'),
+                addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction),
+                toggleHighlight: (rowIndex) => this.runGas('toggleHighlight', rowIndex)
             };
             
             this.init();
@@ -312,74 +335,140 @@
 
         createAnswerCard(data) {
             const card = document.createElement('div');
-            card.className = 'answer-card glass-panel rounded-xl p-4 flex flex-col justify-between shadow-lg border-2 border-cyan-400/80 cursor-pointer opacity-0';
+            const highlightClass = data.highlight ? ' highlighted' : '';
+            card.className = 'answer-card glass-panel rounded-xl p-4 flex flex-col justify-between shadow-lg border-2 border-cyan-400/80 cursor-pointer opacity-0' + highlightClass;
             card.dataset.rowIndex = data.rowIndex;
-            
-            const likeIcon = this.getIcon('thumbs-up', 'w-5 h-5');
-            const hasLikedClass = data.hasLiked ? 'liked' : '';
-            
-            card.innerHTML = 
-                '<div class="flex-grow mb-3 answer-preview">' +
-                '<p class="opinion-text text-cyan-200 whitespace-pre-wrap break-words text-xl md:text-2xl font-semibold leading-tight">' + 
+
+            const active = this.reactionTypes
+              .filter(rt => data.reactions && data.reactions[rt.key] && data.reactions[rt.key].count > 0)
+              .map(rt => rt.key);
+            if (active.length === 1) {
+                if (active[0] === 'LIKE') card.classList.add('reaction-bg-like');
+                if (active[0] === 'UNDERSTAND') card.classList.add('reaction-bg-understand');
+                if (active[0] === 'CURIOUS') card.classList.add('reaction-bg-curious');
+            } else if (active.length === 2) {
+                card.classList.add('reaction-bg-mixed');
+            } else if (active.length > 2) {
+                card.classList.add('reaction-bg-all');
+            }
+
+            let highlightBtn = '';
+            if (this.showHighlightToggle) {
+                const cls = data.highlight ? 'liked' : '';
+                highlightBtn = '<button type="button" class="highlight-btn like-btn ' + cls + '" aria-label="Highlight" data-row-index="' + data.rowIndex + '">' +
+                               this.getIcon('star', 'w-5 h-5') +
+                               '</button>';
+            }
+            const badge = data.highlight ? '<span class="highlight-badge">' + this.getIcon('star', 'w-5 h-5 fill-yellow-400 stroke-yellow-400') + '</span>' : '';
+
+            const nameHtml = this.showAdminFeatures ? '<div><span class="font-bold text-sm text-gray-200">' + this.escapeHtml(data.name) + '</span></div>' : '';
+
+            const reactionButtons = this.reactionTypes.map(rt => {
+                const info = data.reactions ? data.reactions[rt.key] : { count: 0, reacted: false };
+                const cls = info.reacted ? 'liked' : '';
+                return '<button type="button" class="reaction-btn like-btn ' + cls + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.key + '">' +
+                       this.getIcon(rt.icon, 'w-5 h-5') +
+                       '<span class="reaction-count font-bold text-lg text-gray-200">' + (info.count || 0) + '</span>' +
+                       '</button>';
+            }).join('');
+
+            card.innerHTML =
+                '<div class="relative flex-grow mb-3 answer-preview">' + badge +
+                '<p class="opinion-text text-cyan-200 whitespace-pre-wrap break-words text-xl md:text-2xl font-semibold leading-tight">' +
                 this.escapeHtml(data.opinion || '') + '</p>' +
-                '<p class="text-gray-100 whitespace-pre-wrap break-words mt-4">' + 
+                '<p class="text-gray-100 whitespace-pre-wrap break-words mt-4">' +
                 this.escapeHtml(data.reason || '') + '</p>' +
                 '</div>' +
                 '<div class="text-xs text-gray-400 pt-3 border-t-2 border-cyan-400/80 border-dashed flex justify-between items-center">' +
-                '<div><span class="font-bold text-sm text-gray-200">' + this.escapeHtml(data.name) + '</span></div>' +
-                '<button type="button" class="like-btn flex items-center gap-1.5 ' + hasLikedClass + '" aria-label="いいね" data-row-index="' + data.rowIndex + '">' +
-                likeIcon +
-                '<span class="like-count font-bold text-lg text-gray-200">' + (data.likes || 0) + '</span>' +
-                '</button>' +
+                nameHtml +
+                '<div class="flex items-center gap-1">' +
+                highlightBtn +
+                reactionButtons +
+                '</div>' +
                 '</div>';
-            
+
             card.addEventListener('click', (e) => {
-                if (e.target.closest('.like-btn')) {
+                if (e.target.closest('.reaction-btn')) {
                     e.stopPropagation();
-                    this.handleLike(data.rowIndex);
+                    const r = e.target.closest('.reaction-btn').dataset.reaction;
+                    this.handleReaction(data.rowIndex, r);
+                } else if (e.target.closest('.highlight-btn')) {
+                    e.stopPropagation();
+                    this.handleHighlight(data.rowIndex);
                 } else {
                     this.showAnswerModal(data.rowIndex);
                 }
             });
-            
+
             return card;
         }
 
         async handleLike(rowIndex) {
-            const btns = document.querySelectorAll('[data-row-index="' + rowIndex + '"].like-btn');
-            btns.forEach(btn => {
-                gsap.fromTo(btn, 
-                    { scale: 1 }, 
-                    { scale: 1.3, yoyo: true, repeat: 1, duration: 0.2, ease: 'power2.inOut' }
-                );
-            });
-            
+            await this.handleReaction(rowIndex, 'LIKE');
+        }
+
+        async handleReaction(rowIndex, reaction) {
+            const btns = document.querySelectorAll('[data-row-index="' + rowIndex + '"][data-reaction="' + reaction + '"]');
+            if (typeof gsap !== 'undefined') {
+                btns.forEach(btn => {
+                    gsap.fromTo(btn,
+                        { scale: 1 },
+                        { scale: 1.3, yoyo: true, repeat: 1, duration: 0.2, ease: 'power2.inOut' }
+                    );
+                });
+            }
             try {
-                const res = await this.gas.addLike(rowIndex);
+                const res = await this.gas.addReaction(rowIndex, reaction);
                 if (res && res.status === 'ok') {
-                    const dataItem = this.state.currentAnswers.find(item => item.rowIndex == rowIndex);
-                    if (dataItem) {
-                        dataItem.likes = res.newScore;
-                        dataItem.hasLiked = !dataItem.hasLiked;
-                        this.updateLikeButtonUI(rowIndex, dataItem.likes, dataItem.hasLiked);
+                    const oldAnswers = [...this.state.currentAnswers];
+                    const item = this.state.currentAnswers.find(i => i.rowIndex == rowIndex);
+                    if (item && res.reactions) {
+                        item.reactions = res.reactions;
+                        this.applyUpdates([item]);
                     }
                 } else if (res && res.message) {
                     alert(res.message);
                 }
             } catch (error) {
-                console.error('Failed to add like:', error);
+                console.error('Failed to add reaction:', error);
             }
         }
 
-        updateLikeButtonUI(rowIndex, likes, hasLiked) {
-            document.querySelectorAll('[data-row-index="' + rowIndex + '"]').forEach(el => {
-                const btn = el.querySelector('.like-btn') || el;
-                if (btn.classList.contains('like-btn')) {
-                    const likeCountEl = btn.querySelector('.like-count');
-                    if (likeCountEl) {
-                        likeCountEl.textContent = likes;
+        async handleHighlight(rowIndex) {
+            try {
+                const res = await this.gas.toggleHighlight(rowIndex);
+                if (res && res.status === 'ok') {
+                    const item = this.state.currentAnswers.find(i => i.rowIndex == rowIndex);
+                    if (item) {
+                        item.highlight = res.highlight;
                     }
-                    btn.classList.toggle('liked', hasLiked);
+                    this.applyUpdates([item]);
+                } else if (res && res.message) {
+                    alert(res.message);
+                }
+            } catch (error) {
+                console.error('Failed to toggle highlight:', error);
+            }
+        }
+
+        updateReactionButtonUI(rowIndex, reaction, count, reacted) {
+            document.querySelectorAll('[data-row-index="' + rowIndex + '"][data-reaction="' + reaction + '"]').forEach(btn => {
+                const countEl = btn.querySelector('.reaction-count');
+                if (countEl) {
+                    countEl.textContent = count;
+                }
+                btn.classList.toggle('liked', reacted);
+            });
+        }
+
+        applyUpdates(items) {
+            items.forEach(item => {
+                this.updateReactionButtonUI(item.rowIndex, 'LIKE', item.reactions.LIKE.count, item.reactions.LIKE.reacted);
+                this.updateReactionButtonUI(item.rowIndex, 'UNDERSTAND', item.reactions.UNDERSTAND.count, item.reactions.UNDERSTAND.reacted);
+                this.updateReactionButtonUI(item.rowIndex, 'CURIOUS', item.reactions.CURIOUS.count, item.reactions.CURIOUS.reacted);
+                const card = document.querySelector('.answer-card[data-row-index="' + item.rowIndex + '"]');
+                if (card) {
+                    card.classList.toggle('highlighted', item.highlight);
                 }
             });
         }
@@ -398,13 +487,13 @@
             
             this.elements.modalStudentName.textContent = data.name;
             this.elements.modalLikeBtn.dataset.rowIndex = rowIndex;
-            this.updateLikeButtonUI(rowIndex, data.likes, data.hasLiked);
+            this.updateReactionButtonUI(rowIndex, 'LIKE', data.reactions.LIKE.count, data.reactions.LIKE.reacted);
             
             if (!this.elements.modalLikeBtn.dataset.listenerAttached) {
                 this.elements.modalLikeBtn.addEventListener('click', () => {
                     const id = this.elements.modalLikeBtn.dataset.rowIndex;
                     if (id) {
-                        this.handleLike(id);
+                        this.handleReaction(id, 'LIKE');
                     }
                 });
                 this.elements.modalLikeBtn.dataset.listenerAttached = 'true';
@@ -443,6 +532,8 @@
                 'book-open-check': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H2v15h7c1.7 0 3 1.3 3 3V7c0-2.2-1.8-4-4-4Z"/><path d="m16 12 2 2 4-4"/><path d="M22 6V3h-6c-2.2 0-4 1.8-4 4v14c0-1.7 1.3-3 3-3h7V6Z"/></svg>',
                 'x': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>',
                 'thumbs-up': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2h0a3.13 3.13 0 0 1 3 3.88Z"/></svg>',
+                'star': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15 8.5 22 9.3 17 14 18.2 21 12 17.8 5.8 21 7 14 2 9.3 9 8.5 12 2"/></svg>',
+                'help-circle': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 1 1 5.82 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>',
                 'grid-2x2': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 12h18"/><path d="M12 3v18"/></svg>',
                 'users': '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>',
             };


### PR DESCRIPTION
## Summary
- add highlight, multiple reaction support and anonymized display logic
- implement admin-related helpers and view toggles
- add backend handlers for reactions and highlights
- support highlight and reactions in front-end cards with new styles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529939db44832b9d255d9d748b1113