### PR TITLE
Remove displayMode and anonymous mode

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -182,7 +182,7 @@ function doGet(e) {
  * サーバー側で設定されたシートのデータを取得します。
  */
 
-function getPublishedSheetData(classFilter, sortBy, namedView) {
+function getPublishedSheetData(classFilter, sortBy) {
   const settings = getAppSettings();
   const sheetName = settings.activeSheetName;
 
@@ -191,8 +191,7 @@ function getPublishedSheetData(classFilter, sortBy, namedView) {
   }
 
   const order = sortBy || 'newest';
-  const named = namedView && isUserAdmin();
-  const data = getSheetData(sheetName, classFilter, order, named);
+  const data = getSheetData(sheetName, classFilter, order);
 
   // ★改善: フロントエンドでシート名を表示できるよう、レスポンスに含める
   return {
@@ -217,7 +216,7 @@ function getSheets() {
   }
 }
 
-function getSheetData(sheetName, classFilter, sortBy, named) {
+function getSheetData(sheetName, classFilter, sortBy) {
   try {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
     if (!sheet) throw new Error(`指定されたシート「${sheetName}」が見つかりません。`);
@@ -248,12 +247,7 @@ function getSheetData(sheetName, classFilter, sortBy, named) {
         const baseScore = reason.length;
         const likeMultiplier = 1 + (likes * SCORING_CONFIG.LIKE_MULTIPLIER_FACTOR);
         const totalScore = baseScore * likeMultiplier;
-        let name;
-        if (named) {
-          name = emailToNameMap[email] || email.split('@')[0];
-        } else {
-          name = '匿名';
-        }
+        const name = emailToNameMap[email] || email.split('@')[0];
         return {
           rowIndex: index + 2,
           name: name,

--- a/src/Page.html
+++ b/src/Page.html
@@ -79,7 +79,6 @@
   </footer>
 
   <script>
-    const displayMode = '<?= displayMode ?>';
     const showAdminFeatures = <?= showAdminFeatures ? 'true' : 'false' ?>;
     const showHighlightToggle = <?= showHighlightToggle ? 'true' : 'false' ?>;
     const isAdminUser = <?= isAdminUser ? 'true' : 'false' ?>;
@@ -129,7 +128,6 @@
 
             this.showHighlightToggle = showHighlightToggle;
             this.showAdminFeatures = showAdminFeatures;
-            this.displayMode = displayMode;
             this.isAdminUser = isAdminUser;
             this.reactionTypes = [
                 { key: 'LIKE', icon: 'hand-thumb-up' },
@@ -138,7 +136,7 @@
             ];
             
             this.gas = {
-                getPublishedSheetData: (classFilter, sort) => this.runGas('getPublishedSheetData', classFilter, sort, this.displayMode === 'named'),
+                getPublishedSheetData: (classFilter, sort) => this.runGas('getPublishedSheetData', classFilter, sort),
                 addLike: (rowIndex) => this.runGas('addReaction', rowIndex, 'LIKE'),
                 addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction),
                 toggleHighlight: (rowIndex) => this.runGas('toggleHighlight', rowIndex),
@@ -515,7 +513,6 @@
             }
             this.showAdminFeatures = enable;
             this.showHighlightToggle = enable;
-            this.displayMode = enable ? 'named' : 'anonymous';
             if (this.elements.adminToggleBtn) {
                 this.elements.adminToggleBtn.textContent = enable ? '閲覧モード' : '管理モード';
             }

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -30,7 +30,7 @@ test('page parameter is ignored and interface starts in viewer mode', () => {
   const { getTemplate } = setup({});
   doGet({ parameter: { page: 'admin' } });
   const tpl = getTemplate();
-  expect(tpl.displayMode).toBe('anonymous');
+  expect(tpl.showAdminFeatures).toBe(false);
 });
 
 test('admin user is flagged but initial mode is viewer', () => {
@@ -38,7 +38,7 @@ test('admin user is flagged but initial mode is viewer', () => {
   doGet({ parameter: {} });
   const tpl = getTemplate();
   expect(tpl.isAdminUser).toBe(true);
-  expect(tpl.displayMode).toBe('anonymous');
+  expect(tpl.showAdminFeatures).toBe(false);
 });
 
 test('non admin user starts in viewer mode', () => {
@@ -46,5 +46,5 @@ test('non admin user starts in viewer mode', () => {
   doGet({ parameter: {} });
   const tpl = getTemplate();
   expect(tpl.isAdminUser).toBe(false);
-  expect(tpl.displayMode).toBe('anonymous');
+  expect(tpl.showAdminFeatures).toBe(false);
 });

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -60,7 +60,7 @@ test('getSheetData filters and scores rows', () => {
   ];
   setupMocks(data, 'b@example.com', 'b@example.com');
 
-  const result = getSheetData('Sheet1', undefined, 'score', true);
+  const result = getSheetData('Sheet1', undefined, 'score');
 
   expect(result.header).toBe(COLUMN_HEADERS.OPINION);
   expect(result.rows).toHaveLength(2);
@@ -115,7 +115,7 @@ test('getSheetData supports random sort', () => {
   expect(indexes).toEqual([2, 3]);
 });
 
-test('getSheetData forces anonymous mode for non-admin', () => {
+test('getSheetData returns names for non-admin', () => {
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -131,9 +131,9 @@ test('getSheetData forces anonymous mode for non-admin', () => {
   ];
   setupMocks(data, 'a@example.com', '');
 
-  const result = getSheetData('Sheet1', undefined, undefined);
+  const result = getSheetData('Sheet1');
 
-  expect(result.rows[0].name).toBe('匿名');
+  expect(result.rows[0].name).toBe('A Alice');
 });
 
 test('reaction lists trim spaces and ignore empties', () => {
@@ -161,7 +161,7 @@ test('reaction lists trim spaces and ignore empties', () => {
   ];
   setupMocks(data, 'a@example.com', 'a@example.com');
 
-  const result = getSheetData('Sheet1', undefined, undefined, true);
+  const result = getSheetData('Sheet1');
 
   const row = result.rows[0];
   expect(row.reactions.UNDERSTAND.count).toBe(2);


### PR DESCRIPTION
## Summary
- simplify sheet data retrieval by always returning user names
- drop `namedView` parameter from `getSheetData` and update usage
- remove `displayMode` logic in client page
- adjust tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853aaac8f7c832bbf8a459d9d401c06