### PR TITLE
Limit admin view

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -170,15 +170,8 @@ function doGet(e) {
 
   const params = e && e.parameter ? e.parameter : {};
   const userEmail = safeGetUserEmail();
-  const adminOverride = params.admin;
-  let isAdminView;
-  if (adminOverride === 'true') {
-    isAdminView = true;
-  } else if (adminOverride === 'false') {
-    isAdminView = false;
-  } else {
-    isAdminView = isUserAdmin(userEmail);
-  }
+  const page = params.page;
+  const isAdminView = page === 'admin' && isUserAdmin(userEmail);
 
   const template = HtmlService.createTemplateFromFile('Page');
   const adminOpts = {

--- a/src/Page.html
+++ b/src/Page.html
@@ -81,6 +81,7 @@
     const displayMode = '<?= displayMode ?>';
     const showAdminFeatures = <?= showAdminFeatures ? 'true' : 'false' ?>;
     const showHighlightToggle = <?= showHighlightToggle ? 'true' : 'false' ?>;
+    const showCounts = <?= showCounts ? 'true' : 'false' ?>;
     const ICONS = {
         'lightbulb-outline': '<svg fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2V.5M5.25 6.75L4.2 5.7M18.75 6.75l1.05-1.05M12 4a6 6 0 00-6 6c0 2.25 1 4.2 2.5 5.34V16.5h7v-1.16A6.002 6.002 0 0018 10a6 6 0 00-6-6zM9 16.5h6v4H9v-4zm0 1h6zm0 1h6zM10.5 11l.5 2h2l.5-2m-3 1h3"/></svg>',
         'lightbulb-solid': '<svg fill="currentColor" viewBox="0 0 24 24"><path d="M12 2V.5M5.25 6.75L4.2 5.7M18.75 6.75l1.05-1.05" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path fill-rule="evenodd" clip-rule="evenodd" d="M12 4a6 6 0 00-6 6c0 2.25 1 4.2 2.5 5.34V16.5h7v-1.16A6.002 6.002 0 0018 10a6 6 0 00-6-6z M10.5 11.25 L11 13 L13 13 L13.5 11.25 H 10.5 Z"/><path d="M9 16.5h6v1H9z M9 18h6v1H9z M9 19.5h6v1H9z"/></svg>',
@@ -126,6 +127,7 @@
 
             this.showHighlightToggle = showHighlightToggle;
             this.showAdminFeatures = showAdminFeatures;
+            this.showCounts = showCounts;
             this.displayMode = displayMode;
             this.reactionTypes = [
                 { key: 'LIKE', icon: 'hand-thumb-up' },
@@ -396,8 +398,9 @@
                 const info = data.reactions ? data.reactions[rt.key] : { count: 0, reacted: false };
                 const cls = info.reacted ? 'liked' : '';
                 const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
+                const countHtml = this.showCounts ? '<span class="reaction-count font-bold text-lg text-gray-200">' + (info.count || 0) + '</span>' : '';
                 return '<button type="button" class="reaction-btn like-btn flex items-center gap-1 ' + colorClass + ' ' + cls + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.key + '">' +
-                       '<span class="reaction-count font-bold text-lg text-gray-200">' + (info.count || 0) + '</span>' +
+                       countHtml +
                        this.getIcon(rt.icon, 'w-5 h-5', info.reacted) +
                        '</button>';
             }).join('');
@@ -489,7 +492,7 @@
         updateReactionButtonUI(rowIndex, reaction, count, reacted) {
             document.querySelectorAll('[data-row-index="' + rowIndex + '"][data-reaction="' + reaction + '"]').forEach(btn => {
                 const countEl = btn.querySelector('.reaction-count');
-                if (countEl) {
+                if (countEl && this.showCounts) {
                     countEl.textContent = count;
                 }
                 const rt = this.reactionTypes.find(r => r.key === reaction);
@@ -547,9 +550,10 @@
                 const info = data.reactions[rt.key];
                 const cls = info.reacted ? 'liked' : '';
                 const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
+                const countHtml = this.showCounts ? '<span class="reaction-count font-bold text-2xl text-gray-200">' + info.count + '</span>' : '';
                 return '<button type="button" class="reaction-btn like-btn flex items-center gap-1.5 ' + colorClass + ' ' + cls + '" ' +
                        'data-row-index="' + rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.key + '">' +
-                       '<span class="reaction-count font-bold text-2xl text-gray-200">' + info.count + '</span>' +
+                       countHtml +
                        this.getIcon(rt.icon, 'w-5 h-5', info.reacted) +
                        '</button>';
             }).join('');

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -26,9 +26,9 @@ function setup({userEmail='admin@example.com', adminEmails='admin@example.com'})
   return { output, getTemplate: () => template };
 }
 
-test('admin user with view parameter sees admin view', () => {
+test('admin user with ?page=admin sees admin view', () => {
   const { getTemplate } = setup({});
-  const e = { parameter: { view: 'board' } };
+  const e = { parameter: { page: 'admin' } };
   doGet(e);
   const template = getTemplate();
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
@@ -44,32 +44,16 @@ test('non-admin default shows student view', () => {
   expect(template.displayMode).toBe('anonymous');
 });
 
-test('admin email automatically routes to admin view', () => {
+test('admin email without page parameter shows student view', () => {
   const { getTemplate } = setup({});
   const e = { parameter: {} };
   doGet(e);
   const template = getTemplate();
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
-  expect(template.displayMode).toBe('named');
-});
-
-test('admin=true enables admin view', () => {
-  const { getTemplate } = setup({});
-  const e = { parameter: { admin: 'true' } };
-  doGet(e);
-  const template = getTemplate();
-  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
-  expect(template.displayMode).toBe('named');
-});
-
-test('admin=false forces student view even for admins', () => {
-  const { getTemplate } = setup({});
-  const e = { parameter: { admin: 'false' } };
-  doGet(e);
-  const template = getTemplate();
-  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
   expect(template.displayMode).toBe('anonymous');
 });
+
+
 
 test('doGet sets isAdminUser based on isUserAdmin when in student mode', () => {
   const { getTemplate } = setup({ userEmail: 'user@example.com', adminEmails: 'admin@example.com' });


### PR DESCRIPTION
## Summary
- add showCounts toggle in Page.html and update UI
- hide reaction counts for non-admins
- change doGet logic to require `?page=admin` for admin view
- update tests for new admin access rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68532cc6fc58832baf9c9cf63761c154