### PR TITLE
Improve config workflow on publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ A separate sheet named `sheet 1` should contain roster information with the colu
 Opening the spreadsheet adds an **アプリ管理** menu. From here you can:
 
 1. **管理パネルを開く** – choose which sheet to publish or unpublish.
+   Use the "Config" section to map the question, answer and name columns. The
+   selected settings are saved automatically when publishing a sheet for the
+   first time.
 2. **名簿キャッシュをリセット** – refresh the cached roster information.
 
 When unpublished, visiting the Web App URL shows a message that the board is closed. Once published, the board is available and updates automatically every 15 seconds.

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -198,14 +198,27 @@
           showMessage('公開するシートを選択してください。', 'red');
           return;
         }
+        const cfg = {
+          questionHeader: elements.qHeader.value,
+          answerHeader: elements.aHeader.value,
+          reasonHeader: elements.rHeader.value,
+          nameMode: elements.nameMode.value,
+          nameHeader: elements.nameHeader.value,
+          classHeader: elements.classHeader.value
+        };
         setLoading(true, "公開処理中...");
         google.script.run
-          .withSuccessHandler((msg) => {
-            showMessage(msg, 'green');
-            loadInitialState();
+          .withSuccessHandler(() => {
+            google.script.run
+              .withSuccessHandler((msg) => {
+                showMessage(msg, 'green');
+                loadInitialState();
+              })
+              .withFailureHandler(showError)
+              .publishApp(selectedSheet);
           })
           .withFailureHandler(showError)
-          .publishApp(selectedSheet);
+          .saveSheetConfig(selectedSheet, cfg);
       }
 
       function unpublish() {


### PR DESCRIPTION
## Summary
- auto-save Config settings when publishing a sheet
- document that Config is saved during publish

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565dad286c832bb3d6fbb8b1b205fb