### PR TITLE
Add roster sheet property

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The sheet you publish must contain the following columns:
 - **予想したわけを書きましょう。** – explanation shown when opening a card
 - **いいね！** – comma separated list of users who liked the answer
 
-A separate sheet named `sheet 1` should contain roster information with the columns `姓`, `名`, `ニックネーム` and `Googleアカウント`. These names are shown on the board instead of raw email addresses.
+A separate sheet named `sheet 1` should contain roster information with the columns `姓`, `名`, `ニックネーム` and `Googleアカウント`. These names are shown on the board instead of raw email addresses. If your roster sheet has a different name, set the `ROSTER_SHEET_NAME` script property to override the default.
 
 ## Managing the board
 
@@ -62,6 +62,12 @@ You can also set the value from the console:
 PropertiesService.getScriptProperties()
   .setProperty('ADMIN_EMAILS', 'teacher1@example.com,teacher2@example.com');
 ```
+
+### Setting `ROSTER_SHEET_NAME`
+
+1. Open the Apps Script **Project Settings** and expand **Script Properties**.
+2. Add a property named `ROSTER_SHEET_NAME` and set its value to your roster sheet's name.
+3. Leave it blank or remove it to use the default `sheet 1`.
 
 ## Front‑end features
 

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -18,6 +18,7 @@ const COLUMN_HEADERS = {
 };
 const ROSTER_CONFIG = {
   SHEET_NAME: 'sheet 1',
+  PROPERTY_NAME: 'ROSTER_SHEET_NAME',
   CACHE_KEY: 'roster_name_map_v3',
   HEADER_LAST_NAME: '姓',
   HEADER_FIRST_NAME: '名',
@@ -473,15 +474,19 @@ function getRosterMap() {
   const cache = CacheService.getScriptCache();
   const cachedMap = cache.get(ROSTER_CONFIG.CACHE_KEY);
   if (cachedMap) { return JSON.parse(cachedMap); }
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(ROSTER_CONFIG.SHEET_NAME);
-  if (!sheet) { console.error(`名簿シート「${ROSTER_CONFIG.SHEET_NAME}」が見つかりません。`); return {}; }
+  const props = PropertiesService.getScriptProperties();
+  const rosterSheetName = props && typeof props.getProperty === 'function'
+    ? (props.getProperty(ROSTER_CONFIG.PROPERTY_NAME) || ROSTER_CONFIG.SHEET_NAME)
+    : ROSTER_CONFIG.SHEET_NAME;
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(rosterSheetName);
+  if (!sheet) { console.error(`名簿シート「${rosterSheetName}」が見つかりません。`); return {}; }
   const rosterValues = sheet.getDataRange().getValues();
   const rosterHeaders = rosterValues.shift();
   const lastNameIndex = rosterHeaders.indexOf(ROSTER_CONFIG.HEADER_LAST_NAME);
   const firstNameIndex = rosterHeaders.indexOf(ROSTER_CONFIG.HEADER_FIRST_NAME);
   const nicknameIndex = rosterHeaders.indexOf(ROSTER_CONFIG.HEADER_NICKNAME);
   const emailIndex = rosterHeaders.indexOf(ROSTER_CONFIG.HEADER_EMAIL);
-  if (lastNameIndex === -1 || firstNameIndex === -1 || emailIndex === -1) { throw new Error(`名簿シート「${ROSTER_CONFIG.SHEET_NAME}」に必要な列が見つかりません。`); }
+  if (lastNameIndex === -1 || firstNameIndex === -1 || emailIndex === -1) { throw new Error(`名簿シート「${rosterSheetName}」に必要な列が見つかりません。`); }
   const nameMap = {};
   rosterValues.forEach(row => {
     const email = row[emailIndex];

--- a/tests/buildBoardData.test.js
+++ b/tests/buildBoardData.test.js
@@ -19,6 +19,9 @@ function setup({configRows, dataRows, rosterRows}) {
     })
   };
   global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null, remove: () => null }) };
+  global.PropertiesService = {
+    getScriptProperties: () => ({ getProperty: () => null })
+  };
   global.getConfig = (sheetName) => {
     const row = configRows.find((r, idx) => idx > 0 && r[0] === sheetName);
     if (!row) throw new Error('missing');
@@ -41,6 +44,7 @@ function setup({configRows, dataRows, rosterRows}) {
 afterEach(() => {
   delete global.SpreadsheetApp;
   delete global.CacheService;
+  delete global.PropertiesService;
   delete global.getConfig;
   delete global.getRosterMap;
 });

--- a/tests/getRosterMap.test.js
+++ b/tests/getRosterMap.test.js
@@ -25,12 +25,16 @@ function setupMocks(cacheValue) {
       getSheetByName: jest.fn(() => sheet)
     })
   };
+  global.PropertiesService = {
+    getScriptProperties: () => ({ getProperty: () => null })
+  };
   return { sheet, cache: cacheObj };
 }
 
 afterEach(() => {
   delete global.CacheService;
   delete global.SpreadsheetApp;
+  delete global.PropertiesService;
 });
 
 test('getRosterMap builds map and caches it', () => {
@@ -60,5 +64,20 @@ test('getRosterMap returns cached map when available', () => {
   expect(result).toEqual(cached);
   expect(sheetCall).not.toHaveBeenCalled();
   expect(cache.put).not.toHaveBeenCalled();
+});
+
+test('getRosterMap uses ROSTER_SHEET_NAME property when set', () => {
+  const { sheet } = setupMocks(null);
+  const spy = jest.fn(() => sheet);
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({ getSheetByName: spy })
+  };
+  global.PropertiesService = {
+    getScriptProperties: () => ({ getProperty: () => 'RosterSheet' })
+  };
+
+  getRosterMap();
+
+  expect(spy).toHaveBeenCalledWith('RosterSheet');
 });
 


### PR DESCRIPTION
## Summary
- support custom roster sheet name via `ROSTER_SHEET_NAME` script property
- document new property
- test property behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857225558cc832bb237cea2147bb6d5