### PR TITLE
Fix admin mode name display

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -1198,7 +1198,11 @@ class StudyQuestApp {
       this.showAdminControls();
       this.updateSortOptions();
       // 管理モード切り替え時は設定変更のため再描画が必要
-      this.loadSheetData(true, false);
+      // 既に読み込み中の場合は完了を待ってからデータを再取得する
+      while (this.state.isLoading) {
+        await new Promise(r => setTimeout(r, 50));
+      }
+      await this.loadSheetData(true, false);
     } finally {
       // ボタンを再度有効化
       if (btn) {


### PR DESCRIPTION
## Summary
- ensure toggleAdminMode waits for any ongoing load before reloading

## Testing
- `npm test` *(fails: buildBoardData tests, publishPermissions tests, getAdminSettings, doGetUnpublished)*

------
https://chatgpt.com/codex/tasks/task_e_685bfa26d4e0832b96742f833b3819cb