### PR TITLE
Add board-specific admin tests

### DIFF
--- a/tests/perBoardAdmin.test.js
+++ b/tests/perBoardAdmin.test.js
@@ -1,0 +1,80 @@
+const { isUserAdmin } = require('../src/Code.gs');
+
+function setup({ currentEmail, userId, boardId, adminLists }) {
+  const scriptProps = {
+    getProperty: (key) => {
+      if (key === 'USER_DB_ID') return 'db1';
+      if (key.startsWith('ADMIN_EMAILS_')) {
+        const id = key.replace('ADMIN_EMAILS_', '');
+        const emails = adminLists[id];
+        return emails ? emails.join(',') : null;
+      }
+      return null;
+    },
+    setProperty: jest.fn()
+  };
+
+  const userProps = {
+    getProperty: jest.fn((k) => (k === 'CURRENT_USER_ID' ? userId : null)),
+    setProperty: jest.fn(),
+    setProperties: jest.fn()
+  };
+
+  const sheet = {
+    getDataRange: () => ({
+      getValues: () => [
+        ['userId','spreadsheetId','adminEmail','configJson','lastAccessedAt'],
+        [userId, boardId, currentEmail, '{}', '']
+      ]
+    }),
+    getRange: jest.fn(() => ({ setValue: jest.fn() }))
+  };
+
+  global.PropertiesService = {
+    getScriptProperties: () => scriptProps,
+    getUserProperties: () => userProps
+  };
+  global.DriveApp = {
+    getFileById: jest.fn(() => ({ setSharing: jest.fn() })),
+    Access: { DOMAIN_WITH_LINK: 'link' },
+    Permission: { VIEW: 'view' }
+  };
+  global.SpreadsheetApp = {
+    openById: jest.fn(() => ({ getSheetByName: () => sheet }))
+  };
+
+  global.Session = { getActiveUser: () => ({ getEmail: () => currentEmail }) };
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+  delete global.Session;
+  delete global.SpreadsheetApp;
+  delete global.DriveApp;
+});
+
+test('returns true when user is admin for current board', () => {
+  setup({
+    currentEmail: 'board1admin@example.com',
+    userId: 'u1',
+    boardId: 'board1',
+    adminLists: {
+      board1: ['board1admin@example.com'],
+      board2: ['board2admin@example.com']
+    }
+  });
+  expect(isUserAdmin()).toBe(true);
+});
+
+test('returns false when user is admin for a different board', () => {
+  setup({
+    currentEmail: 'board2admin@example.com',
+    userId: 'u1',
+    boardId: 'board1',
+    adminLists: {
+      board1: ['board1admin@example.com'],
+      board2: ['board2admin@example.com']
+    }
+  });
+  expect(isUserAdmin()).toBe(false);
+});


### PR DESCRIPTION
## Summary
- test `isUserAdmin` behaviour for board-specific admin lists

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859b8cae7bc832b9bac9b4b1d22f664