### PR TITLE
Fix email retrieval

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -158,7 +158,7 @@ function doGet(e) {
   const settings = getAppSettings();
   
   if (!settings.isPublished) {
-    const userEmail = Session.getActiveUser().getEmail();
+    const userEmail = safeGetUserEmail();
     const template = HtmlService.createTemplateFromFile('Unpublished');
     template.userEmail = userEmail;
     return template.evaluate().setTitle('公開終了');
@@ -407,7 +407,7 @@ function addLike(rowIndex) {
   const lock = LockService.getScriptLock();
   lock.waitLock(10000);
   try {
-    const userEmail = Session.getActiveUser().getEmail();
+    const userEmail = safeGetUserEmail();
     if (!userEmail) return { status: 'error', message: 'ログインしていないため、操作できません。' };
     const settings = getAppSettings();
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(settings.activeSheetName);

--- a/tests/addLikeColumn.test.js
+++ b/tests/addLikeColumn.test.js
@@ -50,3 +50,18 @@ test('addLike updates value in LIKE column', () => {
   expect(sheet.getRange.mock.calls[1][0]).toBe(2);
   expect(sheet.getRange.mock.calls[1][1]).toBe(3);
 });
+
+test('addLike handles failure to get user email', () => {
+  const sheet = buildSheet();
+  global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
+  global.Session = { getActiveUser: () => ({ getEmail: () => { throw new Error('fail'); } }) };
+  global.PropertiesService = { getScriptProperties: () => ({}) };
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({
+      getSheetByName: () => sheet,
+      getSheets: () => [sheet]
+    })
+  };
+  const result = addLike(2);
+  expect(result.status).toBe('error');
+});

--- a/tests/doGetUnpublished.test.js
+++ b/tests/doGetUnpublished.test.js
@@ -1,0 +1,32 @@
+const { doGet } = require('../src/Code.gs');
+
+afterEach(() => {
+  delete global.PropertiesService;
+  delete global.Session;
+  delete global.HtmlService;
+});
+
+function setup() {
+  global.PropertiesService = {
+    getScriptProperties: () => ({
+      getProperty: (key) => {
+        if (key === 'IS_PUBLISHED') return 'false';
+        return null;
+      }
+    })
+  };
+  global.Session = { getActiveUser: () => ({ getEmail: () => { throw new Error('no user'); } }) };
+  const output = { setTitle: jest.fn(() => output) };
+  let template = { evaluate: () => output };
+  global.HtmlService = {
+    createTemplateFromFile: jest.fn(() => template)
+  };
+  return template;
+}
+
+test('doGet uses Unpublished template when email fails', () => {
+  const template = setup();
+  doGet({});
+  expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Unpublished');
+  expect(template.userEmail).toBe('');
+});


### PR DESCRIPTION
## Summary
- use `safeGetUserEmail()` for unpublished page and addLike
- handle errors from user email in addLike tests
- add test for doGet unpublished branch when email fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68535ce2e4a0832bb9b433be1ce1d71b