### PR TITLE
Fix handleError duplication

### DIFF
--- a/src/admin.gs
+++ b/src/admin.gs
@@ -1,4 +1,8 @@
-const { handleError } = require('./ErrorHandling.gs');
+// In the Apps Script environment, handleError is defined globally.
+// When running tests in Node, import it from the module.
+if (typeof module !== 'undefined') {
+  var handleError = require('./ErrorHandling.gs').handleError;
+}
 
 function safeGetUserEmail() {
   try {

--- a/src/reactions.gs
+++ b/src/reactions.gs
@@ -1,5 +1,8 @@
 const admin = require('./admin.gs');
-const { handleError } = require('./ErrorHandling.gs');
+// Use global handleError in Apps Script; import for Node tests
+if (typeof module !== 'undefined') {
+  var handleError = require('./ErrorHandling.gs').handleError;
+}
 const REACTION_KEYS = ['UNDERSTAND','LIKE','CURIOUS'];
 
 function parseReactionString(val) {


### PR DESCRIPTION
## Summary
- avoid redeclaring `handleError` in admin and reactions files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685767db2e00832b96ac235a8646ed94