### PR TITLE
Implement admin menu and remove roster cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Opening the spreadsheet adds an **アプリ管理** menu. From here you can:
    Use the "Config" section to map the question, answer and name columns. The
    selected settings are saved automatically when publishing a sheet for the
    first time.
-2. **名簿キャッシュをリセット** – refresh the cached roster information.
 
 When unpublished, visiting the Web App URL shows a message that the board is closed. Once published, the board is available and updates automatically every 15 seconds.
 

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -19,7 +19,6 @@ const COLUMN_HEADERS = {
 const ROSTER_CONFIG = {
   SHEET_NAME: 'roster',
   PROPERTY_NAME: 'ROSTER_SHEET_NAME',
-  CACHE_KEY: 'roster_name_map_v3',
   HEADER_LAST_NAME: '姓',
   HEADER_FIRST_NAME: '名',
   HEADER_NICKNAME: 'ニックネーム',
@@ -64,6 +63,20 @@ if (typeof global !== 'undefined' && global.getConfig) {
 /**
  * スプレッドシートを開いた時に「アプリ管理」メニューを追加します。
  */
+function onOpen() {
+  SpreadsheetApp.getUi()
+    .createMenu('アプリ管理')
+    .addItem('管理パネルを開く', 'showAdminDialog')
+    .addToUi();
+}
+
+function showAdminDialog() {
+  const html = HtmlService
+    .createTemplateFromFile('SheetSelector')
+    .evaluate()
+    .setTitle('管理パネル');
+  SpreadsheetApp.getUi().showSidebar(html);
+}
 
 /**
  * 管理パネルの初期化に必要なデータを取得します。
@@ -264,9 +277,6 @@ function buildBoardData(sheetName) {
 
 
 function getRosterMap() {
-  const cache = CacheService.getScriptCache();
-  const cachedMap = cache.get(ROSTER_CONFIG.CACHE_KEY);
-  if (cachedMap) { return JSON.parse(cachedMap); }
   const props = PropertiesService.getScriptProperties();
   const rosterSheetName = props && typeof props.getProperty === 'function'
     ? (props.getProperty(ROSTER_CONFIG.PROPERTY_NAME) || ROSTER_CONFIG.SHEET_NAME)
@@ -291,7 +301,6 @@ function getRosterMap() {
       nameMap[email] = nickname ? `${fullName} (${nickname})` : fullName;
     }
   });
-  cache.put(ROSTER_CONFIG.CACHE_KEY, JSON.stringify(nameMap), 21600);
   return nameMap;
 }
 
@@ -344,15 +353,6 @@ function findHeaderIndices(sheetHeaders, requiredHeaders) {
   return indices;
 }
 
-function clearRosterCache() {
-  const cache = CacheService.getScriptCache();
-  const cacheKey = ROSTER_CONFIG.CACHE_KEY;
-  cache.remove(cacheKey);
-  console.log(`名簿キャッシュ（キー: ${cacheKey}）を削除しました。`);
-  try {
-    SpreadsheetApp.getUi().alert('名簿のキャッシュをリセットしました。');
-  } catch (e) { /* no-op */ }
-}
 
 
 function createTemplateSheet(name) {

--- a/tests/getRosterMap.test.js
+++ b/tests/getRosterMap.test.js
@@ -11,15 +11,8 @@ function buildSheet() {
   };
 }
 
-function setupMocks(cacheValue) {
+function setupMocks() {
   const sheet = buildSheet();
-  const cacheObj = {
-    get: jest.fn(() => cacheValue),
-    put: jest.fn()
-  };
-  global.CacheService = {
-    getScriptCache: () => cacheObj
-  };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({
       getSheetByName: jest.fn(() => sheet)
@@ -28,17 +21,16 @@ function setupMocks(cacheValue) {
   global.PropertiesService = {
     getScriptProperties: () => ({ getProperty: () => null })
   };
-  return { sheet, cache: cacheObj };
+  return { sheet };
 }
 
 afterEach(() => {
-  delete global.CacheService;
   delete global.SpreadsheetApp;
   delete global.PropertiesService;
 });
 
-test('getRosterMap builds map and caches it', () => {
-  const { sheet, cache } = setupMocks(null);
+test('getRosterMap builds map from sheet', () => {
+  const { sheet } = setupMocks();
 
   const result = getRosterMap();
 
@@ -47,27 +39,10 @@ test('getRosterMap builds map and caches it', () => {
     'b@example.com': 'B Bob (Bobby)'
   });
   expect(sheet.getDataRange).toBeDefined();
-  expect(cache.put).toHaveBeenCalledWith(
-    'roster_name_map_v3',
-    JSON.stringify(result),
-    21600
-  );
-});
-
-test('getRosterMap returns cached map when available', () => {
-  const cached = { 'x@example.com': 'X X' };
-  const { cache } = setupMocks(JSON.stringify(cached));
-  const sheetCall = SpreadsheetApp.getActiveSpreadsheet().getSheetByName;
-
-  const result = getRosterMap();
-
-  expect(result).toEqual(cached);
-  expect(sheetCall).not.toHaveBeenCalled();
-  expect(cache.put).not.toHaveBeenCalled();
 });
 
 test('getRosterMap uses ROSTER_SHEET_NAME property when set', () => {
-  const { sheet } = setupMocks(null);
+  const { sheet } = setupMocks();
   const spy = jest.fn(() => sheet);
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({ getSheetByName: spy })


### PR DESCRIPTION
## Summary
- add `onOpen` custom menu with admin sidebar
- delete roster cache logic
- adjust README to mention only the admin panel
- update tests to reflect removal of caching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68577ef13434832bae46ee25a6d3a19a