### PR TITLE
Implement display options and UI improvements

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -29,7 +29,8 @@ const SCORING_CONFIG = {
 };
 const APP_PROPERTIES = {
   ACTIVE_SHEET: 'ACTIVE_SHEET_NAME',
-  IS_PUBLISHED: 'IS_PUBLISHED'
+  IS_PUBLISHED: 'IS_PUBLISHED',
+  SHOW_DETAILS: 'SHOW_DETAILS'
 };
 
 const TIME_CONSTANTS = {
@@ -112,7 +113,8 @@ function getAdminSettings() {
     adminEmails: adminEmails,
     isUserAdmin: adminEmails.includes(currentUserEmail),
     isPublished: appSettings.isPublished,
-    activeSheetName: appSettings.activeSheetName
+    activeSheetName: appSettings.activeSheetName,
+    showDetails: appSettings.showDetails
   };
 }
 
@@ -145,6 +147,15 @@ function unpublishApp() {
   return 'アプリを非公開にしました。';
 }
 
+function setShowDetails(flag) {
+  if (!checkAdmin()) {
+    throw new Error('権限がありません。');
+  }
+  const properties = PropertiesService.getScriptProperties();
+  properties.setProperty(APP_PROPERTIES.SHOW_DETAILS, String(flag));
+  return `詳細表示を${flag ? '有効' : '無効'}にしました。`;
+}
+
 
 
 // =================================================================
@@ -171,7 +182,9 @@ function doGet(e) {
   Object.assign(template, {
     showAdminFeatures: false,
     showHighlightToggle: false,
-    isAdminUser: admin
+    isAdminUser: admin,
+    showCounts: settings.showDetails,
+    displayMode: settings.showDetails ? 'named' : 'anonymous'
   });
   template.userEmail = userEmail;
   return template.evaluate()
@@ -203,7 +216,8 @@ function getPublishedSheetData(classFilter, sortBy) {
   return {
     sheetName: sheetName,
     header: data.header,
-    rows: data.rows
+    rows: data.rows,
+    showDetails: settings.showDetails
   };
 }
 
@@ -371,6 +385,7 @@ function getAppSettings() {
   const getProp = typeof properties.getProperty === 'function' ? (k) => properties.getProperty(k) : () => null;
   const published = getProp(APP_PROPERTIES.IS_PUBLISHED);
   const sheet = getProp(APP_PROPERTIES.ACTIVE_SHEET);
+  const showDetailsProp = getProp(APP_PROPERTIES.SHOW_DETAILS);
   let activeName = sheet;
   if (!activeName) {
     try {
@@ -383,7 +398,8 @@ function getAppSettings() {
   }
   return {
     isPublished: published === null ? true : published === 'true',
-    activeSheetName: activeName
+    activeSheetName: activeName,
+    showDetails: showDetailsProp === 'true'
   };
 }
 
@@ -487,6 +503,7 @@ if (typeof module !== 'undefined') {
     getHeaderIndices,
     addReaction,
     toggleHighlight,
+    setShowDetails,
     saveWebAppUrl,
     saveDeployId,
     findHeaderIndices,

--- a/src/Page.html
+++ b/src/Page.html
@@ -84,6 +84,10 @@
     // モード初期化
     ModeManager.initializeMode();
   </script>
+  <script>
+    window.showCounts = <?= showCounts ?>;
+    window.displayMode = '<?= displayMode ?>';
+  </script>
   <style>
     /* カスタムプロパティ（CSS変数）定義 */
     :root {
@@ -211,9 +215,9 @@
     /* リアクションボタンの背景グラデーションとボーダーカラー */
     .reaction-bg-like { border-color:#ef4444; border-image: linear-gradient(to bottom,#facc15,#fcd34d) 1; }
     .reaction-bg-understand { border-color:#fbbf24; border-image: linear-gradient(to bottom,#a3e635,#bef264) 1; }
-    .reaction-bg-curious { border-color:#3b82f6; border-image: linear-gradient(to bottom,#38bdf8,#7dd3fc) 1; }
-    .reaction-bg-mixed { border-color:#8b5cf6; border-image: linear-gradient(to bottom,#f59e0b,#10b981,#3b82f6) 1; }
-    .reaction-bg-all { border-color:transparent; border-image: linear-gradient(90deg,#ef4444,#fbbf24,#3b82f6) 1; }
+    .reaction-bg-curious { border-color:#10b981; border-image: linear-gradient(to bottom,#34d399,#6ee7b7) 1; }
+    .reaction-bg-mixed { border-color:#8b5cf6; border-image: linear-gradient(to bottom,#f59e0b,#10b981,#10b981) 1; }
+    .reaction-bg-all { border-color:transparent; border-image: linear-gradient(90deg,#ef4444,#fbbf24,#10b981) 1; }
     /* 回答プレビューの表示制限と省略 */
     .answer-preview { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; text-overflow: ellipsis; min-height: 120px; }
     /* いいねボタンのSVGトランジション */
@@ -281,7 +285,7 @@
     <div id="answerModalCard" class="glass-panel rounded-xl p-6 flex flex-col shadow-2xl border-2 border-cyan-400/80 w-full max-w-5xl h-auto max-h-[85vh] transform scale-95 transition-transform duration-300" role="document" aria-labelledby="modalAnswer">
       <button id="answerModalCloseBtn" class="absolute -top-3 -right-3 bg-red-600 rounded-full p-2 text-white hover:scale-110 transition-transform" aria-label="閉じる"></button>
       <div id="modalAnswer" class="flex-grow min-h-[200px] mb-4 overflow-y-auto pr-4"></div>
-      <div class="text-xs text-gray-400 pt-4 border-t-2 border-dashed border-cyan-400/80 flex justify-between items-center">
+      <div id="modalFooter" class="text-xs text-gray-400 pt-4 border-t-2 border-dashed border-cyan-400/80 flex justify-between items-center">
         <div><span id="modalStudentName" class="font-bold text-2xl text-gray-200"></span></div>
         <div id="modalReactions" class="flex items-center gap-2"></div>
       </div>
@@ -351,6 +355,7 @@
           modalAnswer: document.getElementById('modalAnswer'),
           modalStudentName: document.getElementById('modalStudentName'),
           modalReactionContainer: document.getElementById('modalReactions'),
+          modalFooter: document.getElementById('modalFooter'),
           classFilter: document.getElementById('classFilter'),
           sortOrder: document.getElementById('sortOrder'),
           scoreOption: document.getElementById('scoreOption'), // スコア順オプション
@@ -850,6 +855,11 @@
           console.log('Calling getPublishedSheetData with:', { selectedClass, sortOrder });
           const data = await this.gas.getPublishedSheetData(selectedClass, sortOrder); // GASからデータを取得
           console.log('Received data:', data);
+          if (typeof data.showDetails !== 'undefined') {
+            window.showCounts = data.showDetails;
+            window.displayMode = data.showDetails ? 'named' : 'anonymous';
+            this.updateConfigFromGlobals();
+          }
           this.adjustLayout(); // レイアウト調整
 
           // 管理者権限がない場合は管理機能を無効化
@@ -1043,12 +1053,13 @@
         
         // 管理者ユーザーの場合のみ学生名を表示
         const nameHtml = this.state.isAdminUser ? '<div><span class="font-bold text-sm text-gray-200">' + this.escapeHtml(data.name) + '</span></div>' : '';
+        const containerClass = nameHtml ? 'text-xs text-gray-400 pt-3 border-t-2 border-cyan-400/80 border-dashed flex justify-between items-center' : 'text-xs text-gray-400 pt-3 border-t-2 border-cyan-400/80 border-dashed flex justify-end items-center';
 
         // リアクションボタンのHTMLを生成（アクセシビリティ強化）
         const reactionButtonsHtml = this.reactionTypes.map(rt => {
           const info = data.reactions ? data.reactions[rt.key] : { count: 0, reacted: false };
           const cls = info.reacted ? 'liked' : '';
-          const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
+          const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-green-500';
           
           // showCountsがtrueの場合のみカウントを表示
           const countSpan = this.state.showCounts ? '<span class="reaction-count font-bold text-lg text-gray-200" aria-hidden="true">' + (info.count || 0) + '</span>' : '';
@@ -1063,8 +1074,8 @@
           const ariaLabel = `${reactionName}${info.reacted ? 'を取り消す' : 'する'}${this.state.showCounts ? ` (現在${info.count || 0}件)` : ''}`;
           
           return '<button type="button" class="reaction-btn like-btn flex items-center gap-1 ' + colorClass + ' ' + cls + '" data-row-index="' + data.rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + ariaLabel + '" aria-pressed="' + info.reacted + '">' +
-                   countSpan +
                    this.getIcon(rt.icon, 'w-5 h-5', info.reacted) +
+                   countSpan +
                    '</button>';
         }).join('');
 
@@ -1079,7 +1090,7 @@
           '<p class="text-gray-100 whitespace-pre-wrap break-words mt-4">' +
           this.escapeHtml(data.reason || '') + '</p>' +
           '</div>' +
-          '<div class="text-xs text-gray-400 pt-3 border-t-2 border-cyan-400/80 border-dashed flex justify-between items-center">' +
+          '<div class="' + containerClass + '">' +
           nameHtml + // 学生名（管理者モードのみ）
           '<div class="flex items-center gap-1" role="group" aria-label="回答への反応">' +
           reactionButtonsHtml + // リアクションボタン群
@@ -1363,18 +1374,20 @@
         
         // 管理者ユーザーの場合のみ学生名を表示
         this.elements.modalStudentName.textContent = this.state.isAdminUser ? data.name : '';
+        const footerBase = 'text-xs text-gray-400 pt-4 border-t-2 border-dashed border-cyan-400/80 flex';
+        this.elements.modalFooter.className = footerBase + (this.state.isAdminUser ? ' justify-between items-center' : ' justify-end items-center');
 
         // モーダル内のリアクションボタンを生成
         const reactionButtonsHtml = this.reactionTypes.map(rt => {
           const info = data.reactions?.[rt.key] || { count: 0, reacted: false };
           const cls = info.reacted ? 'liked' : '';
-          const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-blue-500';
+          const colorClass = rt.key === 'LIKE' ? 'text-red-500' : rt.key === 'UNDERSTAND' ? 'text-yellow-500' : 'text-green-500';
           // showCountsがtrueの場合のみカウントを表示
           const countSpan = this.state.showCounts ? '<span class="reaction-count font-bold text-2xl text-gray-200">' + info.count + '</span>' : '';
           return '<button type="button" class="reaction-btn like-btn flex items-center gap-1.5 ' + colorClass + ' ' + cls + '" ' +
                    'data-row-index="' + rowIndex + '" data-reaction="' + rt.key + '" aria-label="' + rt.key + '">' +
-                   countSpan +
                    this.getIcon(rt.icon, 'w-5 h-5', info.reacted) +
+                   countSpan +
                    '</button>';
         }).join('');
         this.elements.modalReactionContainer.innerHTML = reactionButtonsHtml;

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -40,9 +40,24 @@
         </div>
       </div>
 
+      <!-- Display Options -->
+      <div class="mb-6">
+        <h3 class="font-semibold mb-3">2. 表示オプション</h3>
+        <div id="detail-options" class="flex flex-col gap-2 rounded-lg glass-panel p-2">
+          <label class="flex items-center p-2 rounded-md cursor-pointer">
+            <input type="radio" name="showDetails" value="true" class="mr-3 h-4 w-4 text-blue-600 border-gray-300 focus:ring-blue-500">
+            名前・リアクション数を表示
+          </label>
+          <label class="flex items-center p-2 rounded-md cursor-pointer">
+            <input type="radio" name="showDetails" value="false" class="mr-3 h-4 w-4 text-blue-600 border-gray-300 focus:ring-blue-500">
+            表示しない
+          </label>
+        </div>
+      </div>
+
       <!-- Actions -->
       <div class="glass-panel p-4 rounded-lg">
-        <h3 class="font-semibold mb-3">2. 操作を選択</h3>
+        <h3 class="font-semibold mb-3">3. 操作を選択</h3>
         <div class="flex flex-col gap-3">
           <button id="publish-btn" class="w-full text-white font-bold py-2 px-4 rounded-lg bg-blue-500 hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75 transition disabled:bg-blue-300">
             選択したシートを公開
@@ -63,7 +78,8 @@
         sheetList: document.getElementById('sheet-list'),
         publishBtn: document.getElementById('publish-btn'),
         unpublishBtn: document.getElementById('unpublish-btn'),
-        messageArea: document.getElementById('message-area')
+        messageArea: document.getElementById('message-area'),
+        detailOptions: document.getElementById('detail-options')
       };
 
       let selectedSheet = null;
@@ -84,6 +100,11 @@
 
       function updateUI(status) {
         selectedSheet = status.activeSheetName;
+
+        if (elements.detailOptions) {
+          const radios = elements.detailOptions.querySelectorAll('input[name="showDetails"]');
+          radios.forEach(r => { r.checked = r.value === String(status.showDetails); r.onchange = () => updateShowDetails(r.value); });
+        }
         
         if (status.isPublished && status.activeSheetName) {
           elements.statusText.innerHTML = `公開中: <span class="font-bold text-green-700">${status.activeSheetName}</span>`;
@@ -148,6 +169,14 @@
           })
           .withFailureHandler(showError)
           .unpublishApp();
+      }
+
+      function updateShowDetails(val) {
+        setLoading(true, "設定を保存中...");
+        google.script.run
+          .withSuccessHandler((msg) => { showMessage(msg, 'green'); setLoading(false); })
+          .withFailureHandler(showError)
+          .setShowDetails(val === 'true');
       }
 
       function setLoading(isLoading, msg = "") {

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -39,7 +39,8 @@ test('getAdminSettings returns board state', () => {
     adminEmails: ['a@example.com','b@example.com'],
     isUserAdmin: true,
     isPublished: true,
-    activeSheetName: 'SheetA'
+    activeSheetName: 'SheetA',
+    showDetails: false
   });
 });
 


### PR DESCRIPTION
## Summary
- add SHOW_DETAILS property and support functions in Code.gs
- expose display settings via SheetSelector sidebar
- inject showCounts/displayMode variables into Page.html
- right-align reactions when names hidden and swap count position
- change Curious reaction color to green
- update test expectations for new settings

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685606676f8c832bb361983503278fed