### PR TITLE
Show all reactions in modal

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -55,13 +55,10 @@
       <div id="answerModalCard" class="glass-panel rounded-xl p-6 flex flex-col shadow-2xl border-2 border-cyan-400/80 w-full max-w-5xl h-auto max-h-[85vh] transform scale-95 transition-transform duration-300">
           <button id="answerModalCloseBtn" class="absolute -top-3 -right-3 bg-red-600 rounded-full p-2 text-white hover:scale-110 transition-transform" aria-label="閉じる"></button>
           <div id="modalAnswer" class="flex-grow min-h-[200px] mb-4 overflow-y-auto pr-4"></div>
-          <div class="text-xs text-gray-400 pt-4 border-t-2 border-dashed border-cyan-400/80 flex justify-between items-center">
-              <div><span id="modalStudentName" class="font-bold text-2xl text-gray-200"></span></div>
-              <button type="button" id="modalLikeBtn" class="like-btn flex items-center gap-1.5 transition-colors" aria-label="いいね">
-                  <span id="modalLikeBtnIcon" class="w-7 h-7"></span>
-                  <span id="modalLikeCount" class="like-count font-bold text-2xl text-gray-200">0</span>
-              </button>
-          </div>
+            <div class="text-xs text-gray-400 pt-4 border-t-2 border-dashed border-cyan-400/80 flex justify-between items-center">
+                <div><span id="modalStudentName" class="font-bold text-2xl text-gray-200"></span></div>
+                <div id="modalReactions" class="flex items-center gap-3"></div>
+            </div>
       </div>
   </div>
 
@@ -96,7 +93,7 @@
                 answerModalCard: document.getElementById('answerModalCard'),
                 modalAnswer: document.getElementById('modalAnswer'),
                 modalStudentName: document.getElementById('modalStudentName'),
-                modalLikeBtn: document.getElementById('modalLikeBtn'),
+                modalReactions: document.getElementById('modalReactions'),
                 classFilter: document.getElementById('classFilter'),
                 footer: document.getElementById('controlsFooter'),
             };
@@ -156,7 +153,7 @@
             const headerHeight = this.elements.header.offsetHeight;
             const footerHeight = this.elements.footer.offsetHeight;
             this.elements.mainContainer.style.paddingTop = headerHeight + 'px';
-            this.elements.body.style.paddingBottom = (footerHeight + 20) + 'px';
+            this.elements.body.style.paddingBottom = (footerHeight + 40) + 'px';
         }
 
         runGas(funcName, ...args) {
@@ -369,7 +366,7 @@
                 const info = data.reactions ? data.reactions[rt.key] : { count: 0, reacted: false };
                 const cls = info.reacted ? 'liked' : '';
                 const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
-                return '<button type="button" class="reaction-btn like-btn ' + colorClass + ' ' + cls + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.key + '">' +
+                return '<button type="button" class="reaction-btn like-btn flex items-center gap-1 ' + colorClass + ' ' + cls + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '" data-icon-size="w-5 h-5" aria-label="' + rt.key + '">' +
                        this.getIcon(rt.icon, 'w-5 h-5', info.reacted) +
                        '<span class="reaction-count font-bold text-lg text-gray-200">' + (info.count || 0) + '</span>' +
                        '</button>';
@@ -463,7 +460,8 @@
                 const rt = this.reactionTypes.find(r => r.key === reaction);
                 const svgEl = btn.querySelector('svg');
                 if (svgEl && rt) {
-                    svgEl.outerHTML = this.getIcon(rt.icon, 'w-5 h-5', reacted);
+                    const size = btn.dataset.iconSize || 'w-5 h-5';
+                    svgEl.outerHTML = this.getIcon(rt.icon, size, reacted);
                 }
                 btn.classList.toggle('liked', reacted);
             });
@@ -494,17 +492,28 @@
                 this.escapeHtml(data.reason || '') + '</p>';
             
             this.elements.modalStudentName.textContent = data.name;
-            this.elements.modalLikeBtn.dataset.rowIndex = rowIndex;
-            this.updateReactionButtonUI(rowIndex, 'LIKE', data.reactions.LIKE.count, data.reactions.LIKE.reacted);
-            
-            if (!this.elements.modalLikeBtn.dataset.listenerAttached) {
-                this.elements.modalLikeBtn.addEventListener('click', () => {
-                    const id = this.elements.modalLikeBtn.dataset.rowIndex;
-                    if (id) {
-                        this.handleReaction(id, 'LIKE');
+            this.elements.modalReactions.innerHTML = this.reactionTypes.map(rt => {
+                const info = data.reactions[rt.key];
+                const cls = info.reacted ? 'liked' : '';
+                const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
+                return '<button type="button" class="reaction-btn like-btn flex items-center gap-1 ' + colorClass + ' ' + cls + '" data-row-index="' + rowIndex + '" data-reaction="' + rt.key + '" data-icon-size="w-7 h-7" aria-label="' + rt.key + '">' +
+                       this.getIcon(rt.icon, 'w-7 h-7', info.reacted) +
+                       '<span class="reaction-count font-bold text-2xl text-gray-200">' + (info.count || 0) + '</span>' +
+                       '</button>';
+            }).join('');
+
+            if (!this.elements.modalReactions.dataset.listenerAttached) {
+                this.elements.modalReactions.addEventListener('click', (e) => {
+                    const btn = e.target.closest('.reaction-btn');
+                    if (btn) {
+                        const id = btn.dataset.rowIndex;
+                        const reaction = btn.dataset.reaction;
+                        if (id && reaction) {
+                            this.handleReaction(id, reaction);
+                        }
                     }
                 });
-                this.elements.modalLikeBtn.dataset.listenerAttached = 'true';
+                this.elements.modalReactions.dataset.listenerAttached = 'true';
             }
             
             this.elements.answerModalContainer.classList.remove('hidden');
@@ -554,7 +563,6 @@
         
         renderIcons() {
             document.getElementById('answerModalCloseBtn').innerHTML = this.getIcon('x', 'w-6 h-6');
-            document.getElementById('modalLikeBtnIcon').innerHTML = this.getIcon('hand-thumb-up');
             document.getElementById('footerIcon').innerHTML = this.getIcon('grid-2x2');
         }
 

--- a/tests/iconState.test.js
+++ b/tests/iconState.test.js
@@ -20,7 +20,7 @@ function updateReactionButtonUI(rowIndex, reaction, count, reacted) {
 
 test('updateReactionButtonUI applies solid icon when reacted', () => {
   const dom = new JSDOM(`
-    <button class="reaction-btn like-btn" data-row-index="1" data-reaction="LIKE">
+    <button class="reaction-btn like-btn" data-row-index="1" data-reaction="LIKE" data-icon-size="w-5 h-5">
       <svg class="w-5 h-5"></svg>
       <span class="reaction-count">0</span>
     </button>


### PR DESCRIPTION
## Summary
- swap icon and count order on reaction buttons
- display all reaction buttons in the answer modal
- keep icon sizes when reactions update
- update DOM test markup

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852b06d66f8832ba63d12dbb099d107