### PR TITLE
Update roster sheet and admin menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The sheet you publish must contain the following columns:
 - **予想したわけを書きましょう。** – explanation shown when opening a card
 - **いいね！** – comma separated list of users who liked the answer
 
-A separate sheet named `sheet 1` should contain roster information with the columns `姓`, `名`, `ニックネーム` and `Googleアカウント`. These names are shown on the board instead of raw email addresses. If your roster sheet has a different name, set the `ROSTER_SHEET_NAME` script property to override the default.
+A separate sheet named `roster` should contain roster information with the columns `学年`, `組`, `番号`, `姓`, `名`, `Googleアカウント`, `ニックネーム`. These names are shown on the board instead of raw email addresses. If your roster sheet has a different name, set the `ROSTER_SHEET_NAME` script property to override the default.
 
 ## Managing the board
 
@@ -67,7 +67,7 @@ PropertiesService.getScriptProperties()
 
 1. Open the Apps Script **Project Settings** and expand **Script Properties**.
 2. Add a property named `ROSTER_SHEET_NAME` and set its value to your roster sheet's name.
-3. Leave it blank or remove it to use the default `sheet 1`.
+3. Leave it blank or remove it to use the default `roster`.
 
 ## Front‑end features
 

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -17,7 +17,7 @@ const COLUMN_HEADERS = {
   HIGHLIGHT: 'ハイライト'
 };
 const ROSTER_CONFIG = {
-  SHEET_NAME: 'sheet 1',
+  SHEET_NAME: 'roster',
   PROPERTY_NAME: 'ROSTER_SHEET_NAME',
   CACHE_KEY: 'roster_name_map_v3',
   HEADER_LAST_NAME: '姓',
@@ -89,7 +89,7 @@ function onOpen() {
       .addItem('管理パネルを開く', 'showAdminSidebar')
       .addSeparator()
       .addItem('名簿キャッシュをリセット', 'clearRosterCache')
-      .addItem('Configシートを作成', 'createConfigSheet')
+      .addItem('設定シートを追加', 'createConfigSheet')
       .addToUi();
 }
 

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -30,7 +30,7 @@
       <!-- Sheet Selection -->
       <div class="mb-6">
         <h3 class="font-semibold mb-3">1. 公開するシートを選択</h3>
-        <select id="sheet-select" class="w-full p-2 rounded-lg glass-panel text-gray-900">
+        <select id="sheet-select" class="w-full p-2 rounded-lg glass-panel text-white">
           <option>読み込み中...</option>
         </select>
       </div>

--- a/src/config.gs
+++ b/src/config.gs
@@ -54,14 +54,27 @@ function saveSheetConfig(sheetName, cfg) {
 
 function createConfigSheet() {
   const ss = SpreadsheetApp.getActive();
-  if (ss.getSheetByName('Config')) {
-    SpreadsheetApp.getUi().alert('Configシートは既に存在します。');
-    return;
+  const created = [];
+  let cfgSheet = ss.getSheetByName('Config');
+  if (!cfgSheet) {
+    cfgSheet = ss.insertSheet('Config');
+    const headers = ['表示シート名','問題文ヘッダー','回答ヘッダー','理由ヘッダー','名前取得モード','名前列ヘッダー','クラス列ヘッダー'];
+    cfgSheet.appendRow(headers);
+    created.push('Config');
   }
-  const sheet = ss.insertSheet('Config');
-  const headers = ['表示シート名','問題文ヘッダー','回答ヘッダー','理由ヘッダー','名前取得モード','名前列ヘッダー','クラス列ヘッダー'];
-  sheet.appendRow(headers);
-  SpreadsheetApp.getUi().alert('Configシートを作成しました。設定を入力してください。');
+  const rosterName = typeof ROSTER_CONFIG !== 'undefined' ? ROSTER_CONFIG.SHEET_NAME : 'roster';
+  let rosterSheet = ss.getSheetByName(rosterName);
+  if (!rosterSheet) {
+    rosterSheet = ss.insertSheet(rosterName);
+    const rosterHeaders = ['学年','組','番号','姓','名','Googleアカウント','ニックネーム'];
+    rosterSheet.appendRow(rosterHeaders);
+    created.push(rosterName);
+  }
+  if (created.length) {
+    SpreadsheetApp.getUi().alert(`${created.join('と')}シートを作成しました。設定を入力してください。`);
+  } else {
+    SpreadsheetApp.getUi().alert('ConfigシートとRosterシートは既に存在します。');
+  }
 }
 
 if (typeof module !== 'undefined') {

--- a/tests/buildBoardData.test.js
+++ b/tests/buildBoardData.test.js
@@ -11,7 +11,7 @@ function setup({configRows, dataRows, rosterRows}) {
         if (name === 'Sheet1') {
           return { getDataRange: () => ({ getValues: () => dataRows }) };
         }
-        if (name === 'sheet 1') {
+        if (name === 'roster') {
           return { getDataRange: () => ({ getValues: () => rosterRows }) };
         }
         return null;

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -17,7 +17,7 @@ function setup() {
         { getName: () => 'SheetA', isSheetHidden: () => false },
         { getName: () => 'SheetB', isSheetHidden: () => false },
         { getName: () => 'Config', isSheetHidden: () => false },
-        { getName: () => 'sheet 1', isSheetHidden: () => false }
+        { getName: () => 'roster', isSheetHidden: () => false }
       ]
     })
   };

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -20,7 +20,7 @@ function setupMocks(rows, userEmail, adminEmails = '') {
         if (name === 'Sheet1') {
           return { getDataRange: () => ({ getValues: () => rows }) };
         }
-        if (name === 'sheet 1') {
+        if (name === 'roster') {
           return { getDataRange: () => ({ getValues: () => [rosterHeaders, ...rosterRows] }) };
         }
         return null;


### PR DESCRIPTION
## Summary
- adjust sheet selector text color for dark mode
- rename roster sheet from `sheet 1` to `roster`
- create roster sheet when creating config sheet
- rename custom menu item
- update tests and docs

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685725b72634832b93298feec5d954ef