### PR TITLE
Implement shared database setup

### DIFF
--- a/tests/doGetUnpublished.test.js
+++ b/tests/doGetUnpublished.test.js
@@ -13,7 +13,7 @@ function setup() {
     getScriptProperties: () => ({
       getProperty: (key) => {
         if (key === 'IS_PUBLISHED') return 'false';
-        if (key === 'USER_DB_ID') return 'db1';
+        if (key === 'DATABASE_ID') return 'db1';
         return null;
       },
       setProperty: jest.fn()

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -14,7 +14,7 @@ function setup({ userEmail = 'admin@example.com', adminEmails = 'admin@example.c
     getScriptProperties: () => ({
       getProperty: (key) => {
         if (key === 'ADMIN_EMAILS') return adminEmails;
-        if (key === 'USER_DB_ID') return 'db1';
+        if (key === 'DATABASE_ID') return 'db1';
         return null;
       },
       setProperty: jest.fn()

--- a/tests/perBoardAdmin.test.js
+++ b/tests/perBoardAdmin.test.js
@@ -3,7 +3,7 @@ const { isUserAdmin } = require('../src/Code.gs');
 function setup({ currentEmail, userId, boardId, adminLists }) {
   const scriptProps = {
     getProperty: (key) => {
-      if (key === 'USER_DB_ID') return 'db1';
+      if (key === 'DATABASE_ID') return 'db1';
       if (key.startsWith('ADMIN_EMAILS_')) {
         const id = key.replace('ADMIN_EMAILS_', '');
         const emails = adminLists[id];

--- a/tests/publishPermissions.test.js
+++ b/tests/publishPermissions.test.js
@@ -5,7 +5,7 @@ function setup(userEmail, adminEmails) {
   const props = {
     getProperty: (key) => {
       if (key === 'ADMIN_EMAILS') return adminEmails.join(',');
-      if (key === 'USER_DB_ID') return 'db1';
+      if (key === 'DATABASE_ID') return 'db1';
       return null;
     },
     setProperty: jest.fn()
@@ -22,14 +22,16 @@ function setup(userEmail, adminEmails) {
     adminEmail: adminEmails[0],
     spreadsheetId: 'id1'
   }));
-  jest.spyOn(gas, 'getUserDatabase').mockImplementation(() => ({
-    getDataRange: () => ({
-      getValues: () => [
-        ['userId','spreadsheetId','adminEmail','configJson','lastAccessedAt'],
-        ['u1','id1','admin@example.com', JSON.stringify({ isPublished: true, sheetName: 'Sheet1' }), '']
-      ]
-    }),
-    getRange: jest.fn(() => ({ setValue: jest.fn() }))
+  jest.spyOn(gas, 'getDatabase').mockImplementation(() => ({
+    getSheetByName: () => ({
+      getDataRange: () => ({
+        getValues: () => [
+          ['userId','spreadsheetId','adminEmail','configJson','lastAccessedAt'],
+          ['u1','id1','admin@example.com', JSON.stringify({ isPublished: true, sheetName: 'Sheet1' }), '']
+        ]
+      }),
+      getRange: jest.fn(() => ({ setValue: jest.fn() }))
+    })
   }));
   global.DriveApp = { getFileById: jest.fn(() => ({ setSharing: jest.fn() })) };
   global.Session = { getActiveUser: () => ({ getEmail: () => userEmail }) };


### PR DESCRIPTION
## Summary
- add `setup` and `getDatabase` helpers for shared user DB
- switch all user DB access to use `getDatabase`
- update unit tests for new `DATABASE_ID` property

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c2db9594832bbf21f0dac5502e3d