### PR TITLE
Add board setup helpers and auto column guess

### DIFF
--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -232,9 +232,11 @@
         google.script.run
           .withSuccessHandler((headers) => {
             populateHeaderOptions(headers);
+            const guesses = guessHeaders(headers);
+            populateConfig(guesses);
             google.script.run
-              .withSuccessHandler(populateConfig)
-              .withFailureHandler(clearConfigFields)
+              .withSuccessHandler(cfg => populateConfig(Object.assign({}, guesses, cfg)))
+              .withFailureHandler(() => {})
               .getConfig(selectedSheet);
           })
           .withFailureHandler(clearConfigFields)
@@ -252,6 +254,17 @@
             sel.appendChild(opt);
           });
         });
+      }
+
+      function guessHeaders(headers) {
+        const find = (keys) => headers.find(h => keys.some(k => h.includes(k))) || '';
+        return {
+          questionHeader: find(['質問', '問題']),
+          answerHeader: find(['回答', '答え']),
+          reasonHeader: find(['理由']),
+          nameHeader: find(['名前', '氏名']),
+          classHeader: find(['クラス'])
+        };
       }
 
       function populateConfig(cfg) {

--- a/tests/prepareSheetForBoard.test.js
+++ b/tests/prepareSheetForBoard.test.js
@@ -1,0 +1,30 @@
+const { prepareSheetForBoard, COLUMN_HEADERS } = require('../src/Code.gs');
+
+function setup(headers) {
+  const sheet = {
+    getLastColumn: () => headers.length,
+    insertColumnAfter: jest.fn(() => { headers.push(''); }),
+    getRange: jest.fn((row, col) => ({
+      getValues: () => [headers],
+      setValue: (val) => { headers[col - 1] = val; }
+    }))
+  };
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
+  };
+  return { sheet, headers };
+}
+
+afterEach(() => {
+  delete global.SpreadsheetApp;
+});
+
+test('prepareSheetForBoard appends missing reaction columns', () => {
+  const base = [COLUMN_HEADERS.EMAIL, COLUMN_HEADERS.CLASS];
+  const { headers } = setup(base);
+  prepareSheetForBoard('Sheet1');
+  expect(headers).toContain(COLUMN_HEADERS.UNDERSTAND);
+  expect(headers).toContain(COLUMN_HEADERS.LIKE);
+  expect(headers).toContain(COLUMN_HEADERS.CURIOUS);
+  expect(headers).toContain(COLUMN_HEADERS.HIGHLIGHT);
+});

--- a/tests/publishPermissions.test.js
+++ b/tests/publishPermissions.test.js
@@ -7,12 +7,19 @@ function setup(userEmail, adminEmails) {
   };
   global.PropertiesService = { getScriptProperties: () => props };
   global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
+  const sheet = {
+    getLastColumn: () => 2,
+    getRange: () => ({ getValues: () => [['a','b']], setValue: jest.fn() }),
+    insertColumnAfter: jest.fn()
+  };
+  global.SpreadsheetApp = { getActiveSpreadsheet: () => ({ getSheetByName: () => sheet }) };
   return props;
 }
 
 afterEach(() => {
   delete global.PropertiesService;
   delete global.Session;
+  delete global.SpreadsheetApp;
 });
 
 test('publishApp succeeds for admin user', () => {


### PR DESCRIPTION
## Summary
- add prepareSheetForBoard to ensure reaction columns exist
- auto-fill mapping fields in admin sidebar based on common header names
- allow creating template sheets with standard columns
- update publish permissions test mocks
- test new prepareSheetForBoard utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565adea2e8832b920d4b32bd3fb94b