### PR TITLE
Enhance domain checks and database access

### DIFF
--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -6,7 +6,6 @@ afterEach(() => {
   delete global.Session;
   delete global.PropertiesService;
   delete global.SpreadsheetApp;
-  delete global.getUserDatabase;
   delete global.getCurrentSpreadsheet;
 });
 
@@ -85,4 +84,12 @@ test('non admin user starts in viewer mode', () => {
   const tpl = getTemplate();
   expect(tpl.isAdminUser).toBe(false);
   expect(tpl.showAdminFeatures).toBe(false);
+});
+
+test('different domain user receives permission error', () => {
+  setup({ userEmail: 'user@other.com' });
+  const output = { setTitle: jest.fn(() => output) };
+  global.HtmlService.createHtmlOutput = jest.fn(() => output);
+  doGet({ parameter: { userId: 'u1' } });
+  expect(HtmlService.createHtmlOutput).toHaveBeenCalledWith(expect.stringContaining('権限'));
 });

--- a/tests/publishPermissions.test.js
+++ b/tests/publishPermissions.test.js
@@ -18,11 +18,11 @@ function setup(userEmail, adminEmails) {
       setProperties: jest.fn()
     })
   };
-  global.getUserInfo = jest.fn(() => ({
+  jest.spyOn(gas, 'getUserInfo').mockImplementation(() => ({
     adminEmail: adminEmails[0],
     spreadsheetId: 'id1'
   }));
-  global.getUserDatabase = jest.fn(() => ({
+  jest.spyOn(gas, 'getUserDatabase').mockImplementation(() => ({
     getDataRange: () => ({
       getValues: () => [
         ['userId','spreadsheetId','adminEmail','configJson','lastAccessedAt'],
@@ -31,6 +31,7 @@ function setup(userEmail, adminEmails) {
     }),
     getRange: jest.fn(() => ({ setValue: jest.fn() }))
   }));
+  global.DriveApp = { getFileById: jest.fn(() => ({ setSharing: jest.fn() })) };
   global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };
   const sheet = {
     getLastColumn: () => 2,
@@ -58,7 +59,7 @@ afterEach(() => {
   delete global.PropertiesService;
   delete global.Session;
   delete global.SpreadsheetApp;
-  delete global.getUserDatabase;
+  delete global.DriveApp;
   delete global.getCurrentSpreadsheet;
   jest.restoreAllMocks();
 });


### PR DESCRIPTION
## Summary
- restrict board access to users in the same domain
- avoid recreating the user database when access is denied
- expose domain helper functions
- test cross-domain access error and update admin permission tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859bb0dbcbc832bbc035d15a1cef621