### PR TITLE
Implement pause/resume polling on visibility change

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -204,6 +204,13 @@
                 }
             });
             window.addEventListener('resize', this.debounce(() => this.adjustLayout(), 100));
+            document.addEventListener('visibilitychange', () => {
+                if (document.hidden) {
+                    this.stopPolling();
+                } else {
+                    this.startPolling();
+                }
+            });
         }
 
         adjustLayout() {
@@ -294,13 +301,24 @@
                 }, 500);
             });
         }
-        
-        async loadInitialData() {
-            await this.loadSheetData(true, true);
+
+        startPolling() {
             if (this.pollingInterval) {
                 clearInterval(this.pollingInterval);
             }
             this.pollingInterval = setInterval(() => this.loadSheetData(false), 15000);
+        }
+
+        stopPolling() {
+            if (this.pollingInterval) {
+                clearInterval(this.pollingInterval);
+                this.pollingInterval = null;
+            }
+        }
+
+        async loadInitialData() {
+            await this.loadSheetData(true, true);
+            this.startPolling();
         }
 
         async loadSheetData(showLoading = true, isInitialLoad = false) {

--- a/tests/visibilityPolling.test.js
+++ b/tests/visibilityPolling.test.js
@@ -1,0 +1,55 @@
+const { JSDOM } = require('jsdom');
+
+test('polling stops and restarts on visibility change', () => {
+  const dom = new JSDOM(`<!DOCTYPE html><body></body>`, { pretendToBeVisual: true });
+  global.document = dom.window.document;
+  global.window = dom.window;
+
+  let hidden = false;
+  Object.defineProperty(document, 'hidden', {
+    get: () => hidden,
+    set: (val) => { hidden = val; },
+    configurable: true
+  });
+
+  let id = 1;
+  window.setInterval = jest.fn(() => id++);
+  window.clearInterval = jest.fn();
+
+  let pollingInterval = null;
+  function startPolling() {
+    if (pollingInterval) {
+      window.clearInterval(pollingInterval);
+    }
+    pollingInterval = window.setInterval(() => {}, 15000);
+  }
+  function stopPolling() {
+    if (pollingInterval) {
+      window.clearInterval(pollingInterval);
+      pollingInterval = null;
+    }
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      stopPolling();
+    } else {
+      startPolling();
+    }
+  });
+
+  startPolling();
+  expect(window.setInterval).toHaveBeenCalledTimes(1);
+
+  document.hidden = true;
+  document.dispatchEvent(new dom.window.Event('visibilitychange'));
+  expect(window.clearInterval).toHaveBeenCalledTimes(1);
+  expect(pollingInterval).toBeNull();
+
+  document.hidden = false;
+  document.dispatchEvent(new dom.window.Event('visibilitychange'));
+  expect(window.setInterval).toHaveBeenCalledTimes(2);
+
+  delete global.document;
+  delete global.window;
+});


### PR DESCRIPTION
## Summary
- ensure StudyQuest polling stops when the page is hidden and restarts when visible
- start polling via a new `startPolling` helper
- add a visibility polling jest test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68554ed1792c832bb1bedcb3fc24ae5c