### PR TITLE
Improve registration flow

### DIFF
--- a/src/Registration.html
+++ b/src/Registration.html
@@ -191,6 +191,7 @@
       
       // 登録処理を実行
       google.script.run
+
         .withSuccessHandler(result => {
           showMessage(result.message || '登録が完了しました！', 'success');
           
@@ -207,6 +208,9 @@
               
               <p class="text-sm text-gray-300">
                 以下のURLをブックマークして、いつでもアクセスできるようにしてください。
+              </p>
+              <p class="text-sm text-gray-300">
+                管理画面は自動で開きます。まずは列の設定を確認しましょう。
               </p>
               
               <div class="space-y-3">
@@ -255,6 +259,10 @@
           resultArea.classList.remove('hidden');
           btn.style.display = 'none';
           document.getElementById('spreadsheet-url').disabled = true;
+
+          // 自動で管理画面を開き、次のステップを案内
+          window.open(result.adminUrl, '_blank');
+          showMessage('管理画面を別タブで開きました。列設定を確認してください。', 'info');
         })
         .withFailureHandler(error => {
           showMessage(`エラー: ${error.message || '登録に失敗しました'}`, 'error');

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -38,7 +38,7 @@
       <!-- Config Setup -->
       <div class="mb-6">
         <h3 class="font-semibold mb-3">2. Config設定</h3>
-        <p class="text-sm text-gray-300 mb-2">ボードで使用する列を指定します。</p>
+        <p class="text-sm text-gray-300 mb-2">ボードで使用する列を指定します。シートを選ぶと候補が表示されます。</p>
           <div class="flex flex-col gap-2 rounded-lg glass-panel p-2 hidden" id="config-area">
             <label class="flex flex-col gap-1">
               <span>問題文ヘッダー</span>


### PR DESCRIPTION
## Summary
- open admin panel automatically after spreadsheet registration
- add hint that a new tab opened for column configuration
- clarify instructions in sheet selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685945a57b90832b86809ce6ea52b6b1