### PR TITLE
Implement gradient border per reaction combo

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -227,10 +227,12 @@
       box-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
     }
     /* リアクションボタンの背景グラデーションとボーダーカラー */
-    .reaction-bg-like { border-color:#ef4444; border-image: linear-gradient(to bottom,#facc15,#fcd34d) 1; }
-    .reaction-bg-understand { border-color:#fbbf24; border-image: linear-gradient(to bottom,#a3e635,#bef264) 1; }
-    .reaction-bg-curious { border-color:#10b981; border-image: linear-gradient(to bottom,#34d399,#6ee7b7) 1; }
-    .reaction-bg-mixed { border-color:#8b5cf6; border-image: linear-gradient(to bottom,#f59e0b,#10b981,#10b981) 1; }
+    .reaction-bg-like { border-color:#ef4444; border-image:none; }
+    .reaction-bg-understand { border-color:#fbbf24; border-image:none; }
+    .reaction-bg-curious { border-color:#10b981; border-image:none; }
+    .reaction-bg-like-understand { border-color:transparent; border-image: linear-gradient(90deg,#ef4444,#fbbf24) 1; }
+    .reaction-bg-like-curious { border-color:transparent; border-image: linear-gradient(90deg,#ef4444,#10b981) 1; }
+    .reaction-bg-understand-curious { border-color:transparent; border-image: linear-gradient(90deg,#fbbf24,#10b981) 1; }
     .reaction-bg-all { border-color:transparent; border-image: linear-gradient(90deg,#ef4444,#fbbf24,#10b981) 1; }
     /* リアクション総数に応じたボーダー太さ */
     .reaction-border-1 { border-width: 2px; }
@@ -1179,7 +1181,14 @@
           if (active[0] === 'UNDERSTAND') card.classList.add('reaction-bg-understand');
           if (active[0] === 'CURIOUS') card.classList.add('reaction-bg-curious');
         } else if (active.length === 2) {
-          card.classList.add('reaction-bg-mixed');
+          const order = this.reactionTypes.map(rt => rt.key);
+          const combo = active.slice().sort((a, b) => order.indexOf(a) - order.indexOf(b)).join('-');
+          const comboMap = {
+            'LIKE-UNDERSTAND': 'reaction-bg-like-understand',
+            'LIKE-CURIOUS': 'reaction-bg-like-curious',
+            'UNDERSTAND-CURIOUS': 'reaction-bg-understand-curious'
+          };
+          card.classList.add(comboMap[combo] || 'reaction-bg-all');
         } else if (active.length > 2) {
           card.classList.add('reaction-bg-all');
         }
@@ -1508,7 +1517,9 @@
               'reaction-bg-like',
               'reaction-bg-understand',
               'reaction-bg-curious',
-              'reaction-bg-mixed',
+              'reaction-bg-like-understand',
+              'reaction-bg-like-curious',
+              'reaction-bg-understand-curious',
               'reaction-bg-all'
             ].forEach(cls => card.classList.remove(cls));
 
@@ -1518,7 +1529,14 @@
               if (active[0] === 'UNDERSTAND') card.classList.add('reaction-bg-understand');
               if (active[0] === 'CURIOUS') card.classList.add('reaction-bg-curious');
             } else if (active.length === 2) {
-              card.classList.add('reaction-bg-mixed');
+              const order = this.reactionTypes.map(rt => rt.key);
+              const combo = active.slice().sort((a, b) => order.indexOf(a) - order.indexOf(b)).join('-');
+              const comboMap = {
+                'LIKE-UNDERSTAND': 'reaction-bg-like-understand',
+                'LIKE-CURIOUS': 'reaction-bg-like-curious',
+                'UNDERSTAND-CURIOUS': 'reaction-bg-understand-curious'
+              };
+              card.classList.add(comboMap[combo] || 'reaction-bg-all');
             } else if (active.length > 2) {
               card.classList.add('reaction-bg-all');
             }


### PR DESCRIPTION
## Summary
- style answer card borders according to reaction types
- add combos for two reactions and update JS logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858102c3c24832ba7a027cb75cf70f7