### PR TITLE
Improve registration flow for existing users

### DIFF
--- a/src/Registration.html
+++ b/src/Registration.html
@@ -132,7 +132,10 @@
       
       <!-- メッセージエリア -->
       <div id="message-area" class="text-center min-h-[24px]" role="alert" aria-live="polite"></div>
-      
+
+      <!-- Existing board info -->
+      <div id="existing-board-area" class="hidden"></div>
+
       <!-- 結果表示エリア -->
       <div id="result-area" class="hidden"></div>
     </div>
@@ -152,10 +155,14 @@
         .withSuccessHandler(email => {
           userEmail = email;
           document.getElementById('user-email').textContent = email || 'メールアドレスを取得できません';
-          
-          // メールアドレスが取得できた場合のみボタンを有効化
+
           if (email) {
             document.getElementById('register-btn').disabled = false;
+
+            // fetch existing board information
+            google.script.run
+              .withSuccessHandler(showExistingBoard)
+              .getExistingBoard();
           } else {
             showMessage('Googleアカウントでログインしてください。', 'error');
           }
@@ -410,6 +417,67 @@
         .registerNewUser(spreadsheetUrl);
     });
     
+    // 既存ボード情報の表示
+    function showExistingBoard(data) {
+      if (!data) return;
+      const area = document.getElementById('existing-board-area');
+      const adminInput = document.createElement('input');
+      adminInput.type = 'text';
+      adminInput.value = data.adminUrl;
+      adminInput.readOnly = true;
+      adminInput.id = 'existing-admin-url';
+      adminInput.className = 'flex-1 p-2 bg-gray-800 border border-gray-600 rounded text-sm cursor-pointer hover:bg-gray-700';
+      adminInput.onclick = function() { this.select(); };
+
+      const viewInput = document.createElement('input');
+      viewInput.type = 'text';
+      viewInput.value = data.viewUrl;
+      viewInput.readOnly = true;
+      viewInput.id = 'existing-view-url';
+      viewInput.className = 'flex-1 p-2 bg-gray-800 border border-gray-600 rounded text-sm cursor-pointer hover:bg-gray-700';
+      viewInput.onclick = function() { this.select(); };
+
+      const adminLink = document.createElement('a');
+      adminLink.href = data.adminUrl;
+      adminLink.target = '_blank';
+      adminLink.className = 'block w-full text-center px-4 py-3 bg-cyan-600 hover:bg-cyan-700 rounded-lg font-semibold transition-colors';
+      adminLink.textContent = '管理画面を開く →';
+
+      area.innerHTML = `
+        <div class="glass-panel rounded-lg p-6 space-y-4">
+          <h3 class="font-bold text-lg text-green-400 flex items-center gap-2">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+            既に登録済みの回答ボードがあります
+          </h3>
+          <div class="space-y-3">
+            <div>
+              <label class="text-sm text-gray-400 block mb-1">管理画面URL（先生用）:</label>
+              <div class="flex gap-2" id="existing-admin-container">
+                <button onclick="copyToClipboard('existing-admin-url')" class="px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded text-sm transition-colors">コピー</button>
+              </div>
+            </div>
+            <div>
+              <label class="text-sm text-gray-400 block mb-1">生徒用URL:</label>
+              <div class="flex gap-2" id="existing-view-container">
+                <button onclick="copyToClipboard('existing-view-url')" class="px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded text-sm transition-colors">コピー</button>
+              </div>
+            </div>
+          </div>
+          <div id="existing-admin-link-container"></div>
+        </div>`;
+
+      const adminContainer = document.getElementById('existing-admin-container');
+      adminContainer.insertBefore(adminInput, adminContainer.firstChild);
+      const viewContainer = document.getElementById('existing-view-container');
+      viewContainer.insertBefore(viewInput, viewContainer.firstChild);
+      const linkContainer = document.getElementById('existing-admin-link-container');
+      linkContainer.appendChild(adminLink);
+
+      area.classList.remove('hidden');
+    }
+
     // メッセージ表示関数
     function showMessage(message, type) {
       const messageArea = document.getElementById('message-area');


### PR DESCRIPTION
## Summary
- show existing board URLs on the registration page
- check for existing user by email on registration
- add helper utilities for fetching current user's board

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abf2c3f30832bb01b4a0d877f5d03