### PR TITLE
Fix missing GAS vars when opening HTML locally

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -92,10 +92,17 @@
     ModeManager.initializeMode();
   </script>
   <script>
-    window.showCounts = <?= showCounts ?>;
-    window.displayMode = '<?= displayMode ?>';
-    const SHEET_NAME = '<?= sheetName ?>';
-    const MAPPING = <?= JSON.stringify(mapping) ?>;
+    try {
+      window.showCounts = JSON.parse('<?= showCounts ?>');
+      window.displayMode = JSON.parse('<?= JSON.stringify(displayMode) ?>');
+      window.sheetName = JSON.parse('<?= JSON.stringify(sheetName) ?>');
+      window.mapping = JSON.parse('<?= JSON.stringify(mapping) ?>');
+    } catch (e) {
+      window.showCounts = false;
+      window.displayMode = 'anonymous';
+      window.sheetName = '';
+      window.mapping = {};
+    }
   </script>
   <style>
     /* カスタムプロパティ（CSS変数）定義 */


### PR DESCRIPTION
## Summary
- avoid syntax errors when `Page.html` is opened outside GAS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857b9be83dc832b90da6b50cde2e4f6