### PR TITLE
Limit header validation to reaction columns

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -518,7 +518,12 @@ function getHeaderIndices(sheetName) {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
   if (!sheet) throw new Error(`シート '${sheetName}' が見つかりません。`);
   const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-  const indices = findHeaderIndices(headerRow, Object.values(COLUMN_HEADERS));
+  const indices = findHeaderIndices(headerRow, [
+    COLUMN_HEADERS.UNDERSTAND,
+    COLUMN_HEADERS.LIKE,
+    COLUMN_HEADERS.CURIOUS,
+    COLUMN_HEADERS.HIGHLIGHT
+  ]);
   cache.put(cacheKey, JSON.stringify(indices), 21600);
   return indices;
 }

--- a/tests/getHeaderIndices.test.js
+++ b/tests/getHeaderIndices.test.js
@@ -1,0 +1,40 @@
+const { getHeaderIndices, COLUMN_HEADERS } = require('../src/Code.gs');
+
+function setup(headers) {
+  const sheet = {
+    getLastColumn: () => headers.length,
+    getRange: jest.fn(() => ({ getValues: () => [headers] })),
+    getName: () => 'Sheet1'
+  };
+  global.SpreadsheetApp = {
+    getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
+  };
+  global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
+  return { sheet };
+}
+
+afterEach(() => {
+  delete global.SpreadsheetApp;
+  delete global.CacheService;
+});
+
+test('getHeaderIndices ignores unrelated header differences', () => {
+  const headers = [
+    'Email',
+    'Class',
+    'Question',
+    COLUMN_HEADERS.UNDERSTAND,
+    COLUMN_HEADERS.LIKE,
+    COLUMN_HEADERS.CURIOUS,
+    COLUMN_HEADERS.HIGHLIGHT
+  ];
+  setup(headers);
+  const indices = getHeaderIndices('Sheet1');
+  expect(indices).toEqual({
+    [COLUMN_HEADERS.UNDERSTAND]: 3,
+    [COLUMN_HEADERS.LIKE]: 4,
+    [COLUMN_HEADERS.CURIOUS]: 5,
+    [COLUMN_HEADERS.HIGHLIGHT]: 6
+  });
+  expect(Object.keys(indices)).toHaveLength(4);
+});


### PR DESCRIPTION
## Summary
- restrict `getHeaderIndices` to only validate reaction-related headers
- add unit test for `getHeaderIndices` when other headers differ

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858052e54e4832baef019c5d302a8fb