### PR TITLE
Fix header mapping for alternate sheets

### DIFF
--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -1,4 +1,10 @@
-const { getSheetData, COLUMN_HEADERS } = require('../src/Code.gs');
+let getSheetData;
+let COLUMN_HEADERS;
+
+beforeEach(() => {
+  jest.resetModules();
+  delete global.getConfig;
+});
 
 function setupMocks(rows, userEmail, adminEmails = '') {
   const rosterHeaders = ['姓', '名', 'ニックネーム', 'Googleアカウント'];
@@ -40,9 +46,11 @@ afterEach(() => {
   delete global.Session;
   delete global.CacheService;
   delete global.PropertiesService;
+  delete global.getConfig;
 });
 
 test('getSheetData filters and scores rows', () => {
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -60,6 +68,8 @@ test('getSheetData filters and scores rows', () => {
   ];
   setupMocks(data, 'b@example.com', 'b@example.com');
 
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+
   const result = getSheetData('Sheet1', undefined, 'score');
 
   expect(result.header).toBe(COLUMN_HEADERS.OPINION);
@@ -71,6 +81,7 @@ test('getSheetData filters and scores rows', () => {
 });
 
 test('getSheetData sorts by newest when specified', () => {
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -86,6 +97,8 @@ test('getSheetData sorts by newest when specified', () => {
     ['second@example.com', '1-1', 'New', 'B', '', '', '', 'false']
   ];
   setupMocks(data, '', '');
+
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
 
   const result = getSheetData('Sheet1', undefined, 'newest');
 
@@ -93,6 +106,7 @@ test('getSheetData sorts by newest when specified', () => {
 });
 
 test('getSheetData supports random sort', () => {
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -108,6 +122,8 @@ test('getSheetData supports random sort', () => {
     ['second@example.com', '1-1', 'New', 'B', '', '', '', 'false']
   ];
   setupMocks(data, '', '');
+
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
 
   const result = getSheetData('Sheet1', undefined, 'random');
 
@@ -116,6 +132,7 @@ test('getSheetData supports random sort', () => {
 });
 
 test('getSheetData omits names for non-admin', () => {
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -131,12 +148,15 @@ test('getSheetData omits names for non-admin', () => {
   ];
   setupMocks(data, 'a@example.com', '');
 
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+
   const result = getSheetData('Sheet1');
 
   expect(result.rows[0].name).toBe('');
 });
 
 test('getSheetData returns names for admin users', () => {
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -152,12 +172,15 @@ test('getSheetData returns names for admin users', () => {
   ];
   setupMocks(data, 'a@example.com', 'a@example.com');
 
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+
   const result = getSheetData('Sheet1');
 
   expect(result.rows[0].name).toBe('A Alice');
 });
 
 test('reaction lists trim spaces and ignore empties', () => {
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -182,6 +205,8 @@ test('reaction lists trim spaces and ignore empties', () => {
   ];
   setupMocks(data, 'a@example.com', 'a@example.com');
 
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+
   const result = getSheetData('Sheet1');
 
   const row = result.rows[0];
@@ -190,4 +215,37 @@ test('reaction lists trim spaces and ignore empties', () => {
   expect(row.reactions.LIKE.count).toBe(1);
   expect(row.reactions.LIKE.reacted).toBe(true);
   expect(row.reactions.CURIOUS.count).toBe(0);
+});
+
+test('getSheetData supports custom headers from config', () => {
+  global.getConfig = () => ({
+    questionHeader: 'Question',
+    answerHeader: 'Ans',
+    reasonHeader: 'Why',
+    nameMode: '同一シート',
+    nameHeader: 'Name',
+    classHeader: 'Class'
+  });
+  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  const data = [
+    [
+      COLUMN_HEADERS.EMAIL,
+      'Class',
+      'Ans',
+      'Why',
+      COLUMN_HEADERS.UNDERSTAND,
+      COLUMN_HEADERS.LIKE,
+      COLUMN_HEADERS.CURIOUS,
+      COLUMN_HEADERS.HIGHLIGHT,
+      'Name'
+    ],
+    ['a@example.com', '1-1', 'Answer1', 'Because', '', '', '', 'false', 'Alice']
+  ];
+  setupMocks(data, 'a@example.com', 'a@example.com');
+
+  const result = getSheetData('Sheet1');
+
+  expect(result.header).toBe('Question');
+  expect(result.rows[0].opinion).toBe('Answer1');
+  expect(result.rows[0].name).toBe('Alice');
 });


### PR DESCRIPTION
## Summary
- support custom column names when reading sheet data
- test getSheetData with configuration for custom headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68566ee3f6f8832baaf57443aec40f78