### PR TITLE
Fix reaction persistence

### DIFF
--- a/src/reactions.gs
+++ b/src/reactions.gs
@@ -44,14 +44,12 @@ function addReaction(rowIndex, reactionKey) {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(settings.activeSheetName);
     if (!sheet) throw new Error(`シート '${settings.activeSheetName}' が見つかりません。`);
 
-    const reactionHeaders = REACTION_KEYS.map(k => COLUMN_HEADERS[k]);
     const headerIndices = getHeaderIndices(settings.activeSheetName);
-    const startCol = headerIndices[reactionHeaders[0]] + 1;
-    const reactionRange = sheet.getRange(rowIndex, startCol, 1, REACTION_KEYS.length);
-    const values = reactionRange.getValues()[0];
     const lists = {};
-    REACTION_KEYS.forEach((k, idx) => {
-      lists[k] = { arr: parseReactionString(values[idx]) };
+    REACTION_KEYS.forEach(k => {
+      const col = headerIndices[COLUMN_HEADERS[k]] + 1;
+      const val = sheet.getRange(rowIndex, col).getValue();
+      lists[k] = { arr: parseReactionString(val), col: col };
     });
 
     const wasReacted = lists[reactionKey].arr.includes(userEmail);
@@ -62,9 +60,9 @@ function addReaction(rowIndex, reactionKey) {
     if (!wasReacted) {
       lists[reactionKey].arr.push(userEmail);
     }
-    reactionRange.setValues([
-      REACTION_KEYS.map(k => lists[k].arr.join(','))
-    ]);
+    REACTION_KEYS.forEach(k => {
+      sheet.getRange(rowIndex, lists[k].col).setValue(lists[k].arr.join(','));
+    });
     if (typeof SpreadsheetApp !== 'undefined' && typeof SpreadsheetApp.flush === 'function') {
       SpreadsheetApp.flush();
     }

--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -19,16 +19,22 @@ function buildSheet() {
   return {
     getLastColumn: () => headerRow.length,
     getRange: jest.fn((row, col, numRows, numCols) => {
-      if (row === 1) {
-        return { getValues: () => [headerRow] };
+      if (row === 1 && col === 1) {
+        const len = numCols || headerRow.length;
+        return { getValues: () => [headerRow.slice(0, len)] };
+      }
+      const header = headerRow[col - 1];
+      if (numRows === 1 && numCols === 1 || numRows === undefined) {
+        return {
+          getValue: () => values[Object.keys(COLUMN_HEADERS).find(k => COLUMN_HEADERS[k] === header)] || '',
+          setValue: (val) => {
+            const key = Object.keys(COLUMN_HEADERS).find(k => COLUMN_HEADERS[k] === header);
+            values[key] = val;
+          }
+        };
       }
       const headers = headerRow.slice(col - 1, col - 1 + numCols);
       return {
-        getValue: () => values[Object.keys(COLUMN_HEADERS).find(k => COLUMN_HEADERS[k] === headers[0])] || '',
-        setValue: (val) => {
-          const key = Object.keys(COLUMN_HEADERS).find(k => COLUMN_HEADERS[k] === headers[0]);
-          values[key] = val;
-        },
         getValues: () => [headers.map(h => {
           const key = Object.keys(COLUMN_HEADERS).find(k => COLUMN_HEADERS[k] === h);
           return values[key] || '';


### PR DESCRIPTION
## Summary
- allow addReaction to update individual reaction columns regardless of order
- adjust tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68578b116d4c832bba6c17bff80d2e65