### PR TITLE
Admin mode defaults for admin users

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -161,10 +161,11 @@ function doGet(e) {
   const userEmail = safeGetUserEmail();
 
   const template = HtmlService.createTemplateFromFile('Page');
+  const admin = isUserAdmin(userEmail);
   Object.assign(template, {
-    showAdminFeatures: false,
-    showHighlightToggle: false,
-    isAdminUser: isUserAdmin(userEmail)
+    showAdminFeatures: admin,
+    showHighlightToggle: admin,
+    isAdminUser: admin
   });
   template.userEmail = userEmail;
   return template.evaluate()

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -26,19 +26,20 @@ function setup({ userEmail = 'admin@example.com', adminEmails = 'admin@example.c
   return { getTemplate: () => template };
 }
 
-test('page parameter is ignored and interface starts in viewer mode', () => {
+test('page parameter is ignored and admin mode is based on user role', () => {
   const { getTemplate } = setup({});
   doGet({ parameter: { page: 'admin' } });
   const tpl = getTemplate();
-  expect(tpl.showAdminFeatures).toBe(false);
+  expect(tpl.isAdminUser).toBe(true);
+  expect(tpl.showAdminFeatures).toBe(true);
 });
 
-test('admin user is flagged but initial mode is viewer', () => {
+test('admin user starts in admin mode', () => {
   const { getTemplate } = setup({});
   doGet({ parameter: {} });
   const tpl = getTemplate();
   expect(tpl.isAdminUser).toBe(true);
-  expect(tpl.showAdminFeatures).toBe(false);
+  expect(tpl.showAdminFeatures).toBe(true);
 });
 
 test('non admin user starts in viewer mode', () => {


### PR DESCRIPTION
## Summary
- show admin features automatically when the signed-in user is an admin
- update tests for new default behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ae4c28ac832b86d9df423c5d9324