### PR TITLE
Restrict admin view activation

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -167,15 +167,10 @@ function doGet(e) {
 
   const params = e && e.parameter ? e.parameter : {};
   const userEmail = safeGetUserEmail();
-  const adminOverride = params.admin;
   const pageParam = params.page;
   let isAdminView = false;
   if (pageParam === 'admin') {
     isAdminView = isUserAdmin(userEmail);
-  } else if (adminOverride === 'true') {
-    isAdminView = true;
-  } else if (adminOverride === 'false') {
-    isAdminView = false;
   }
 
   const template = HtmlService.createTemplateFromFile('Page');

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -53,13 +53,13 @@ test('admin email without page defaults to student view', () => {
   expect(template.displayMode).toBe('anonymous');
 });
 
-test('admin=true enables admin view', () => {
+test('admin=true alone does not enable admin view', () => {
   const { getTemplate } = setup({});
   const e = { parameter: { admin: 'true' } };
   doGet(e);
   const template = getTemplate();
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Page');
-  expect(template.displayMode).toBe('named');
+  expect(template.displayMode).toBe('anonymous');
 });
 
 test('admin=false forces student view even for admins', () => {


### PR DESCRIPTION
## Summary
- only activate admin features when `page=admin`
- adjust tests for removed `admin=true` override

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68536bd203d4832b80eae2446137f17a