### PR TITLE
Handle trailing spaces in reaction lists

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -59,7 +59,7 @@ function isUserAdmin(email) {
 
 function parseReactionString(val) {
   if (!val) return [];
-  return val.toString().split(',').filter(Boolean);
+  return val.toString().split(',').map(s => s.trim()).filter(Boolean);
 }
 
 

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -135,3 +135,38 @@ test('getSheetData forces anonymous mode for non-admin', () => {
 
   expect(result.rows[0].name).toBe('匿名');
 });
+
+test('reaction lists trim spaces and ignore empties', () => {
+  const data = [
+    [
+      COLUMN_HEADERS.EMAIL,
+      COLUMN_HEADERS.CLASS,
+      COLUMN_HEADERS.OPINION,
+      COLUMN_HEADERS.REASON,
+      COLUMN_HEADERS.UNDERSTAND,
+      COLUMN_HEADERS.LIKE,
+      COLUMN_HEADERS.CURIOUS,
+      COLUMN_HEADERS.HIGHLIGHT
+    ],
+    [
+      'a@example.com',
+      '1-1',
+      'Opinion',
+      'Reason',
+      ' a@example.com , b@example.com ',
+      ' a@example.com , ',
+      '   ',
+      'false'
+    ]
+  ];
+  setupMocks(data, 'a@example.com', 'a@example.com');
+
+  const result = getSheetData('Sheet1', undefined, undefined, true);
+
+  const row = result.rows[0];
+  expect(row.reactions.UNDERSTAND.count).toBe(2);
+  expect(row.reactions.UNDERSTAND.reacted).toBe(true);
+  expect(row.reactions.LIKE.count).toBe(1);
+  expect(row.reactions.LIKE.reacted).toBe(true);
+  expect(row.reactions.CURIOUS.count).toBe(0);
+});


### PR DESCRIPTION
## Summary
- trim reaction emails when parsing
- test reaction list trimming

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68537ac28e00832bae7742bfd77f257b