### PR TITLE
Add getWebAppUrl and expose to admin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This repository contains the source code of a Google Apps Script project. It pub
 - `npm run pull` – Download the latest code from Apps Script.
 - `npm run open` – Open the Apps Script project in a browser.
 - `npm run update-url` – Store the latest Web App URL in script properties.
+- Call `getWebAppUrl()` in Apps Script to read the stored URL. The same value is
+  also returned by `getAdminSettings()` for use in the admin panel.
 
 ## Spreadsheet structure
 

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -115,6 +115,7 @@ function getAdminSettings() {
     allSheets: allSheets,
     currentUserEmail: currentUserEmail,
     deployId: props.getProperty('DEPLOY_ID'),
+    webAppUrl: getWebAppUrl(),
     adminEmails: adminEmails,
     isUserAdmin: adminEmails.includes(currentUserEmail),
     isPublished: appSettings.isPublished,
@@ -570,6 +571,11 @@ function saveWebAppUrl(url) {
   props.setProperties({ WEB_APP_URL: (url || '').trim() });
 }
 
+function getWebAppUrl() {
+  const props = PropertiesService.getScriptProperties();
+  return (props.getProperty('WEB_APP_URL') || '').trim();
+}
+
 function saveDeployId(id) {
   const props = PropertiesService.getScriptProperties();
   props.setProperties({ DEPLOY_ID: (id || '').trim() });
@@ -626,6 +632,7 @@ if (typeof module !== 'undefined') {
     toggleHighlight,
     setShowDetails,
     saveWebAppUrl,
+    getWebAppUrl,
     saveDeployId,
     findHeaderIndices,
     parseReactionString,

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -5,6 +5,7 @@ function setup() {
       getProperty: (key) => {
         if (key === 'ADMIN_EMAILS') return 'a@example.com,b@example.com';
         if (key === 'DEPLOY_ID') return 'deploy123';
+        if (key === 'WEB_APP_URL') return 'https://example.com/app';
         if (key === 'IS_PUBLISHED') return 'true';
         if (key === 'ACTIVE_SHEET_NAME') return 'SheetA';
         return null;
@@ -38,6 +39,7 @@ test('getAdminSettings returns board state', () => {
     allSheets: ['SheetA','SheetB'],
     currentUserEmail: 'a@example.com',
     deployId: 'deploy123',
+    webAppUrl: 'https://example.com/app',
     adminEmails: ['a@example.com','b@example.com'],
     isUserAdmin: true,
     isPublished: true,


### PR DESCRIPTION
## Summary
- add `getWebAppUrl` helper to read WEB_APP_URL from script properties
- expose that URL in `getAdminSettings`
- test the new property in admin settings
- document how to read the stored Web App URL

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571e5f565c832bb003e6b8b8140c47