### PR TITLE
Fix gradient to appear only on card borders

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -198,14 +198,18 @@
       border-radius: var(--border-radius-lg);
     }
     .answer-card.highlighted {
-      border-color: var(--color-accent) !important;
+      border-color: transparent;
       border-image: none !important;
       border-width: 4px;
       box-shadow: 0 0 15px rgba(250,204,21,0.6);
       transform: scale(1.02);
       animation: highlight-pulse 2s 3;
       z-index: 2;
-      background-image: radial-gradient(rgba(250,204,21,0.1), transparent);
+      background-image:
+        linear-gradient(var(--glass-bg), var(--glass-bg)),
+        linear-gradient(90deg, var(--color-accent), var(--color-primary));
+      background-origin: padding-box, border-box;
+      background-clip: padding-box, border-box;
     }
     .answer-card:hover {
       transform: translateY(-4px) scale(1.02);


### PR DESCRIPTION
## Summary
- tweak highlighted card styles so gradient appears on the border only

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858995b9bec832b8409b56cb4d1aad9