### PR TITLE
Add runtime admin mode toggle

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -57,6 +57,10 @@ function isUserAdmin(email) {
   return getAdminEmails().includes(userEmail);
 }
 
+function checkAdmin() {
+  return isUserAdmin();
+}
+
 function parseReactionString(val) {
   if (!val) return [];
   return val
@@ -520,6 +524,7 @@ if (typeof module !== 'undefined') {
     saveWebAppUrl,
     saveDeployId,
     findHeaderIndices,
-    parseReactionString
+    parseReactionString,
+    checkAdmin
   };
 }

--- a/src/Page.html
+++ b/src/Page.html
@@ -48,8 +48,9 @@
         <div class="flex-grow text-center w-full min-w-0">
              <p id="headingLabel" class="text-2xl md:text-3xl font-bold text-pink-400 leading-tight">データを読み込んでいます...</p>
         </div>
-        <div class="w-full lg:w-auto lg:min-w-[150px] text-right">
+        <div class="w-full lg:w-auto lg:min-w-[150px] text-right space-y-1">
             <p id="sheetNameText" class="text-xs text-gray-400 h-4"></p>
+            <button id="adminToggleBtn" class="text-xs text-cyan-400 underline hidden"></button>
         </div>
     </header>
 
@@ -81,6 +82,7 @@
     const displayMode = '<?= displayMode ?>';
     const showAdminFeatures = <?= showAdminFeatures ? 'true' : 'false' ?>;
     const showHighlightToggle = <?= showHighlightToggle ? 'true' : 'false' ?>;
+    const isAdminUser = <?= isAdminUser ? 'true' : 'false' ?>;
     const ICONS = {
         'lightbulb-outline': '<svg fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2V.5M5.25 6.75L4.2 5.7M18.75 6.75l1.05-1.05M12 4a6 6 0 00-6 6c0 2.25 1 4.2 2.5 5.34V16.5h7v-1.16A6.002 6.002 0 0018 10a6 6 0 00-6-6zM9 16.5h6v4H9v-4zm0 1h6zm0 1h6zM10.5 11l.5 2h2l.5-2m-3 1h3"/></svg>',
         'lightbulb-solid': '<svg fill="currentColor" viewBox="0 0 24 24"><path d="M12 2V.5M5.25 6.75L4.2 5.7M18.75 6.75l1.05-1.05" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path fill-rule="evenodd" clip-rule="evenodd" d="M12 4a6 6 0 00-6 6c0 2.25 1 4.2 2.5 5.34V16.5h7v-1.16A6.002 6.002 0 0018 10a6 6 0 00-6-6z M10.5 11.25 L11 13 L13 13 L13.5 11.25 H 10.5 Z"/><path d="M9 16.5h6v1H9z M9 18h6v1H9z M9 19.5h6v1H9z"/></svg>',
@@ -104,6 +106,7 @@
                 sliderValue: document.getElementById('sliderValue'),
                 headingLabel: document.getElementById('headingLabel'),
                 sheetNameText: document.getElementById('sheetNameText'),
+                adminToggleBtn: document.getElementById('adminToggleBtn'),
                 answerCount: document.getElementById('answerCount'),
                 answerModalContainer: document.getElementById('answerModalContainer'),
                 answerModalCloseBtn: document.getElementById('answerModalCloseBtn'),
@@ -127,6 +130,7 @@
             this.showHighlightToggle = showHighlightToggle;
             this.showAdminFeatures = showAdminFeatures;
             this.displayMode = displayMode;
+            this.isAdminUser = isAdminUser;
             this.reactionTypes = [
                 { key: 'LIKE', icon: 'hand-thumb-up' },
                 { key: 'UNDERSTAND', icon: 'lightbulb' },
@@ -137,7 +141,8 @@
                 getPublishedSheetData: (classFilter, sort) => this.runGas('getPublishedSheetData', classFilter, sort, this.displayMode === 'named'),
                 addLike: (rowIndex) => this.runGas('addReaction', rowIndex, 'LIKE'),
                 addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction),
-                toggleHighlight: (rowIndex) => this.runGas('toggleHighlight', rowIndex)
+                toggleHighlight: (rowIndex) => this.runGas('toggleHighlight', rowIndex),
+                checkAdmin: () => this.runGas('checkAdmin')
             };
             
             this.init();
@@ -146,6 +151,10 @@
         init() {
             this.renderIcons();
             this.setupEventListeners();
+            if (this.isAdminUser && this.elements.adminToggleBtn) {
+                this.elements.adminToggleBtn.classList.remove('hidden');
+                this.elements.adminToggleBtn.textContent = this.showAdminFeatures ? '閲覧モード' : '管理モード';
+            }
             this.adjustLayout();
             this.loadInitialData();
         }
@@ -170,6 +179,9 @@
             });
             this.elements.classFilter.addEventListener('change', () => this.loadSheetData(true));
             this.elements.sortOrder.addEventListener('change', () => this.loadSheetData(true));
+            if (this.elements.adminToggleBtn) {
+                this.elements.adminToggleBtn.addEventListener('click', () => this.toggleAdminMode());
+            }
             document.addEventListener('keydown', (e) => {
                 if (e.key === 'Escape') {
                     this.hideAnswerModal();
@@ -485,6 +497,29 @@
             } catch (error) {
                 console.error('Failed to toggle highlight:', error);
             }
+        }
+
+        async toggleAdminMode() {
+            const enable = !this.showAdminFeatures;
+            if (enable) {
+                try {
+                    const ok = await this.gas.checkAdmin();
+                    if (!ok) {
+                        alert('管理者権限がありません。');
+                        return;
+                    }
+                } catch (e) {
+                    alert('権限確認に失敗しました');
+                    return;
+                }
+            }
+            this.showAdminFeatures = enable;
+            this.showHighlightToggle = enable;
+            this.displayMode = enable ? 'named' : 'anonymous';
+            if (this.elements.adminToggleBtn) {
+                this.elements.adminToggleBtn.textContent = enable ? '閲覧モード' : '管理モード';
+            }
+            this.loadSheetData(true, true);
         }
 
         updateReactionButtonUI(rowIndex, reaction, count, reacted) {

--- a/tests/checkAdmin.test.js
+++ b/tests/checkAdmin.test.js
@@ -1,0 +1,23 @@
+const { checkAdmin } = require('../src/Code.gs');
+
+function setup(admins, currentEmail) {
+  global.PropertiesService = {
+    getScriptProperties: () => ({ getProperty: (key) => key === 'ADMIN_EMAILS' ? admins.join(',') : null })
+  };
+  global.Session = { getActiveUser: () => ({ getEmail: () => currentEmail }) };
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+  delete global.Session;
+});
+
+test('checkAdmin returns true for admin user', () => {
+  setup(['a@example.com','b@example.com'], 'a@example.com');
+  expect(checkAdmin()).toBe(true);
+});
+
+test('checkAdmin returns false for non-admin', () => {
+  setup(['a@example.com','b@example.com'], 'c@example.com');
+  expect(checkAdmin()).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add `checkAdmin` to verify admin privileges
- expose admin status to the frontend
- add admin mode toggle button and functionality
- test `checkAdmin`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853929bc640832b9df3da9fa91afc5f