### PR TITLE
Add dropdown config loading

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -243,6 +243,13 @@ function getSheets() {
   }
 }
 
+function getSheetHeaders(sheetName) {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+  if (!sheet) throw new Error(`シート '${sheetName}' が見つかりません。`);
+  const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+  return headerRow.map(v => (v !== null && v !== undefined) ? String(v) : '');
+}
+
 function getSheetData(sheetName, classFilter, sortBy) {
   try {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
@@ -531,6 +538,7 @@ if (typeof module !== 'undefined') {
     buildBoardData,
     getPublishedSheetData,
     getSheets,
+    getSheetHeaders,
     getSheetData,
     getRosterMap,
     getHeaderIndices,

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -44,15 +44,15 @@
       <div class="mb-6">
         <h3 class="font-semibold mb-3">2. Config設定</h3>
         <div class="flex flex-col gap-2 rounded-lg glass-panel p-2" id="config-area">
-          <input id="qHeader" type="text" placeholder="問題文ヘッダー" class="p-1 rounded text-gray-900" />
-          <input id="aHeader" type="text" placeholder="回答ヘッダー" class="p-1 rounded text-gray-900" />
-          <input id="rHeader" type="text" placeholder="理由ヘッダー(任意)" class="p-1 rounded text-gray-900" />
+          <select id="qHeader" class="p-1 rounded text-gray-900"></select>
+          <select id="aHeader" class="p-1 rounded text-gray-900"></select>
+          <select id="rHeader" class="p-1 rounded text-gray-900"></select>
           <select id="nameMode" class="p-1 rounded text-gray-900">
             <option value="同一シート">同一シート</option>
             <option value="別シート">別シート</option>
           </select>
-          <input id="nameHeader" type="text" placeholder="名前列ヘッダー(任意)" class="p-1 rounded text-gray-900" />
-          <input id="classHeader" type="text" placeholder="クラス列ヘッダー(任意)" class="p-1 rounded text-gray-900" />
+          <select id="nameHeader" class="p-1 rounded text-gray-900"></select>
+          <select id="classHeader" class="p-1 rounded text-gray-900"></select>
           <button id="save-config-btn" class="bg-green-600 hover:bg-green-700 text-white rounded py-1">保存</button>
         </div>
       </div>
@@ -209,9 +209,28 @@
       function loadConfigForSelected() {
         if (!selectedSheet) { clearConfigFields(); return; }
         google.script.run
-          .withSuccessHandler(populateConfig)
+          .withSuccessHandler((headers) => {
+            populateHeaderOptions(headers);
+            google.script.run
+              .withSuccessHandler(populateConfig)
+              .withFailureHandler(clearConfigFields)
+              .getConfig(selectedSheet);
+          })
           .withFailureHandler(clearConfigFields)
-          .getConfig(selectedSheet);
+          .getSheetHeaders(selectedSheet);
+      }
+
+      function populateHeaderOptions(headers) {
+        const selects = [elements.qHeader, elements.aHeader, elements.rHeader, elements.nameHeader, elements.classHeader];
+        selects.forEach(sel => {
+          sel.innerHTML = '<option value=""></option>';
+          headers.forEach(h => {
+            const opt = document.createElement('option');
+            opt.value = h;
+            opt.textContent = h;
+            sel.appendChild(opt);
+          });
+        });
       }
 
       function populateConfig(cfg) {
@@ -224,12 +243,11 @@
       }
 
       function clearConfigFields() {
-        elements.qHeader.value = '';
-        elements.aHeader.value = '';
-        elements.rHeader.value = '';
+        [elements.qHeader, elements.aHeader, elements.rHeader, elements.nameHeader, elements.classHeader].forEach(sel => {
+          sel.innerHTML = '<option value=""></option>';
+          sel.value = '';
+        });
         elements.nameMode.value = '同一シート';
-        elements.nameHeader.value = '';
-        elements.classHeader.value = '';
       }
 
       function saveConfig() {

--- a/tests/getSheetHeaders.test.js
+++ b/tests/getSheetHeaders.test.js
@@ -1,0 +1,31 @@
+const { getSheetHeaders } = require('../src/Code.gs');
+
+function setup(headers) {
+  const sheet = {
+    getLastColumn: jest.fn(() => headers.length),
+    getRange: jest.fn(() => ({ getValues: () => [headers] }))
+  };
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({
+      getSheetByName: jest.fn(() => sheet)
+    })
+  };
+  return { sheet };
+}
+
+afterEach(() => {
+  delete global.SpreadsheetApp;
+});
+
+test('getSheetHeaders returns header row', () => {
+  const headers = ['A', 'B', 'C'];
+  setup(headers);
+  expect(getSheetHeaders('Sheet1')).toEqual(headers);
+});
+
+test('getSheetHeaders throws when sheet missing', () => {
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({ getSheetByName: jest.fn(() => null) })
+  };
+  expect(() => getSheetHeaders('Missing')).toThrow("シート 'Missing' が見つかりません。");
+});


### PR DESCRIPTION
## Summary
- list sheet headers from Apps Script via `getSheetHeaders`
- switch config text inputs to dropdowns using these headers
- support populating dropdowns in SheetSelector client code
- test new `getSheetHeaders` helper

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685646bb4f60832bb927aa57296741dc