### PR TITLE
Allow specifying sheet name for reactions

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -367,7 +367,7 @@ function buildBoardData(sheetName) {
   return { header: cfg.questionHeader, entries };
 }
 
-function addReaction(rowIndex, reactionKey) {
+function addReaction(rowIndex, reactionKey, sheetName) {
   if (!rowIndex || !reactionKey || !COLUMN_HEADERS[reactionKey]) {
     return { status: 'error', message: '無効なパラメータです。' };
   }
@@ -381,11 +381,12 @@ function addReaction(rowIndex, reactionKey) {
       return { status: 'error', message: 'ログインしていないため、操作できません。' };
     }
     const settings = getAppSettings();
-    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(settings.activeSheetName);
-    if (!sheet) throw new Error(`シート '${settings.activeSheetName}' が見つかりません。`);
+    const targetSheet = sheetName || settings.activeSheetName;
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(targetSheet);
+    if (!sheet) throw new Error(`シート '${targetSheet}' が見つかりません。`);
 
   const reactionHeaders = REACTION_KEYS.map(k => COLUMN_HEADERS[k]);
-  const headerIndices = getHeaderIndices(settings.activeSheetName);
+  const headerIndices = getHeaderIndices(targetSheet);
   const startCol = headerIndices[reactionHeaders[0]] + 1;
   const reactionRange = sheet.getRange(rowIndex, startCol, 1, REACTION_KEYS.length);
   const values = reactionRange.getValues()[0];
@@ -421,18 +422,19 @@ function addReaction(rowIndex, reactionKey) {
   }
 }
 
-function toggleHighlight(rowIndex) {
+function toggleHighlight(rowIndex, sheetName) {
   if (!checkAdmin()) {
     return { status: 'error', message: '権限がありません。' };
   }
   const lock = LockService.getScriptLock();
   lock.waitLock(TIME_CONSTANTS.LOCK_WAIT_MS);
   try {
-    const sheetName = getAppSettings().activeSheetName;
-    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
-    if (!sheet) throw new Error(`シート '${sheetName}' が見つかりません。`);
+    const settings = getAppSettings();
+    const targetSheet = sheetName || settings.activeSheetName;
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(targetSheet);
+    if (!sheet) throw new Error(`シート '${targetSheet}' が見つかりません。`);
 
-    const headerIndices = getHeaderIndices(sheetName);
+    const headerIndices = getHeaderIndices(targetSheet);
     const colIndex = headerIndices[COLUMN_HEADERS.HIGHLIGHT] + 1;
 
     const cell = sheet.getRange(rowIndex, colIndex);

--- a/src/Page.html
+++ b/src/Page.html
@@ -443,9 +443,9 @@
         // Google Apps Script関数へのラッパー
         this.gas = {
           getPublishedSheetData: (classFilter, sort) => this.runGas('getPublishedSheetData', classFilter, sort),
-          addLike: (rowIndex) => this.runGas('addReaction', rowIndex, 'LIKE'),
-          addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction),
-          toggleHighlight: (rowIndex) => this.runGas('toggleHighlight', rowIndex),
+          addLike: (rowIndex) => this.runGas('addReaction', rowIndex, 'LIKE', SHEET_NAME),
+          addReaction: (rowIndex, reaction) => this.runGas('addReaction', rowIndex, reaction, SHEET_NAME),
+          toggleHighlight: (rowIndex, current) => this.runGas('toggleHighlight', rowIndex, SHEET_NAME, current),
           checkAdmin: () => this.runGas('checkAdmin')
         };
         
@@ -853,7 +853,7 @@
               });
             } else if (funcName === 'toggleHighlight') {
               // ハイライトトグルのモック
-              const currentHighlight = args[1] === undefined ? false : !args[1]; // 現在のハイライト状態を反転させる
+              const currentHighlight = args[2] === undefined ? (args[1] === undefined ? false : !args[1]) : !args[2];
               resolve({
                 status: 'ok',
                 highlight: currentHighlight

--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -72,12 +72,12 @@ test('addReaction toggles user in list', () => {
   const sheet = buildSheet();
   setupMocks('b@example.com', sheet);
 
-  const result1 = addReaction(2, 'UNDERSTAND');
+  const result1 = addReaction(2, 'UNDERSTAND', 'Sheet1');
   expect(result1.status).toBe('ok');
   expect(result1.reactions.UNDERSTAND.count).toBe(2);
   expect(result1.reactions.UNDERSTAND.reacted).toBe(true);
 
-  const result2 = addReaction(2, 'UNDERSTAND');
+  const result2 = addReaction(2, 'UNDERSTAND', 'Sheet1');
   expect(result2.status).toBe('ok');
   expect(result2.reactions.UNDERSTAND.count).toBe(1);
   expect(result2.reactions.UNDERSTAND.reacted).toBe(false);
@@ -87,13 +87,13 @@ test('addReaction switches reaction columns', () => {
   const sheet = buildSheet();
   setupMocks('c@example.com', sheet);
 
-  const res1 = addReaction(2, 'LIKE');
+  const res1 = addReaction(2, 'LIKE', 'Sheet1');
   expect(res1.status).toBe('ok');
   expect(sheet.values.LIKE).toBe('c@example.com');
   expect(sheet.values.UNDERSTAND).toBe('a@example.com');
   expect(res1.reactions.LIKE.reacted).toBe(true);
 
-  const res2 = addReaction(2, 'CURIOUS');
+  const res2 = addReaction(2, 'CURIOUS', 'Sheet1');
   expect(res2.status).toBe('ok');
   expect(sheet.values.LIKE).toBe('');
   expect(sheet.values.CURIOUS).toBe('c@example.com');
@@ -105,7 +105,7 @@ test('addReaction errors when user email is empty', () => {
   const sheet = buildSheet();
   setupMocks('', sheet);
 
-  const result = addReaction(2, 'UNDERSTAND');
+  const result = addReaction(2, 'UNDERSTAND', 'Sheet1');
   expect(result.status).toBe('error');
 });
 
@@ -118,8 +118,8 @@ test('addReaction reads headers only once with cache', () => {
   };
   setupMocks('cache@example.com', sheet, cache);
 
-  addReaction(2, 'LIKE');
-  addReaction(2, 'LIKE');
+  addReaction(2, 'LIKE', 'Sheet1');
+  addReaction(2, 'LIKE', 'Sheet1');
 
   const headerCalls = sheet.getRange.mock.calls.filter(c => c[0] === 1).length;
   expect(headerCalls).toBe(1);

--- a/tests/addLikeColumn.test.js
+++ b/tests/addLikeColumn.test.js
@@ -63,7 +63,7 @@ afterEach(() => {
 test('addReaction updates value in LIKE column', () => {
   const sheet = buildSheet();
   setupMocks('like@example.com', sheet);
-  const result = addReaction(2, 'LIKE');
+  const result = addReaction(2, 'LIKE', 'Sheet1');
   expect(result.status).toBe('ok');
   expect(sheet.getRange.mock.calls[1][0]).toBe(2);
   expect(sheet.getRange.mock.calls[1][1]).toBe(6);
@@ -81,6 +81,6 @@ test('addReaction handles failure to get user email', () => {
       getSheets: () => [sheet]
     })
   };
-  const result = addReaction(2, 'LIKE');
+  const result = addReaction(2, 'LIKE', 'Sheet1');
   expect(result.status).toBe('error');
 });

--- a/tests/toggleHighlight.test.js
+++ b/tests/toggleHighlight.test.js
@@ -55,10 +55,10 @@ test('toggleHighlight flips stored value', () => {
   const sheet = buildSheet();
   setupMocks(sheet);
 
-  const result1 = toggleHighlight(2);
+  const result1 = toggleHighlight(2, 'Sheet1');
   expect(result1).toEqual({ status: 'ok', highlight: true });
 
-  const result2 = toggleHighlight(2);
+  const result2 = toggleHighlight(2, 'Sheet1');
   expect(result2).toEqual({ status: 'ok', highlight: false });
 });
 
@@ -71,8 +71,8 @@ test('toggleHighlight reads headers only once with cache', () => {
   };
   setupMocks(sheet, cache);
 
-  toggleHighlight(2);
-  toggleHighlight(2);
+  toggleHighlight(2, 'Sheet1');
+  toggleHighlight(2, 'Sheet1');
 
   const headerCalls = sheet.getRange.mock.calls.filter(c => c[0] === 1).length;
   expect(headerCalls).toBe(1);
@@ -81,6 +81,6 @@ test('toggleHighlight reads headers only once with cache', () => {
 test('toggleHighlight returns error for non-admin user', () => {
   const sheet = buildSheet();
   setupMocks(sheet, null, 'user@example.com', 'admin@example.com');
-  const result = toggleHighlight(2);
+  const result = toggleHighlight(2, 'Sheet1');
   expect(result.status).toBe('error');
 });


### PR DESCRIPTION
## Summary
- allow `addReaction` and `toggleHighlight` to target a specific sheet
- include sheet name when calling these functions from the front end
- update development mock and tests for the new parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857e593f8e0832b9b9c43d202f2e3c1