### PR TITLE
Use cached header indices in interactive functions

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -327,7 +327,7 @@ function addReaction(rowIndex, reactionKey) {
 
   const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
   const reactionHeaders = REACTION_KEYS.map(k => COLUMN_HEADERS[k]);
-  const headerIndices = findHeaderIndices(headerRow, reactionHeaders);
+  const headerIndices = getAndCacheHeaderIndices(settings.activeSheetName, headerRow);
   const startCol = headerIndices[reactionHeaders[0]] + 1;
   const reactionRange = sheet.getRange(rowIndex, startCol, 1, REACTION_KEYS.length);
   const values = reactionRange.getValues()[0];
@@ -373,7 +373,7 @@ function toggleHighlight(rowIndex) {
     if (!sheet) throw new Error(`シート '${sheetName}' が見つかりません。`);
 
     const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-    const headerIndices = findHeaderIndices(headerRow, [COLUMN_HEADERS.HIGHLIGHT]);
+    const headerIndices = getAndCacheHeaderIndices(sheetName, headerRow);
     const colIndex = headerIndices[COLUMN_HEADERS.HIGHLIGHT] + 1;
 
     const cell = sheet.getRange(rowIndex, colIndex);
@@ -400,7 +400,7 @@ function addLike(rowIndex) {
     if (!sheet) throw new Error(`シート '${settings.activeSheetName}' が見つかりません。`);
 
     const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-    const headerIndices = findHeaderIndices(headerRow, [COLUMN_HEADERS.LIKE]);
+    const headerIndices = getAndCacheHeaderIndices(settings.activeSheetName, headerRow);
     const likesColIndex = headerIndices[COLUMN_HEADERS.LIKE] + 1;
 
     const likeCell = sheet.getRange(rowIndex, likesColIndex);

--- a/tests/addLikeColumn.test.js
+++ b/tests/addLikeColumn.test.js
@@ -1,7 +1,16 @@
 const { addLike, COLUMN_HEADERS } = require('../src/Code.gs');
 
 function buildSheet() {
-  const headerRow = [COLUMN_HEADERS.EMAIL, 'Other', COLUMN_HEADERS.LIKE];
+  const headerRow = [
+    COLUMN_HEADERS.EMAIL,
+    COLUMN_HEADERS.CLASS,
+    COLUMN_HEADERS.LIKE,
+    COLUMN_HEADERS.OPINION,
+    COLUMN_HEADERS.REASON,
+    COLUMN_HEADERS.UNDERSTAND,
+    COLUMN_HEADERS.CURIOUS,
+    COLUMN_HEADERS.HIGHLIGHT
+  ];
   let likeVal = '';
   const sheet = {
     getLastColumn: () => headerRow.length,
@@ -27,6 +36,7 @@ function setupMocks(email, sheet) {
   global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
   global.Session = { getActiveUser: () => ({ getEmail: () => email }) };
   global.PropertiesService = { getScriptProperties: () => ({}) };
+  global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({
       getSheetByName: () => sheet,
@@ -39,6 +49,7 @@ afterEach(() => {
   delete global.LockService;
   delete global.Session;
   delete global.PropertiesService;
+  delete global.CacheService;
   delete global.SpreadsheetApp;
 });
 
@@ -56,6 +67,7 @@ test('addLike handles failure to get user email', () => {
   global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
   global.Session = { getActiveUser: () => ({ getEmail: () => { throw new Error('fail'); } }) };
   global.PropertiesService = { getScriptProperties: () => ({}) };
+  global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({
       getSheetByName: () => sheet,

--- a/tests/toggleHighlight.test.js
+++ b/tests/toggleHighlight.test.js
@@ -1,7 +1,16 @@
 const { toggleHighlight, COLUMN_HEADERS } = require('../src/Code.gs');
 
 function buildSheet() {
-  const headerRow = [COLUMN_HEADERS.HIGHLIGHT];
+  const headerRow = [
+    COLUMN_HEADERS.EMAIL,
+    COLUMN_HEADERS.CLASS,
+    COLUMN_HEADERS.OPINION,
+    COLUMN_HEADERS.REASON,
+    COLUMN_HEADERS.UNDERSTAND,
+    COLUMN_HEADERS.LIKE,
+    COLUMN_HEADERS.CURIOUS,
+    COLUMN_HEADERS.HIGHLIGHT
+  ];
   let highlight = false;
   return {
     getLastColumn: () => headerRow.length,
@@ -22,6 +31,7 @@ function buildSheet() {
 function setupMocks(sheet) {
   global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
   global.PropertiesService = { getScriptProperties: () => ({}) };
+  global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({
       getSheetByName: () => sheet,
@@ -33,6 +43,7 @@ function setupMocks(sheet) {
 afterEach(() => {
   delete global.LockService;
   delete global.PropertiesService;
+  delete global.CacheService;
   delete global.SpreadsheetApp;
 });
 


### PR DESCRIPTION
## Summary
- use `getAndCacheHeaderIndices` in `addReaction`, `toggleHighlight`, and `addLike`
- mock `CacheService` in unit tests
- update test headers to include all columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68537672c25c832b884e0dbb5262ccd4