### PR TITLE
Fix gradient border for multi-reaction cards

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -242,22 +242,18 @@
     .reaction-bg-all {
       border-color: transparent;
       border-style: solid;
-      background-origin: padding-box, border-box;
-      background-clip: padding-box, border-box;
-      background-image: linear-gradient(var(--glass-bg), var(--glass-bg)),
-                        linear-gradient(90deg,#ef4444,#fbbf24);
+      background: var(--glass-bg);
+      border-image-slice: 1;
+      border-image-source: linear-gradient(90deg,#ef4444,#fbbf24);
     }
     .reaction-bg-like-curious {
-      background-image: linear-gradient(var(--glass-bg), var(--glass-bg)),
-                        linear-gradient(90deg,#ef4444,#10b981);
+      border-image-source: linear-gradient(90deg,#ef4444,#10b981);
     }
     .reaction-bg-understand-curious {
-      background-image: linear-gradient(var(--glass-bg), var(--glass-bg)),
-                        linear-gradient(90deg,#fbbf24,#10b981);
+      border-image-source: linear-gradient(90deg,#fbbf24,#10b981);
     }
     .reaction-bg-all {
-      background-image: linear-gradient(var(--glass-bg), var(--glass-bg)),
-                        linear-gradient(90deg,#ef4444,#fbbf24,#10b981);
+      border-image-source: linear-gradient(90deg,#ef4444,#fbbf24,#10b981);
     }
     /* リアクション総数に応じたボーダー太さ */
     .reaction-border-1 { border-width: 2px; }


### PR DESCRIPTION
## Summary
- apply gradient via `border-image` when multiple reaction types are present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858bf866488832bb46fc67a7b2bb3a2