### PR TITLE
Fix preview mode detection

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -62,10 +62,13 @@
     // プレビューモード検出とモード設定
     const ModeManager = {
       isPreviewMode() {
-        return window.location.protocol === 'file:' || 
-               window.location.hostname === 'localhost' || 
-               window.location.pathname.includes('preview') ||
-               window.location.href.includes('preview');
+        if (typeof google !== 'undefined' && google.script && google.script.run) {
+          return false; // GAS 環境では常に本番モード
+        }
+        const url = new URL(window.location.href);
+        return window.location.protocol === 'file:' ||
+               window.location.hostname === 'localhost' ||
+               url.searchParams.has('preview');
       },
       
       applyMode(modeConfig) {


### PR DESCRIPTION
## Summary
- refine `isPreviewMode` so it doesn't trigger when running inside the GAS runtime
- detect preview mode with `?preview` query parameter rather than any URL containing "preview"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685790099bd8832b9feb4c601a0eb901