### PR TITLE
Fix admin toggle visibility when Tailwind missing

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -50,7 +50,7 @@
         </div>
         <div class="w-full lg:w-auto lg:min-w-[150px] text-right space-y-1">
             <p id="sheetNameText" class="text-xs text-gray-400 h-4"></p>
-            <button id="adminToggleBtn" class="text-xs text-cyan-400 underline hidden"></button>
+            <button id="adminToggleBtn" class="text-xs text-cyan-400 underline hidden" hidden></button>
         </div>
     </header>
 
@@ -151,6 +151,7 @@
             this.setupEventListeners();
             if (this.isAdminUser && this.elements.adminToggleBtn) {
                 this.elements.adminToggleBtn.classList.remove('hidden');
+                this.elements.adminToggleBtn.removeAttribute('hidden');
                 this.elements.adminToggleBtn.textContent = this.showAdminFeatures ? '閲覧モード' : '管理モード';
             }
             this.adjustLayout();


### PR DESCRIPTION
## Summary
- keep admin toggle hidden with the `hidden` attribute
- remove the hidden attribute for admins at initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ecb442c8832ba6043ad7eb8ac2a4