### PR TITLE
Fix order of reaction and highlight buttons in footer

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -464,8 +464,8 @@
                 '<div class="text-xs text-gray-400 pt-3 border-t-2 border-cyan-400/80 border-dashed flex justify-between items-center">' +
                 nameHtml +
                 '<div class="flex items-center gap-1">' +
-                highlightBtn +
                 reactionButtons +
+                highlightBtn +
                 '</div>' +
                 '</div>';
 


### PR DESCRIPTION
## Summary
- reverse the order so reaction buttons come before the highlight button in `createAnswerCard`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685418af044c832bb00345d3a1a984a3