### PR TITLE
Add aria-live on message areas

### DIFF
--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -104,7 +104,7 @@
         </div>
       </div>
       
-      <div id="message-area" class="mt-4 text-center text-sm h-5"></div>
+      <div id="message-area" class="mt-4 text-center text-sm h-5" aria-live="polite" role="status"></div>
 
     </div>
 

--- a/src/Unpublished.html
+++ b/src/Unpublished.html
@@ -32,7 +32,7 @@
                     このシートで公開する
                 </button>
             </div>
-            <p id="message-area" class="mt-4 text-sm h-5"></p>
+            <p id="message-area" class="mt-4 text-sm h-5" aria-live="polite" role="status"></p>
         </div>
     </div>
 

--- a/tests/messageAreaA11y.test.js
+++ b/tests/messageAreaA11y.test.js
@@ -1,0 +1,23 @@
+const { JSDOM } = require('jsdom');
+
+test('SheetSelector showMessage preserves aria-live attribute', () => {
+  const dom = new JSDOM(`<div id="message-area" aria-live="polite" role="status"></div>`);
+  const elements = { messageArea: dom.window.document.getElementById('message-area') };
+  function showMessage(msg, color = 'red') {
+    const colorClasses = { red: 'text-red-600', green: 'text-green-600', blue: 'text-blue-600' };
+    elements.messageArea.className = `mt-4 text-center text-sm h-5 ${colorClasses[color]}`;
+    elements.messageArea.textContent = msg;
+  }
+  showMessage('hello', 'green');
+  expect(elements.messageArea.getAttribute('aria-live')).toBe('polite');
+  expect(elements.messageArea.getAttribute('role')).toBe('status');
+});
+
+test('Unpublished message updates preserve aria-live attribute', () => {
+  const dom = new JSDOM(`<p id="message-area" aria-live="polite" role="status"></p>`);
+  const messageArea = dom.window.document.getElementById('message-area');
+  messageArea.textContent = 'error';
+  messageArea.className = 'mt-4 text-sm h-5 text-red-400';
+  expect(messageArea.getAttribute('aria-live')).toBe('polite');
+  expect(messageArea.getAttribute('role')).toBe('status');
+});


### PR DESCRIPTION
## Summary
- add `aria-live="polite"` and `role="status"` to message-area elements
- verify attributes survive JS updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856549b616c832ba873bd76aaf02f3f