### PR TITLE
Filter config and roster sheets

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -239,7 +239,11 @@ function getSheets() {
   try {
     const allSheets = SpreadsheetApp.getActiveSpreadsheet().getSheets();
     const visibleSheets = allSheets.filter(sheet => !sheet.isSheetHidden());
-    return visibleSheets.map(sheet => sheet.getName());
+    const filtered = visibleSheets.filter(sheet => {
+      const name = sheet.getName();
+      return name !== 'Config' && name !== ROSTER_CONFIG.SHEET_NAME;
+    });
+    return filtered.map(sheet => sheet.getName());
   } catch (error) {
     handleError('getSheets', error);
   }

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -15,7 +15,9 @@ function setup() {
     getActiveSpreadsheet: () => ({
       getSheets: () => [
         { getName: () => 'SheetA', isSheetHidden: () => false },
-        { getName: () => 'SheetB', isSheetHidden: () => false }
+        { getName: () => 'SheetB', isSheetHidden: () => false },
+        { getName: () => 'Config', isSheetHidden: () => false },
+        { getName: () => 'sheet 1', isSheetHidden: () => false }
       ]
     })
   };


### PR DESCRIPTION
## Summary
- ignore Config and roster sheets when listing sheets
- cover filtering in admin settings test

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856b5f92e54832b950621782fd71fd0