### PR TITLE
Fix duplicate reaction constant

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -38,7 +38,6 @@ const TIME_CONSTANTS = {
   LOCK_WAIT_MS: 10000
 };
 
-const REACTION_KEYS = ["UNDERSTAND","LIKE","CURIOUS"];
 var safeGetUserEmail, getAdminEmails, isUserAdmin, checkAdmin;
 var getAdminSettings, publishApp, unpublishApp, setShowDetails;
 var getSheets, getAppSettings;


### PR DESCRIPTION
## Summary
- remove unused `REACTION_KEYS` constant from `Code.gs`

## Testing
- `npm test` *(fails: APP_PROPERTIES is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68576c3c73ec832b9ba177f44ba334d9