### PR TITLE
Handle reaction delay and export constants

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -38,6 +38,14 @@ const TIME_CONSTANTS = {
   LOCK_WAIT_MS: 10000
 };
 
+if (typeof global !== 'undefined') {
+  global.COLUMN_HEADERS = COLUMN_HEADERS;
+  global.ROSTER_CONFIG = ROSTER_CONFIG;
+  global.SCORING_CONFIG = SCORING_CONFIG;
+  global.APP_PROPERTIES = APP_PROPERTIES;
+  global.TIME_CONSTANTS = TIME_CONSTANTS;
+}
+
 var safeGetUserEmail, getAdminEmails, isUserAdmin, checkAdmin;
 var getAdminSettings, publishApp, unpublishApp, setShowDetails;
 var getSheets, getAppSettings;

--- a/src/Page.html
+++ b/src/Page.html
@@ -241,6 +241,7 @@
     /* いいねボタンのSVGトランジション */
     .like-btn svg { transition: all 0.2s ease-in-out; fill: none; }
     .like-btn.liked svg { stroke: transparent; fill: currentColor; transform: scale(1.1); }
+    .reaction-btn:disabled { opacity: 0.5; pointer-events: none; }
     /* ハイライトボタンのスタイル */
     .highlight-btn {
       transition: all 0.2s ease;
@@ -1295,7 +1296,8 @@
        */
       async handleReaction(rowIndex, reaction) {
         // リアクションボタンのアニメーション
-        const btns = document.querySelectorAll('[data-row-index="' + rowIndex + '"][data-reaction="' + reaction + '"]');
+        const btns = document.querySelectorAll('[data-row-index="' + rowIndex + '"][data-reaction]');
+        btns.forEach(b => b.disabled = true);
         if (typeof gsap !== 'undefined') {
           btns.forEach(btn => {
             gsap.fromTo(btn,
@@ -1320,6 +1322,8 @@
           }
         } catch (error) {
           console.error('Failed to add reaction:', error);
+        } finally {
+          btns.forEach(b => b.disabled = false);
         }
       }
 

--- a/src/reactions.gs
+++ b/src/reactions.gs
@@ -64,6 +64,9 @@ function addReaction(rowIndex, reactionKey) {
     reactionRange.setValues([
       REACTION_KEYS.map(k => lists[k].arr.join(','))
     ]);
+    if (typeof SpreadsheetApp !== 'undefined' && typeof SpreadsheetApp.flush === 'function') {
+      SpreadsheetApp.flush();
+    }
 
     const reactions = REACTION_KEYS.reduce((obj, k) => {
       obj[k] = {


### PR DESCRIPTION
## Summary
- expose constants globally when running tests
- ensure Apps Script calls flush when possible
- disable reaction buttons until the server response is received

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857732f7f18832bba9aca28c0c7614c