### PR TITLE
Add loading spinners

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -46,7 +46,12 @@
             </select>
         </div>
         <div class="flex-grow text-center w-full min-w-0">
-             <p id="headingLabel" class="text-2xl md:text-3xl font-bold text-pink-400 leading-tight">データを読み込んでいます...</p>
+             <p id="headingLabel" class="text-2xl md:text-3xl font-bold text-pink-400 leading-tight flex justify-center">
+                 <svg class="w-6 h-6 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                     <path class="opacity-75" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" fill="currentColor"></path>
+                 </svg>
+             </p>
         </div>
         <div class="w-full lg:w-auto lg:min-w-[150px] text-right space-y-1">
             <p id="sheetNameText" class="text-xs text-gray-400 h-4"></p>
@@ -280,7 +285,13 @@
             const oldAnswers = [...this.state.currentAnswers];
 
             if (showLoading) {
-                this.elements.answersContainer.innerHTML = '<p class="text-center text-gray-400 col-span-full mt-8">データを読み込み中...</p>';
+                this.elements.answersContainer.innerHTML =
+                    '<div class="flex justify-center col-span-full mt-8" role="status">' +
+                    '<svg class="w-6 h-6 text-gray-400 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">' +
+                    '<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>' +
+                    '<path class="opacity-75" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" fill="currentColor"></path>' +
+                    '</svg>' +
+                    '</div>';
             }
             
             try {

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -19,14 +19,24 @@
       <!-- Current Status -->
       <div class="mb-6 glass-panel p-4 rounded-lg">
         <h3 class="font-semibold mb-2">現在の状態</h3>
-        <p id="status-text" class="text-gray-300">状態を読み込み中...</p>
+        <p id="status-text" class="text-gray-300 flex justify-center">
+          <svg class="w-5 h-5 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" fill="currentColor"></path>
+          </svg>
+        </p>
       </div>
 
       <!-- Sheet Selection -->
       <div class="mb-6">
         <h3 class="font-semibold mb-3">1. 公開するシートを選択</h3>
         <div id="sheet-list" class="flex flex-col gap-2 rounded-lg glass-panel p-2 max-h-48 overflow-y-auto">
-          <p class="text-gray-400 p-2">シートを読み込み中...</p>
+          <div class="flex justify-center p-2" role="status">
+            <svg class="w-5 h-5 text-gray-400 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" fill="currentColor"></path>
+            </svg>
+          </div>
         </div>
       </div>
 

--- a/src/Unpublished.html
+++ b/src/Unpublished.html
@@ -17,8 +17,13 @@
             <h2 class="text-lg font-bold mb-4 text-yellow-300">管理者用パネル</h2>
             <p class="text-sm text-gray-300 mb-4">表示するシートを選択して公開してください。</p>
             <div class="flex flex-col gap-4">
-                <select id="sheet-selector" class="w-full p-2 rounded bg-gray-800 border border-gray-600 text-white focus:ring-2 focus:ring-yellow-400 focus:outline-none">
-                    <option>シートを読み込み中...</option>
+                <div id="sheet-loader" class="flex justify-center p-2" role="status">
+                    <svg class="w-5 h-5 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" fill="currentColor"></path>
+                    </svg>
+                </div>
+                <select id="sheet-selector" class="hidden w-full p-2 rounded bg-gray-800 border border-gray-600 text-white focus:ring-2 focus:ring-yellow-400 focus:outline-none">
                 </select>
                 <button id="publish-btn" class="w-full bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-bold py-2 px-4 rounded transition disabled:opacity-50">
                     このシートで公開する
@@ -31,7 +36,10 @@
     <script>
         const userEmail = "<?= userEmail ?>";
         const adminCheckMessage = document.getElementById('admin-check-message');
-        adminCheckMessage.textContent = '管理者権限を確認中...';
+        adminCheckMessage.innerHTML = '<svg class="w-5 h-5 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">' +
+            '<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>' +
+            '<path class="opacity-75" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" fill="currentColor"></path>' +
+            '</svg>';
 
         google.script.run
             .withSuccessHandler((isAdmin) => {
@@ -42,6 +50,7 @@
                 adminPanel.classList.remove('hidden');
 
                 const sheetSelector = document.getElementById('sheet-selector');
+                const sheetLoader = document.getElementById('sheet-loader');
                 const publishBtn = document.getElementById('publish-btn');
                 const messageArea = document.getElementById('message-area');
 
@@ -52,6 +61,8 @@
                     .getSheets();
 
                 function populateSheets(sheetNames) {
+                    sheetLoader.classList.add('hidden');
+                    sheetSelector.classList.remove('hidden');
                     sheetSelector.innerHTML = '<option value="">-- シートを選択してください --</option>';
                     if (sheetNames && sheetNames.length > 0) {
                         sheetNames.forEach(name => {
@@ -67,6 +78,8 @@
                 }
 
                 function showError(error) {
+                    sheetLoader.classList.add('hidden');
+                    sheetSelector.classList.remove('hidden');
                     messageArea.textContent = `エラー: ${error.message}`;
                     messageArea.className = 'mt-4 text-sm h-5 text-red-400';
                 }


### PR DESCRIPTION
## Summary
- show animated spinner while loading board data
- use spinners in admin sheet selector UI
- display spinners during unpublished admin checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853fce87e50832b9b27af3b97cbd8ad