### PR TITLE
Restore background-clip gradient borders

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -242,22 +242,28 @@
     .reaction-bg-all {
       border-color: transparent;
       border-style: solid;
-      background-origin: padding-box, border-box;
+      background:
+        linear-gradient(var(--glass-bg), var(--glass-bg)) padding-box,
+        linear-gradient(90deg,#ef4444,#fbbf24) border-box;
       background-clip: padding-box, border-box;
-      background-image: linear-gradient(var(--glass-bg), var(--glass-bg)),
-                        linear-gradient(90deg,#ef4444,#fbbf24);
     }
     .reaction-bg-like-curious {
-      background-image: linear-gradient(var(--glass-bg), var(--glass-bg)),
-                        linear-gradient(90deg,#ef4444,#10b981);
+      background:
+        linear-gradient(var(--glass-bg), var(--glass-bg)) padding-box,
+        linear-gradient(90deg,#ef4444,#10b981) border-box;
+      background-clip: padding-box, border-box;
     }
     .reaction-bg-understand-curious {
-      background-image: linear-gradient(var(--glass-bg), var(--glass-bg)),
-                        linear-gradient(90deg,#fbbf24,#10b981);
+      background:
+        linear-gradient(var(--glass-bg), var(--glass-bg)) padding-box,
+        linear-gradient(90deg,#fbbf24,#10b981) border-box;
+      background-clip: padding-box, border-box;
     }
     .reaction-bg-all {
-      background-image: linear-gradient(var(--glass-bg), var(--glass-bg)),
-                        linear-gradient(90deg,#ef4444,#fbbf24,#10b981);
+      background:
+        linear-gradient(var(--glass-bg), var(--glass-bg)) padding-box,
+        linear-gradient(90deg,#ef4444,#fbbf24,#10b981) border-box;
+      background-clip: padding-box, border-box;
     }
     /* リアクション総数に応じたボーダー太さ */
     .reaction-border-1 { border-width: 2px; }


### PR DESCRIPTION
## Summary
- revert multi-reaction card styling to use `background-clip` with dual gradients

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858bf866488832bb46fc67a7b2bb3a2