### PR TITLE
Fix highlight icon to use solid star

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -1328,7 +1328,7 @@
           const cls = data.highlight ? 'liked' : '';
           const highlightAriaLabel = data.highlight ? 'ハイライトを解除する' : 'ハイライトする';
           highlightBtnHtml = '<button type="button" class="highlight-btn like-btn text-yellow-400 ' + cls + '" aria-label="' + highlightAriaLabel + '" aria-pressed="' + data.highlight + '" data-row-index="' + data.rowIndex + '">' +
-                             this.getIcon('star', 'w-5 h-5', data.highlight) +
+                             this.getIcon('star', 'w-5 h-5', true) +
                              '</button>';
         }
         
@@ -1681,7 +1681,7 @@
               highlightBtn.setAttribute('aria-label', label);
               const svgEl = highlightBtn.querySelector('svg');
               if (svgEl) {
-                svgEl.outerHTML = this.getIcon('star', 'w-5 h-5', item.highlight);
+                svgEl.outerHTML = this.getIcon('star', 'w-5 h-5', true);
               }
               highlightBtn.disabled = false;
               highlightBtn.setAttribute('aria-disabled', 'false');

--- a/tests/applyUpdatesHighlight.test.js
+++ b/tests/applyUpdatesHighlight.test.js
@@ -23,7 +23,7 @@ function applyUpdates(items) {
     if (item.highlight && !badge) {
       badge = document.createElement('span');
       badge.className = 'highlight-badge';
-      badge.innerHTML = getIcon('star', 'w-6 h-6');
+      badge.innerHTML = getIcon('star', 'w-6 h-6', true);
       if (preview) preview.insertBefore(badge, preview.firstChild);
       animateHighlightBadge(badge);
     } else if (!item.highlight && badge) {


### PR DESCRIPTION
## Summary
- always render the solid star icon for highlight buttons
- update highlight button UI refresh logic
- adjust test helper for solid star icon

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685898ffc430832b9bb32271ba8609d0