### PR TITLE
Implement admin view toggle via query parameter

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -171,13 +171,14 @@ function doGet(e) {
   const params = e && e.parameter ? e.parameter : {};
   const userEmail = safeGetUserEmail();
   const adminOverride = params.admin;
-  let isAdminView;
-  if (adminOverride === 'true') {
+  const pageParam = params.page;
+  let isAdminView = false;
+  if (pageParam === 'admin') {
+    isAdminView = isUserAdmin(userEmail);
+  } else if (adminOverride === 'true') {
     isAdminView = true;
   } else if (adminOverride === 'false') {
     isAdminView = false;
-  } else {
-    isAdminView = isUserAdmin(userEmail);
   }
 
   const template = HtmlService.createTemplateFromFile('Page');
@@ -215,7 +216,7 @@ function doGet(e) {
  * サーバー側で設定されたシートのデータを取得します。
  */
 
-function getPublishedSheetData(classFilter, sortBy) {
+function getPublishedSheetData(classFilter, sortBy, namedView) {
   const settings = getAppSettings();
   const sheetName = settings.activeSheetName;
 
@@ -224,7 +225,8 @@ function getPublishedSheetData(classFilter, sortBy) {
   }
 
   const order = sortBy || 'newest';
-  const data = getSheetData(sheetName, classFilter, order, isUserAdmin());
+  const named = namedView && isUserAdmin();
+  const data = getSheetData(sheetName, classFilter, order, named);
 
   // ★改善: フロントエンドでシート名を表示できるよう、レスポンスに含める
   return {

--- a/src/Page.html
+++ b/src/Page.html
@@ -134,7 +134,7 @@
             ];
             
             this.gas = {
-                getPublishedSheetData: (classFilter, sort) => this.runGas('getPublishedSheetData', classFilter, sort),
+                getPublishedSheetData: (classFilter, sort) => this.runGas('getPublishedSheetData', classFilter, sort, this.displayMode === 'named'),
                 addLike: (rowIndex) => this.runGas('addReaction', rowIndex, 'LIKE'),
                 addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction),
                 toggleHighlight: (rowIndex) => this.runGas('toggleHighlight', rowIndex)
@@ -396,8 +396,9 @@
                 const info = data.reactions ? data.reactions[rt.key] : { count: 0, reacted: false };
                 const cls = info.reacted ? 'liked' : '';
                 const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
+                const countSpan = this.showAdminFeatures ? '<span class="reaction-count font-bold text-lg text-gray-200">' + (info.count || 0) + '</span>' : '';
                 return '<button type="button" class="reaction-btn like-btn flex items-center gap-1 ' + colorClass + ' ' + cls + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.key + '">' +
-                       '<span class="reaction-count font-bold text-lg text-gray-200">' + (info.count || 0) + '</span>' +
+                       countSpan +
                        this.getIcon(rt.icon, 'w-5 h-5', info.reacted) +
                        '</button>';
             }).join('');
@@ -547,9 +548,10 @@
                 const info = data.reactions[rt.key];
                 const cls = info.reacted ? 'liked' : '';
                 const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
+                const countSpan = this.showAdminFeatures ? '<span class="reaction-count font-bold text-2xl text-gray-200">' + info.count + '</span>' : '';
                 return '<button type="button" class="reaction-btn like-btn flex items-center gap-1.5 ' + colorClass + ' ' + cls + '" ' +
                        'data-row-index="' + rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.key + '">' +
-                       '<span class="reaction-count font-bold text-2xl text-gray-200">' + info.count + '</span>' +
+                       countSpan +
                        this.getIcon(rt.icon, 'w-5 h-5', info.reacted) +
                        '</button>';
             }).join('');

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -26,9 +26,9 @@ function setup({userEmail='admin@example.com', adminEmails='admin@example.com'})
   return { output, getTemplate: () => template };
 }
 
-test('admin user with view parameter sees admin view', () => {
+test('admin user with page parameter sees admin view', () => {
   const { getTemplate } = setup({});
-  const e = { parameter: { view: 'board' } };
+  const e = { parameter: { page: 'admin' } };
   doGet(e);
   const template = getTemplate();
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
@@ -44,13 +44,13 @@ test('non-admin default shows student view', () => {
   expect(template.displayMode).toBe('anonymous');
 });
 
-test('admin email automatically routes to admin view', () => {
+test('admin email without page defaults to student view', () => {
   const { getTemplate } = setup({});
   const e = { parameter: {} };
   doGet(e);
   const template = getTemplate();
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
-  expect(template.displayMode).toBe('named');
+  expect(template.displayMode).toBe('anonymous');
 });
 
 test('admin=true enables admin view', () => {


### PR DESCRIPTION
## Summary
- add `page=admin` check in `doGet` to require explicit admin mode
- allow `getPublishedSheetData` to receive view info
- hide reaction counts when admin features are disabled
- pass display mode to GAS when fetching data
- adjust unit tests for new behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533432c118832b8ebe974b7e27f32c