### PR TITLE
Fix doGet defaults

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -260,8 +260,10 @@ function setShowDetails(flag) {
 // GAS Webアプリケーションのエントリーポイント
 // =================================================================
 function doGet(e) {
-  const userId = e.parameter.userId;
-  const mode = e.parameter.mode;
+  e = e || {};
+  const params = e.parameter || {};
+  const userId = params.userId;
+  const mode = params.mode;
   
   // ユーザーIDがない場合は登録画面を表示
   if (!userId) {


### PR DESCRIPTION
## Summary
- make `doGet` resilient to missing event objects

## Testing
- `npm test` *(fails: `PropertiesService.getUserProperties` is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68592eb06fac832ba098627059ea606b