### PR TITLE
Fix tests to mock user properties and new doGet event

### DIFF
--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -51,7 +51,14 @@ function buildSheet() {
 function setupMocks(userEmail, sheet, cacheImpl) {
   global.LockService = { getScriptLock: () => ({ tryLock: jest.fn(() => true), releaseLock: jest.fn() }) };
   global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
-  global.PropertiesService = { getScriptProperties: () => ({}) };
+  global.PropertiesService = {
+    getScriptProperties: () => ({}),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   global.CacheService = { getScriptCache: () => cacheImpl || ({ get: () => null, put: () => null }) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({

--- a/tests/addLikeColumn.test.js
+++ b/tests/addLikeColumn.test.js
@@ -43,7 +43,14 @@ function buildSheet() {
 function setupMocks(email, sheet) {
   global.LockService = { getScriptLock: () => ({ tryLock: jest.fn(() => true), releaseLock: jest.fn() }) };
   global.Session = { getActiveUser: () => ({ getEmail: () => email }) };
-  global.PropertiesService = { getScriptProperties: () => ({}) };
+  global.PropertiesService = {
+    getScriptProperties: () => ({}),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({
@@ -74,7 +81,14 @@ test('addReaction handles failure to get user email', () => {
   const sheet = buildSheet();
   global.LockService = { getScriptLock: () => ({ tryLock: jest.fn(() => true), releaseLock: jest.fn() }) };
   global.Session = { getActiveUser: () => ({ getEmail: () => { throw new Error('fail'); } }) };
-  global.PropertiesService = { getScriptProperties: () => ({}) };
+  global.PropertiesService = {
+    getScriptProperties: () => ({}),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({

--- a/tests/buildBoardData.test.js
+++ b/tests/buildBoardData.test.js
@@ -20,7 +20,12 @@ function setup({configRows, dataRows, rosterRows}) {
   };
   global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null, remove: () => null }) };
   global.PropertiesService = {
-    getScriptProperties: () => ({ getProperty: () => null })
+    getScriptProperties: () => ({ getProperty: () => null }),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
   };
   global.getConfig = (sheetName) => {
     const row = configRows.find((r, idx) => idx > 0 && r[0] === sheetName);

--- a/tests/checkAdmin.test.js
+++ b/tests/checkAdmin.test.js
@@ -2,7 +2,12 @@ const { checkAdmin } = require('../src/Code.gs');
 
 function setup(admins, currentEmail) {
   global.PropertiesService = {
-    getScriptProperties: () => ({ getProperty: (key) => key === 'ADMIN_EMAILS' ? admins.join(',') : null })
+    getScriptProperties: () => ({ getProperty: (key) => key === 'ADMIN_EMAILS' ? admins.join(',') : null }),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
   };
   global.Session = { getActiveUser: () => ({ getEmail: () => currentEmail }) };
 }

--- a/tests/doGetUnpublished.test.js
+++ b/tests/doGetUnpublished.test.js
@@ -12,8 +12,14 @@ function setup() {
     getScriptProperties: () => ({
       getProperty: (key) => {
         if (key === 'IS_PUBLISHED') return 'false';
+        if (key === 'USER_DB_ID') return 'db1';
         return null;
       }
+    }),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
     })
   };
   global.Session = { getActiveUser: () => ({ getEmail: () => { throw new Error('no user'); } }) };
@@ -22,19 +28,36 @@ function setup() {
       getSheets: () => [
         { getName: () => 'Sheet1', isSheetHidden: () => false }
       ]
-    })
+    }),
+    create: jest.fn(() => ({
+      getActiveSheet: () => ({
+        setName: jest.fn(),
+        getRange: jest.fn(() => ({ setValues: jest.fn() }))
+      }),
+      getId: () => 'id1'
+    }))
   };
-  const output = { setTitle: jest.fn(() => output) };
+  const output = { setTitle: jest.fn(() => output), addMetaTag: jest.fn(() => output) };
   let template = { evaluate: () => output };
   global.HtmlService = {
     createTemplateFromFile: jest.fn(() => template)
   };
+  const dbSheet = {
+    getDataRange: () => ({
+      getValues: () => [
+        ['userId','spreadsheetId','adminEmail','configJson','lastAccessedAt'],
+        ['u1','id1','admin@example.com', JSON.stringify({ isPublished: false, sheetName: 'Sheet1' }), '']
+      ]
+    }),
+    getRange: jest.fn(() => ({ setValue: jest.fn() }))
+  };
+  global.SpreadsheetApp.openById = jest.fn(() => ({ getSheetByName: () => dbSheet }));
   return template;
 }
 
 test('doGet uses Unpublished template when email fails', () => {
   const template = setup();
-  doGet({});
+  doGet({ parameter: { userId: 'u1' } });
   expect(HtmlService.createTemplateFromFile).toHaveBeenCalledWith('Unpublished');
-  expect(template.userEmail).toBe('');
+  expect(template.userEmail).toBe('admin@example.com');
 });

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -10,6 +10,11 @@ function setup() {
         if (key === 'ACTIVE_SHEET_NAME') return 'SheetA';
         return null;
       }
+    }),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
     })
   };
   global.SpreadsheetApp = {

--- a/tests/getRosterMap.test.js
+++ b/tests/getRosterMap.test.js
@@ -26,7 +26,12 @@ function setupMocks(cacheValue) {
     })
   };
   global.PropertiesService = {
-    getScriptProperties: () => ({ getProperty: () => null })
+    getScriptProperties: () => ({ getProperty: () => null }),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
   };
   return { sheet, cache: cacheObj };
 }

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -37,6 +37,11 @@ function setupMocks(rows, userEmail, adminEmails = '') {
         if (key === 'ADMIN_EMAILS') return adminEmails;
         return null;
       }
+    }),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
     })
   };
 }

--- a/tests/getSheetHeaders.test.js
+++ b/tests/getSheetHeaders.test.js
@@ -10,11 +10,19 @@ function setup(headers) {
       getSheetByName: jest.fn(() => sheet)
     })
   };
+  global.PropertiesService = {
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   return { sheet };
 }
 
 afterEach(() => {
   delete global.SpreadsheetApp;
+  delete global.PropertiesService;
 });
 
 test('getSheetHeaders returns header row', () => {
@@ -26,6 +34,13 @@ test('getSheetHeaders returns header row', () => {
 test('getSheetHeaders throws when sheet missing', () => {
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({ getSheetByName: jest.fn(() => null) })
+  };
+  global.PropertiesService = {
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
   };
   expect(() => getSheetHeaders('Missing')).toThrow("シート 'Missing' が見つかりません。");
 });

--- a/tests/prepareSheetForBoard.test.js
+++ b/tests/prepareSheetForBoard.test.js
@@ -12,11 +12,19 @@ function setup(headers) {
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
   };
+  global.PropertiesService = {
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   return { sheet, headers };
 }
 
 afterEach(() => {
   delete global.SpreadsheetApp;
+  delete global.PropertiesService;
 });
 
 test('prepareSheetForBoard appends missing reaction columns', () => {

--- a/tests/saveDeployId.test.js
+++ b/tests/saveDeployId.test.js
@@ -2,7 +2,14 @@ const { saveDeployId } = require('../src/Code.gs');
 
 function setup() {
   const props = { setProperties: jest.fn(), deleteProperty: jest.fn() };
-  global.PropertiesService = { getScriptProperties: () => props };
+  global.PropertiesService = {
+    getScriptProperties: () => props,
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   return props;
 }
 

--- a/tests/saveSheetConfig.test.js
+++ b/tests/saveSheetConfig.test.js
@@ -13,11 +13,21 @@ function setup(initialRows) {
       insertSheet: () => sheet
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActive();
+  global.PropertiesService = {
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   return { sheet, rows };
 }
 
 afterEach(() => {
   delete global.SpreadsheetApp;
+  delete global.getCurrentSpreadsheet;
+  delete global.PropertiesService;
 });
 
 test('saveSheetConfig appends new row', () => {

--- a/tests/saveWebAppUrl.test.js
+++ b/tests/saveWebAppUrl.test.js
@@ -2,7 +2,14 @@ const { saveWebAppUrl } = require('../src/Code.gs');
 
 function setup() {
   const props = { setProperties: jest.fn(), deleteProperty: jest.fn() };
-  global.PropertiesService = { getScriptProperties: () => props };
+  global.PropertiesService = {
+    getScriptProperties: () => props,
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   return props;
 }
 

--- a/tests/toggleHighlight.test.js
+++ b/tests/toggleHighlight.test.js
@@ -32,9 +32,16 @@ function buildSheet() {
 function setupMocks(sheet, cacheImpl, userEmail = 'admin@example.com', adminEmails = 'admin@example.com') {
   global.LockService = { getScriptLock: () => ({ waitLock: jest.fn(), releaseLock: jest.fn() }) };
   global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
-  global.PropertiesService = { getScriptProperties: () => ({
-    getProperty: (key) => key === 'ADMIN_EMAILS' ? adminEmails : null
-  }) };
+  global.PropertiesService = {
+    getScriptProperties: () => ({
+      getProperty: (key) => key === 'ADMIN_EMAILS' ? adminEmails : null
+    }),
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   global.CacheService = { getScriptCache: () => cacheImpl || ({ get: () => null, put: () => null }) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({


### PR DESCRIPTION
## Summary
- update test helpers to include `getUserProperties` with `getProperty`, `setProperty`, and `setProperties`
- pass an event object to `doGet` tests and account for updated behavior
- stub additional services for new multi-tenant logic
- ensure publish permission tests check updated behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68592edfd96c832b96cd9018ddc4e617