### PR TITLE
Add menu item for config and roster sheets

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -67,6 +67,7 @@ function onOpen() {
   SpreadsheetApp.getUi()
     .createMenu('アプリ管理')
     .addItem('管理パネルを開く', 'showAdminDialog')
+    .addItem('Config/Rosterシート作成', 'createConfigSheet')
     .addToUi();
 }
 


### PR DESCRIPTION
## Summary
- create a menu option for generating Config and roster sheets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68578088cc6c832ba050f53885d8b1b6