### PR TITLE
Fix like column index lookup

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -414,8 +414,8 @@ function addLike(rowIndex) {
     if (!sheet) throw new Error(`シート '${settings.activeSheetName}' が見つかりません。`);
 
     const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-    const headerIndices = findHeaderIndices(headerRow, [COLUMN_HEADERS.LIKES]);
-    const likesColIndex = headerIndices[COLUMN_HEADERS.LIKES] + 1;
+    const headerIndices = findHeaderIndices(headerRow, [COLUMN_HEADERS.LIKE]);
+    const likesColIndex = headerIndices[COLUMN_HEADERS.LIKE] + 1;
 
     const likeCell = sheet.getRange(rowIndex, likesColIndex);
     const likersString = likeCell.getValue().toString();

--- a/tests/addLikeColumn.test.js
+++ b/tests/addLikeColumn.test.js
@@ -1,0 +1,52 @@
+const { addLike, COLUMN_HEADERS } = require('../src/Code.gs');
+
+function buildSheet() {
+  const headerRow = [COLUMN_HEADERS.EMAIL, 'Other', COLUMN_HEADERS.LIKE];
+  let likeVal = '';
+  const sheet = {
+    getLastColumn: () => headerRow.length,
+    getRange: jest.fn((row, col, numRows, numCols) => {
+      if (row === 1 && col === 1) {
+        return { getValues: () => [headerRow] };
+      }
+      if (row === 2 && col === 3) {
+        return {
+          getValue: () => likeVal,
+          setValue: (v) => { likeVal = v; }
+        };
+      }
+      throw new Error('Unexpected range request');
+    }),
+    isSheetHidden: () => false,
+    getName: () => 'Sheet1'
+  };
+  return sheet;
+}
+
+function setupMocks(email, sheet) {
+  global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
+  global.Session = { getActiveUser: () => ({ getEmail: () => email }) };
+  global.PropertiesService = { getScriptProperties: () => ({}) };
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({
+      getSheetByName: () => sheet,
+      getSheets: () => [sheet]
+    })
+  };
+}
+
+afterEach(() => {
+  delete global.LockService;
+  delete global.Session;
+  delete global.PropertiesService;
+  delete global.SpreadsheetApp;
+});
+
+test('addLike updates value in LIKE column', () => {
+  const sheet = buildSheet();
+  setupMocks('like@example.com', sheet);
+  const result = addLike(2);
+  expect(result.status).toBe('ok');
+  expect(sheet.getRange.mock.calls[1][0]).toBe(2);
+  expect(sheet.getRange.mock.calls[1][1]).toBe(3);
+});


### PR DESCRIPTION
## Summary
- fix typo using `COLUMN_HEADERS.LIKE` in `addLike`
- add a unit test that ensures `addLike` targets the correct column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685344759ba4832b860e5b123f9b5a68