### PR TITLE
Restrict names for non-admin users

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -225,6 +225,7 @@ function getSheetData(sheetName, classFilter, sortBy) {
     if (allValues.length < 1) return { header: "シートにデータがありません", rows: [] };
     
     const userEmail = safeGetUserEmail();
+    const isAdmin = isUserAdmin(userEmail);
     const headerIndices = getAndCacheHeaderIndices(sheetName, allValues[0]);
     const dataRows = allValues.slice(1);
     const emailToNameMap = getRosterMap();
@@ -250,7 +251,7 @@ function getSheetData(sheetName, classFilter, sortBy) {
         const name = emailToNameMap[email] || email.split('@')[0];
         return {
           rowIndex: index + 2,
-          name: name,
+          name: isAdmin ? name : '',
           class: row[headerIndices[COLUMN_HEADERS.CLASS]] || '未分類',
           opinion: opinion,
           reason: reason,

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -115,7 +115,7 @@ test('getSheetData supports random sort', () => {
   expect(indexes).toEqual([2, 3]);
 });
 
-test('getSheetData returns names for non-admin', () => {
+test('getSheetData omits names for non-admin', () => {
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -130,6 +130,27 @@ test('getSheetData returns names for non-admin', () => {
     ['a@example.com', '1-1', 'Opinion1', 'Reason1', '', '', '', 'false']
   ];
   setupMocks(data, 'a@example.com', '');
+
+  const result = getSheetData('Sheet1');
+
+  expect(result.rows[0].name).toBe('');
+});
+
+test('getSheetData returns names for admin users', () => {
+  const data = [
+    [
+      COLUMN_HEADERS.EMAIL,
+      COLUMN_HEADERS.CLASS,
+      COLUMN_HEADERS.OPINION,
+      COLUMN_HEADERS.REASON,
+      COLUMN_HEADERS.UNDERSTAND,
+      COLUMN_HEADERS.LIKE,
+      COLUMN_HEADERS.CURIOUS,
+      COLUMN_HEADERS.HIGHLIGHT
+    ],
+    ['a@example.com', '1-1', 'Opinion1', 'Reason1', '', '', '', 'false']
+  ];
+  setupMocks(data, 'a@example.com', 'a@example.com');
 
   const result = getSheetData('Sheet1');
 


### PR DESCRIPTION
## Summary
- check admin status in `getSheetData`
- hide names from non-admins
- update tests to verify admin/non-admin name behavior

## Testing
- `npm test` *(fails: sliderPersistence.test.js due to localStorage issue)*

------
https://chatgpt.com/codex/tasks/task_e_6855ec90fa40832b9280c51ec6ec90c5