### PR TITLE
Add reaction border styling

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -218,6 +218,10 @@
     .reaction-bg-curious { border-color:#10b981; border-image: linear-gradient(to bottom,#34d399,#6ee7b7) 1; }
     .reaction-bg-mixed { border-color:#8b5cf6; border-image: linear-gradient(to bottom,#f59e0b,#10b981,#10b981) 1; }
     .reaction-bg-all { border-color:transparent; border-image: linear-gradient(90deg,#ef4444,#fbbf24,#10b981) 1; }
+    /* リアクション総数に応じたボーダー太さ */
+    .reaction-border-1 { border-width: 2px; }
+    .reaction-border-2 { border-width: 4px; }
+    .reaction-border-3 { border-width: 6px; }
     /* 回答プレビューの表示制限と省略 */
     .answer-preview { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; text-overflow: ellipsis; min-height: 120px; }
     /* いいねボタンのSVGトランジション */
@@ -1047,6 +1051,17 @@
           card.classList.add('reaction-bg-all');
         }
 
+        // リアクション総数に応じてボーダークラスを追加
+        const totalReactions = this.reactionTypes.reduce((sum, rt) =>
+          sum + (data.reactions?.[rt.key]?.count || 0), 0);
+        if (totalReactions >= 10) {
+          card.classList.add('reaction-border-3');
+        } else if (totalReactions >= 5) {
+          card.classList.add('reaction-border-2');
+        } else if (totalReactions > 0) {
+          card.classList.add('reaction-border-1');
+        }
+
         let highlightBtnHtml = '';
         // ハイライトトグル機能が有効な場合のみボタンを生成
         if (this.state.showHighlightToggle) {
@@ -1338,6 +1353,19 @@
               card.classList.add('reaction-bg-mixed');
             } else if (active.length > 2) {
               card.classList.add('reaction-bg-all');
+            }
+
+            // 総リアクション数によるボーダークラスの更新
+            const total = this.reactionTypes.reduce((sum, rt) =>
+              sum + (item.reactions?.[rt.key]?.count || 0), 0);
+            ['reaction-border-1','reaction-border-2','reaction-border-3']
+              .forEach(cls => card.classList.remove(cls));
+            if (total >= 10) {
+              card.classList.add('reaction-border-3');
+            } else if (total >= 5) {
+              card.classList.add('reaction-border-2');
+            } else if (total > 0) {
+              card.classList.add('reaction-border-1');
             }
 
             // ハイライトバッジの表示/非表示を制御

--- a/tests/borderStyleByReaction.test.js
+++ b/tests/borderStyleByReaction.test.js
@@ -1,0 +1,72 @@
+const { JSDOM } = require('jsdom');
+
+function createAnswerCard(data, reactionTypes) {
+  const card = document.createElement('div');
+  card.className = 'answer-card';
+  const total = reactionTypes.reduce((sum, rt) => sum + (data.reactions?.[rt.key]?.count || 0), 0);
+  if (total >= 10) {
+    card.classList.add('reaction-border-3');
+  } else if (total >= 5) {
+    card.classList.add('reaction-border-2');
+  } else if (total > 0) {
+    card.classList.add('reaction-border-1');
+  }
+  return card;
+}
+
+function applyUpdates(items, reactionTypes) {
+  items.forEach(item => {
+    const card = document.querySelector(`.answer-card[data-row-index="${item.rowIndex}"]`);
+    if (!card) return;
+    const total = reactionTypes.reduce((sum, rt) => sum + (item.reactions?.[rt.key]?.count || 0), 0);
+    ['reaction-border-1','reaction-border-2','reaction-border-3'].forEach(c => card.classList.remove(c));
+    if (total >= 10) {
+      card.classList.add('reaction-border-3');
+    } else if (total >= 5) {
+      card.classList.add('reaction-border-2');
+    } else if (total > 0) {
+      card.classList.add('reaction-border-1');
+    }
+  });
+}
+
+const reactionTypes = [
+  { key: 'LIKE' },
+  { key: 'UNDERSTAND' },
+  { key: 'CURIOUS' }
+];
+
+afterEach(() => {
+  delete global.document;
+});
+
+test('createAnswerCard adds border class based on total reactions', () => {
+  const dom = new JSDOM('<body></body>');
+  global.document = dom.window.document;
+
+  const card1 = createAnswerCard({ reactions: { LIKE: { count: 1 } } }, reactionTypes);
+  expect(card1.classList.contains('reaction-border-1')).toBe(true);
+
+  const card2 = createAnswerCard({ reactions: { LIKE: { count: 5 } } }, reactionTypes);
+  expect(card2.classList.contains('reaction-border-2')).toBe(true);
+
+  const card3 = createAnswerCard({ reactions: { LIKE: { count: 10 } } }, reactionTypes);
+  expect(card3.classList.contains('reaction-border-3')).toBe(true);
+});
+
+test('applyUpdates toggles border classes', () => {
+  const dom = new JSDOM('<div class="answer-card" data-row-index="1"></div>');
+  global.document = dom.window.document;
+
+  applyUpdates([{ rowIndex: 1, reactions: { LIKE: { count: 6 } } }], reactionTypes);
+  const card = dom.window.document.querySelector('.answer-card');
+  expect(card.classList.contains('reaction-border-2')).toBe(true);
+
+  applyUpdates([{ rowIndex: 1, reactions: { LIKE: { count: 11 } } }], reactionTypes);
+  expect(card.classList.contains('reaction-border-3')).toBe(true);
+
+  applyUpdates([{ rowIndex: 1, reactions: { LIKE: { count: 0 } } }], reactionTypes);
+  expect(card.classList.contains('reaction-border-1')).toBe(false);
+  expect(card.classList.contains('reaction-border-2')).toBe(false);
+  expect(card.classList.contains('reaction-border-3')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- change card border width based on total reaction count
- recalc border styling when reactions update
- add JSDOM tests for reaction-based border classes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856179bf4cc832b8978c067efae1f4e