### PR TITLE
Fix board URL generation

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -440,7 +440,7 @@ function doGet(e) {
     template.userInfo = userInfo;
     template.isOwner = userInfo.adminEmail === viewerEmail;
     template.ownerName = userInfo.adminEmail || 'Unknown';
-    template.boardUrl = `${ScriptApp.getService().getUrl()}?userId=${validatedUserId}`;
+    template.boardUrl = `${getWebAppUrl()}?userId=${validatedUserId}`;
     auditLog('UNPUBLISHED_ACCESS', validatedUserId, { viewerEmail, isOwner: template.isOwner });
     return template.evaluate()
       .setTitle('StudyQuest - 回答ボード')

--- a/src/SheetSelector.html
+++ b/src/SheetSelector.html
@@ -193,7 +193,7 @@
         if (status.activeSheetName) {
           elements.statusText.innerHTML = `<span class="font-bold text-green-400">利用可能</span> - アクティブシート: <span class="font-bold text-blue-400">${status.activeSheetName}</span>`;
           // 生徒用URLを表示
-          const baseUrl = window.location.origin + window.location.pathname;
+          const baseUrl = status.webAppUrl || (window.location.origin + window.location.pathname);
           const boardUrl = `${baseUrl}?userId=${userId}`;
           elements.boardUrl.value = boardUrl;
           elements.viewBoardLink.href = boardUrl;


### PR DESCRIPTION
## Summary
- correct `boardUrl` generation in server-side template
- use provided `webAppUrl` to show board link on admin panel

## Testing
- `npm test` *(fails: getAdminSettings, publishPermissions, doGetUnpublished)*

------
https://chatgpt.com/codex/tasks/task_e_685abb94ab04832b84fc8104263e2178