### PR TITLE
Fix reaction border color specificity

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -227,9 +227,9 @@
       box-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
     }
     /* リアクションボタンの背景グラデーションとボーダーカラー */
-    .reaction-bg-like { border-color:#ef4444; border-image:none; }
-    .reaction-bg-understand { border-color:#fbbf24; border-image:none; }
-    .reaction-bg-curious { border-color:#10b981; border-image:none; }
+    .answer-card.reaction-bg-like { border-color:#ef4444 !important; border-image:none; }
+    .answer-card.reaction-bg-understand { border-color:#fbbf24 !important; border-image:none; }
+    .answer-card.reaction-bg-curious { border-color:#10b981 !important; border-image:none; }
     .reaction-bg-like-understand { border-color:transparent; border-image: linear-gradient(90deg,#ef4444,#fbbf24) 1; }
     .reaction-bg-like-curious { border-color:transparent; border-image: linear-gradient(90deg,#ef4444,#10b981) 1; }
     .reaction-bg-understand-curious { border-color:transparent; border-image: linear-gradient(90deg,#fbbf24,#10b981) 1; }


### PR DESCRIPTION
## Summary
- adjust CSS specificity so single-reaction borders override Tailwind's cyan border

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68588f1559d8832b9ea74b5cbf8497bb