### PR TITLE
Restrict name and like visibility

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -495,13 +495,13 @@
             }
             const badge = data.highlight ? '<span class="highlight-badge">' + this.getIcon('star') + '</span>' : '';
 
-            const nameHtml = this.showAdminFeatures ? '<div><span class="font-bold text-sm text-gray-200">' + this.escapeHtml(data.name) + '</span></div>' : '';
+            const nameHtml = this.isAdminUser ? '<div><span class="font-bold text-sm text-gray-200">' + this.escapeHtml(data.name) + '</span></div>' : '';
 
             const reactionButtons = this.reactionTypes.map(rt => {
                 const info = data.reactions ? data.reactions[rt.key] : { count: 0, reacted: false };
                 const cls = info.reacted ? 'liked' : '';
                 const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
-                const countSpan = this.showAdminFeatures ? '<span class="reaction-count font-bold text-lg text-gray-200">' + (info.count || 0) + '</span>' : '';
+                const countSpan = this.isAdminUser ? '<span class="reaction-count font-bold text-lg text-gray-200">' + (info.count || 0) + '</span>' : '';
                 return '<button type="button" class="reaction-btn like-btn flex items-center gap-1 ' + colorClass + ' ' + cls + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.key + '">' +
                        countSpan +
                        this.getIcon(rt.icon, 'w-5 h-5', info.reacted) +
@@ -713,13 +713,13 @@
                 '<p class="text-gray-200 whitespace-pre-wrap break-words text-2xl md:text-3xl mt-6">' + 
                 this.escapeHtml(data.reason || '') + '</p>';
             
-            this.elements.modalStudentName.textContent = data.name;
+            this.elements.modalStudentName.textContent = this.isAdminUser ? data.name : '';
 
             const html = this.reactionTypes.map(rt => {
                 const info = data.reactions[rt.key];
                 const cls = info.reacted ? 'liked' : '';
                 const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
-                const countSpan = this.showAdminFeatures ? '<span class="reaction-count font-bold text-2xl text-gray-200">' + info.count + '</span>' : '';
+                const countSpan = this.isAdminUser ? '<span class="reaction-count font-bold text-2xl text-gray-200">' + info.count + '</span>' : '';
                 return '<button type="button" class="reaction-btn like-btn flex items-center gap-1.5 ' + colorClass + ' ' + cls + '" ' +
                        'data-row-index="' + rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.key + '">' +
                        countSpan +


### PR DESCRIPTION
## Summary
- hide student names and reaction counts unless user is admin
- keep highlight toggle guarded by existing flag

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855d76e3478832b85c8d9f3eba7462d