### PR TITLE
Switch to multi-tenant helpers

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -175,7 +175,7 @@ function getAdminSettings() {
   } else {
     // 従来のモード
     adminEmails = getAdminEmails();
-    appSettings = getAppSettings();
+    appSettings = getAppSettingsForUser();
   }
   
   const allSheets = getSheets();
@@ -413,7 +413,7 @@ function getSheetHeaders(sheetName) {
 
 function getSheetData(sheetName, classFilter, sortBy) {
   try {
-    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+    const sheet = getCurrentSpreadsheet().getSheetByName(sheetName);
     if (!sheet) throw new Error(`指定されたシート「${sheetName}」が見つかりません。`);
 
     const allValues = sheet.getDataRange().getValues();
@@ -600,7 +600,7 @@ function getSheetDataForSpreadsheet(spreadsheet, sheetName, classFilter, sortBy)
 function buildBoardData(sheetName) {
   const cfgFunc = (typeof global !== 'undefined' && global.getConfig) ? global.getConfig : getConfig;
   const cfg = cfgFunc ? cfgFunc(sheetName) : {};
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+  const sheet = getCurrentSpreadsheet().getSheetByName(sheetName);
   if (!sheet) throw new Error(`シート '${sheetName}' が見つかりません。`);
   const values = sheet.getDataRange().getValues();
   const headers = values.shift();
@@ -685,9 +685,9 @@ function toggleHighlight(rowIndex, sheetName) {
   const lock = LockService.getScriptLock();
   lock.waitLock(TIME_CONSTANTS.LOCK_WAIT_MS);
   try {
-    const settings = getAppSettings();
+    const settings = getAppSettingsForUser();
     const targetSheet = sheetName || settings.activeSheetName;
-    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(targetSheet);
+    const sheet = getCurrentSpreadsheet().getSheetByName(targetSheet);
     if (!sheet) throw new Error(`シート '${targetSheet}' が見つかりません。`);
 
     const headerIndices = getHeaderIndices(targetSheet);
@@ -763,7 +763,7 @@ function getRosterMap() {
   const rosterSheetName = props && typeof props.getProperty === 'function'
     ? (props.getProperty(ROSTER_CONFIG.PROPERTY_NAME) || ROSTER_CONFIG.SHEET_NAME)
     : ROSTER_CONFIG.SHEET_NAME;
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(rosterSheetName);
+  const sheet = getCurrentSpreadsheet().getSheetByName(rosterSheetName);
   if (!sheet) { console.error(`名簿シート「${rosterSheetName}」が見つかりません。`); return {}; }
   const rosterValues = sheet.getDataRange().getValues();
   const rosterHeaders = rosterValues.shift();
@@ -822,7 +822,7 @@ function getHeaderIndices(sheetName) {
   const cacheKey = `headers_${sheetName}`;
   const cached = cache.get(cacheKey);
   if (cached) { return JSON.parse(cached); }
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+  const sheet = getCurrentSpreadsheet().getSheetByName(sheetName);
   if (!sheet) throw new Error(`シート '${sheetName}' が見つかりません。`);
   const headerRow = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
   const indices = findHeaderIndices(headerRow, [
@@ -838,7 +838,7 @@ function getHeaderIndices(sheetName) {
 
 
 function prepareSheetForBoard(sheetName) {
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
+  const sheet = getCurrentSpreadsheet().getSheetByName(sheetName);
   if (!sheet) throw new Error(`シート '${sheetName}' が見つかりません。`);
   const headers = getSheetHeaders(sheetName);
   let lastCol = headers.length;
@@ -902,7 +902,7 @@ function createTemplateSheet(name) {
   if (!checkAdmin()) {
     throw new Error('権限がありません。');
   }
-  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const ss = getCurrentSpreadsheet();
   const sheetName = name || 'New Q&A';
   if (ss.getSheetByName(sheetName)) {
     throw new Error(`シート '${sheetName}' は既に存在します。`);

--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -66,6 +66,7 @@ function setupMocks(userEmail, sheet, cacheImpl) {
       getSheets: () => [sheet]
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
 }
 
 afterEach(() => {
@@ -74,6 +75,7 @@ afterEach(() => {
   delete global.PropertiesService;
   delete global.CacheService;
   delete global.SpreadsheetApp;
+  delete global.getCurrentSpreadsheet;
 });
 
 test('addReaction toggles user in list', () => {

--- a/tests/addLikeColumn.test.js
+++ b/tests/addLikeColumn.test.js
@@ -58,6 +58,7 @@ function setupMocks(email, sheet) {
       getSheets: () => [sheet]
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
 }
 
 afterEach(() => {
@@ -66,6 +67,7 @@ afterEach(() => {
   delete global.PropertiesService;
   delete global.CacheService;
   delete global.SpreadsheetApp;
+  delete global.getCurrentSpreadsheet;
 });
 
 test('addReaction updates value in LIKE column', () => {
@@ -96,6 +98,7 @@ test('addReaction handles failure to get user email', () => {
       getSheets: () => [sheet]
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   const result = addReaction(2, 'LIKE', 'Sheet1');
   expect(result.status).toBe('error');
 });

--- a/tests/buildBoardData.test.js
+++ b/tests/buildBoardData.test.js
@@ -18,6 +18,7 @@ function setup({configRows, dataRows, rosterRows}) {
       }
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null, remove: () => null }) };
   global.PropertiesService = {
     getScriptProperties: () => ({ getProperty: () => null }),
@@ -52,6 +53,7 @@ afterEach(() => {
   delete global.PropertiesService;
   delete global.getConfig;
   delete global.getRosterMap;
+  delete global.getCurrentSpreadsheet;
 });
 
 test('buildBoardData reads names from same sheet', () => {

--- a/tests/doGetUnpublished.test.js
+++ b/tests/doGetUnpublished.test.js
@@ -5,6 +5,7 @@ afterEach(() => {
   delete global.Session;
   delete global.HtmlService;
   delete global.SpreadsheetApp;
+  delete global.getCurrentSpreadsheet;
 });
 
 function setup() {
@@ -37,6 +38,7 @@ function setup() {
       getId: () => 'id1'
     }))
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   const output = { setTitle: jest.fn(() => output), addMetaTag: jest.fn(() => output) };
   let template = { evaluate: () => output };
   global.HtmlService = {

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -7,6 +7,7 @@ afterEach(() => {
   delete global.PropertiesService;
   delete global.SpreadsheetApp;
   delete global.getUserDatabase;
+  delete global.getCurrentSpreadsheet;
 });
 
 function setup({ userEmail = 'admin@example.com', adminEmails = 'admin@example.com' }) {
@@ -50,6 +51,7 @@ function setup({ userEmail = 'admin@example.com', adminEmails = 'admin@example.c
       getId: () => 'id1'
     }))
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   const output = { setTitle: jest.fn(() => output), addMetaTag: jest.fn(() => output), setSandboxMode: jest.fn(() => output) };
   let template = { evaluate: () => output };
   global.HtmlService = {

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -27,6 +27,7 @@ function setup() {
       ]
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   global.Session = { getActiveUser: () => ({ getEmail: () => 'a@example.com' }) };
   global.getActiveUserEmail = () => 'a@example.com';
 }
@@ -35,6 +36,7 @@ afterEach(() => {
   delete global.SpreadsheetApp;
   delete global.Session;
   delete global.getActiveUserEmail;
+  delete global.getCurrentSpreadsheet;
 });
 
 test('getAdminSettings returns board state', () => {

--- a/tests/getHeaderIndices.test.js
+++ b/tests/getHeaderIndices.test.js
@@ -9,13 +9,23 @@ function setup(headers) {
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   global.CacheService = { getScriptCache: () => ({ get: () => null, put: () => null }) };
+  global.PropertiesService = {
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
   return { sheet };
 }
 
 afterEach(() => {
   delete global.SpreadsheetApp;
   delete global.CacheService;
+  delete global.getCurrentSpreadsheet;
+  delete global.PropertiesService;
 });
 
 test('getHeaderIndices ignores unrelated header differences', () => {

--- a/tests/getRosterMap.test.js
+++ b/tests/getRosterMap.test.js
@@ -25,6 +25,7 @@ function setupMocks(cacheValue) {
       getSheetByName: jest.fn(() => sheet)
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   global.PropertiesService = {
     getScriptProperties: () => ({ getProperty: () => null }),
     getUserProperties: () => ({
@@ -40,6 +41,7 @@ afterEach(() => {
   delete global.CacheService;
   delete global.SpreadsheetApp;
   delete global.PropertiesService;
+  delete global.getCurrentSpreadsheet;
 });
 
 test('getRosterMap builds map and caches it', () => {
@@ -77,8 +79,14 @@ test('getRosterMap uses ROSTER_SHEET_NAME property when set', () => {
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({ getSheetByName: spy })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   global.PropertiesService = {
     getScriptProperties: () => ({ getProperty: () => 'RosterSheet' })
+    ,getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
   };
 
   getRosterMap();

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -27,6 +27,7 @@ function setupMocks(rows, userEmail, adminEmails = '') {
       }
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
 
   // Mock other global services
   global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
@@ -52,6 +53,7 @@ afterEach(() => {
   delete global.CacheService;
   delete global.PropertiesService;
   delete global.getConfig;
+  delete global.getCurrentSpreadsheet;
 });
 
 test('getSheetData filters and scores rows', () => {

--- a/tests/getSheetHeaders.test.js
+++ b/tests/getSheetHeaders.test.js
@@ -10,6 +10,7 @@ function setup(headers) {
       getSheetByName: jest.fn(() => sheet)
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   global.PropertiesService = {
     getUserProperties: () => ({
       getProperty: jest.fn(),
@@ -23,6 +24,7 @@ function setup(headers) {
 afterEach(() => {
   delete global.SpreadsheetApp;
   delete global.PropertiesService;
+  delete global.getCurrentSpreadsheet;
 });
 
 test('getSheetHeaders returns header row', () => {
@@ -35,6 +37,7 @@ test('getSheetHeaders throws when sheet missing', () => {
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({ getSheetByName: jest.fn(() => null) })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   global.PropertiesService = {
     getUserProperties: () => ({
       getProperty: jest.fn(),

--- a/tests/prepareSheetForBoard.test.js
+++ b/tests/prepareSheetForBoard.test.js
@@ -12,6 +12,7 @@ function setup(headers) {
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({ getSheetByName: () => sheet })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   global.PropertiesService = {
     getUserProperties: () => ({
       getProperty: jest.fn(),
@@ -25,6 +26,7 @@ function setup(headers) {
 afterEach(() => {
   delete global.SpreadsheetApp;
   delete global.PropertiesService;
+  delete global.getCurrentSpreadsheet;
 });
 
 test('prepareSheetForBoard appends missing reaction columns', () => {

--- a/tests/publishPermissions.test.js
+++ b/tests/publishPermissions.test.js
@@ -50,6 +50,7 @@ function setup(userEmail, adminEmails) {
       getId: () => 'newid'
     }))
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
   return props;
 }
 
@@ -58,6 +59,7 @@ afterEach(() => {
   delete global.Session;
   delete global.SpreadsheetApp;
   delete global.getUserDatabase;
+  delete global.getCurrentSpreadsheet;
   jest.restoreAllMocks();
 });
 

--- a/tests/toggleHighlight.test.js
+++ b/tests/toggleHighlight.test.js
@@ -49,6 +49,7 @@ function setupMocks(sheet, cacheImpl, userEmail = 'admin@example.com', adminEmai
       getSheets: () => [sheet]
     })
   };
+  global.getCurrentSpreadsheet = () => global.SpreadsheetApp.getActiveSpreadsheet();
 }
 
 afterEach(() => {
@@ -57,6 +58,7 @@ afterEach(() => {
   delete global.PropertiesService;
   delete global.CacheService;
   delete global.SpreadsheetApp;
+  delete global.getCurrentSpreadsheet;
 });
 
 test('toggleHighlight flips stored value', () => {


### PR DESCRIPTION
## Summary
- use `getCurrentSpreadsheet` everywhere instead of `SpreadsheetApp.getActiveSpreadsheet`
- call `getAppSettingsForUser` when reading config
- open highlight sheet with user-specific spreadsheet
- update tests for new helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685934262bf8832b8288b5c7d37d21c0