### PR TITLE
Update admin access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Opening the spreadsheet adds an **アプリ管理** menu. From here you can:
 
 When unpublished, visiting the Web App URL shows a message that the board is closed. Once published, the board is available and updates automatically every 15 seconds.
 
+### Admin interface
+
+Administrators can open the full board interface by appending `?page=admin` to the Web App URL. The list of administrator email addresses is set in the `ADMIN_EMAILS` script property.
+
 ## Front‑end features
 
 - Answers are displayed in a responsive grid. A slider allows changing the number of columns.


### PR DESCRIPTION
## Summary
- document how to open the admin page via the Web App URL
- mention the `ADMIN_EMAILS` script property

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68535fe629e0832ba31cd1f66b3494d2