### PR TITLE
Share user database within domain

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -976,6 +976,10 @@ function getUserDatabase() {
   
   if (dbId) {
     try {
+      const file = DriveApp.getFileById(dbId);
+      try {
+        file.setSharing(DriveApp.Access.DOMAIN_WITH_LINK, DriveApp.Permission.VIEW);
+      } catch (e) {}
       return SpreadsheetApp.openById(dbId).getSheetByName(USER_DB_CONFIG.SHEET_NAME);
     } catch (e) {
       // データベースが削除されている場合は再作成
@@ -989,7 +993,7 @@ function getUserDatabase() {
   sheet.getRange(1, 1, 1, USER_DB_CONFIG.HEADERS.length)
     .setValues([USER_DB_CONFIG.HEADERS]);
 
-  // Share database so users in the same domain can read it
+  // Share database so any user in the domain can read it via link
   try {
     DriveApp.getFileById(newDb.getId())
       .setSharing(DriveApp.Access.DOMAIN_WITH_LINK, DriveApp.Permission.VIEW);

--- a/tests/doGetUnpublished.test.js
+++ b/tests/doGetUnpublished.test.js
@@ -15,7 +15,8 @@ function setup() {
         if (key === 'IS_PUBLISHED') return 'false';
         if (key === 'USER_DB_ID') return 'db1';
         return null;
-      }
+      },
+      setProperty: jest.fn()
     }),
     getUserProperties: () => ({
       getProperty: jest.fn(),
@@ -24,6 +25,7 @@ function setup() {
     })
   };
   global.Session = { getActiveUser: () => ({ getEmail: () => { throw new Error('no user'); } }) };
+  global.DriveApp = { getFileById: jest.fn(() => ({ setSharing: jest.fn() })) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({
       getSheets: () => [

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -17,7 +17,8 @@ function setup({ userEmail = 'admin@example.com', adminEmails = 'admin@example.c
         if (key === 'ADMIN_EMAILS') return adminEmails;
         if (key === 'USER_DB_ID') return 'db1';
         return null;
-      }
+      },
+      setProperty: jest.fn()
     }),
     getUserProperties: () => ({
       getProperty: jest.fn(),
@@ -36,6 +37,7 @@ function setup({ userEmail = 'admin@example.com', adminEmails = 'admin@example.c
   };
   global.getActiveUserEmail = () => userEmail;
   global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
+  global.DriveApp = { getFileById: jest.fn(() => ({ setSharing: jest.fn() })) };
   global.SpreadsheetApp = {
     getActiveSpreadsheet: () => ({
       getSheets: () => [


### PR DESCRIPTION
## Summary
- keep file sharing restricted to domain users
- automatically reapply domain sharing on every database fetch

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859b05c9e64832ba3891bcdca80d617