### PR TITLE
Fix web app URL mismatch

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -886,15 +886,33 @@ function saveWebAppUrl(url) {
   props.setProperties({ WEB_APP_URL: (url || '').trim() });
 }
 
+function getUrlOrigin(url) {
+  const match = String(url).match(/^(https?:\/\/[^/]+)/);
+  return match ? match[1] : '';
+}
+
 function getWebAppUrl() {
   const props = PropertiesService.getScriptProperties();
-  const url = (props.getProperty('WEB_APP_URL') || '').trim();
-  if (url) return url;
+  let stored = (props.getProperty('WEB_APP_URL') || '').trim();
+  let current = '';
   try {
-    return ScriptApp.getService().getUrl();
+    if (typeof ScriptApp !== 'undefined') {
+      current = ScriptApp.getService().getUrl();
+    }
   } catch (e) {
-    return '';
+    current = '';
   }
+
+  if (current) {
+    const currOrigin = getUrlOrigin(current);
+    const storedOrigin = getUrlOrigin(stored);
+    if (!stored || (storedOrigin && currOrigin && currOrigin !== storedOrigin)) {
+      props.setProperties({ WEB_APP_URL: current.trim() });
+      stored = current.trim();
+    }
+  }
+
+  return stored || current || '';
 }
 
 function saveDeployId(id) {
@@ -1616,6 +1634,7 @@ if (typeof module !== 'undefined') {
     getActiveUserEmail,
     prepareSpreadsheetForStudyQuest,
     isSameDomain,
-    getEmailDomain
+    getEmailDomain,
+    getUrlOrigin
   };
 }

--- a/tests/getWebAppUrl.test.js
+++ b/tests/getWebAppUrl.test.js
@@ -1,0 +1,36 @@
+const { getWebAppUrl } = require('../src/Code.gs');
+
+function setup(stored, current) {
+  const propsObj = {
+    getProperty: (key) => key === 'WEB_APP_URL' ? stored : null,
+    setProperties: jest.fn(),
+    setProperty: jest.fn()
+  };
+  global.PropertiesService = {
+    getScriptProperties: () => propsObj,
+    getUserProperties: () => ({
+      getProperty: jest.fn(),
+      setProperty: jest.fn(),
+      setProperties: jest.fn()
+    })
+  };
+  global.ScriptApp = { getService: () => ({ getUrl: () => current }) };
+  return propsObj;
+}
+
+afterEach(() => {
+  delete global.PropertiesService;
+  delete global.ScriptApp;
+});
+
+test('getWebAppUrl returns stored url when origins match', () => {
+  const props = setup('https://example.com/exec', 'https://example.com/exec');
+  expect(getWebAppUrl()).toBe('https://example.com/exec');
+  expect(props.setProperties).not.toHaveBeenCalled();
+});
+
+test('getWebAppUrl updates url when origin differs', () => {
+  const props = setup('https://old.com/exec', 'https://new.com/exec');
+  expect(getWebAppUrl()).toBe('https://new.com/exec');
+  expect(props.setProperties).toHaveBeenCalledWith({ WEB_APP_URL: 'https://new.com/exec' });
+});


### PR DESCRIPTION
## Summary
- automatically update saved web app URL when the origin changes
- expose `getUrlOrigin` helper
- add unit tests for `getWebAppUrl`

## Testing
- `npm test` *(fails: various unit tests report errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859d762f824832b89426bb7b35ffa37