### PR TITLE
Update README with admin interface instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Opening the spreadsheet adds an **アプリ管理** menu. From here you can:
 
 When unpublished, visiting the Web App URL shows a message that the board is closed. Once published, the board is available and updates automatically every 15 seconds.
 
+Administrators can access a more complete interface by appending `?page=admin` to the Web App URL. Email addresses with admin rights are listed in the `ADMIN_EMAILS` script property.
+
 ## Front‑end features
 
 - Answers are displayed in a responsive grid. A slider allows changing the number of columns.


### PR DESCRIPTION
## Summary
- document how to access the admin UI by appending `?page=admin`
- note that admin email addresses are defined in `ADMIN_EMAILS`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68535f4f905c832bb4635b7191a62789