### PR TITLE
Disable reaction buttons during request

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -1302,6 +1302,10 @@
       async handleReaction(rowIndex, reaction) {
         // リアクションボタンのアニメーション
         const btns = document.querySelectorAll('[data-row-index="' + rowIndex + '"][data-reaction="' + reaction + '"]');
+        btns.forEach(btn => {
+          btn.disabled = true;
+          btn.setAttribute('aria-disabled', 'true');
+        });
         if (typeof gsap !== 'undefined') {
           btns.forEach(btn => {
             gsap.fromTo(btn,
@@ -1326,6 +1330,11 @@
           }
         } catch (error) {
           console.error('Failed to add reaction:', error);
+        } finally {
+          btns.forEach(btn => {
+            btn.disabled = false;
+            btn.setAttribute('aria-disabled', 'false');
+          });
         }
       }
 

--- a/tests/handleReactionDisable.test.js
+++ b/tests/handleReactionDisable.test.js
@@ -1,0 +1,44 @@
+const { JSDOM } = require('jsdom');
+
+function createDeferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+async function handleReaction(rowIndex, reaction, gas) {
+  const btns = document.querySelectorAll(`[data-row-index="${rowIndex}"][data-reaction="${reaction}"]`);
+  btns.forEach(btn => {
+    btn.disabled = true;
+    btn.setAttribute('aria-disabled', 'true');
+  });
+  try {
+    await gas.addReaction(rowIndex, reaction);
+  } catch (e) {
+    // ignore
+  } finally {
+    btns.forEach(btn => {
+      btn.disabled = false;
+      btn.setAttribute('aria-disabled', 'false');
+    });
+  }
+}
+
+test('reaction buttons disable during async call', async () => {
+  const dom = new JSDOM(`<button data-row-index="1" data-reaction="LIKE"></button>`);
+  global.document = dom.window.document;
+  const def = createDeferred();
+  const gas = { addReaction: jest.fn(() => def.promise) };
+
+  const promise = handleReaction(1, 'LIKE', gas);
+  const btn = dom.window.document.querySelector('button');
+  expect(btn.disabled).toBe(true);
+  expect(btn.getAttribute('aria-disabled')).toBe('true');
+
+  def.resolve({ status: 'ok' });
+  await promise;
+  expect(btn.disabled).toBe(false);
+  expect(btn.getAttribute('aria-disabled')).toBe('false');
+
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- disable reaction buttons while awaiting addReaction
- show disabled state via `aria-disabled`
- reenable buttons once the request finishes
- test that buttons are disabled during the async call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685809e45778832b833a1a39b8822130