### PR TITLE
Fix admin feature display for non admins

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -328,6 +328,11 @@
                 const sortOrder = this.elements.sortOrder.value;
                 const data = await this.gas.getPublishedSheetData(selectedClass, sortOrder);
                 this.adjustLayout();
+
+                if (!this.isAdminUser) {
+                    this.showAdminFeatures = false;
+                    this.showHighlightToggle = false;
+                }
                 
                 if (isInitialLoad) {
                     this.populateClassFilter(data.rows);


### PR DESCRIPTION
## Summary
- prevent non-admin users from accidentally enabling admin features by resetting the flags each time data is loaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854971ca328832b84c40a7c28a231b4