### PR TITLE
Add Config sheet creation script

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -88,6 +88,7 @@ function onOpen() {
       .addItem('管理パネルを開く', 'showAdminSidebar')
       .addSeparator()
       .addItem('名簿キャッシュをリセット', 'clearRosterCache')
+      .addItem('Configシートを作成', 'createConfigSheet')
       .addToUi();
 }
 
@@ -579,7 +580,7 @@ function createTemplateSheet(name) {
 
 if (typeof module !== 'undefined') {
   const { handleError } = require('./ErrorHandling.gs');
-  const { getConfig, saveSheetConfig } = require('./config.gs');
+  const { getConfig, saveSheetConfig, createConfigSheet } = require('./config.gs');
   module.exports = {
     COLUMN_HEADERS,
     getAdminSettings,
@@ -604,6 +605,7 @@ if (typeof module !== 'undefined') {
     checkAdmin,
     handleError,
     saveSheetConfig,
+    createConfigSheet,
     createTemplateSheet,
     prepareSheetForBoard
   };

--- a/src/config.gs
+++ b/src/config.gs
@@ -52,6 +52,18 @@ function saveSheetConfig(sheetName, cfg) {
   return 'Config saved';
 }
 
+function createConfigSheet() {
+  const ss = SpreadsheetApp.getActive();
+  if (ss.getSheetByName('Config')) {
+    SpreadsheetApp.getUi().alert('Configシートは既に存在します。');
+    return;
+  }
+  const sheet = ss.insertSheet('Config');
+  const headers = ['表示シート名','問題文ヘッダー','回答ヘッダー','理由ヘッダー','名前取得モード','名前列ヘッダー','クラス列ヘッダー'];
+  sheet.appendRow(headers);
+  SpreadsheetApp.getUi().alert('Configシートを作成しました。設定を入力してください。');
+}
+
 if (typeof module !== 'undefined') {
-  module.exports = { getConfig, saveSheetConfig };
+  module.exports = { getConfig, saveSheetConfig, createConfigSheet };
 }


### PR DESCRIPTION
## Summary
- add `createConfigSheet` utility in `config.gs`
- expose `createConfigSheet` for Node tests
- include menu item to call it in `onOpen`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856600cd708832b89f538b1430bb339