### PR TITLE
Fix reaction row handling

### DIFF
--- a/src/reactions.gs
+++ b/src/reactions.gs
@@ -24,6 +24,7 @@ function parseReactionString(val) {
 }
 
 function addReaction(rowIndex, reactionKey) {
+  rowIndex = Number(rowIndex);
   if (typeof module !== 'undefined') {
     var { COLUMN_HEADERS, getHeaderIndices, TIME_CONSTANTS } = require('./Code.gs');
   }
@@ -84,6 +85,7 @@ function addReaction(rowIndex, reactionKey) {
 }
 
 function toggleHighlight(rowIndex) {
+  rowIndex = Number(rowIndex);
   if (typeof module !== 'undefined') {
     var { COLUMN_HEADERS, getHeaderIndices, TIME_CONSTANTS } = require('./Code.gs');
   }


### PR DESCRIPTION
## Summary
- ensure row index values are converted to numbers before updating reaction columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68577a7a7ce4832b961b7139e91cc4aa