### PR TITLE
Ensure names pulled from sheet for all users

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -1121,11 +1121,10 @@ function getSheetData(sheetName, classFilter, sortBy) {
         const likeMultiplier = 1 + (likes * SCORING_CONFIG.LIKE_MULTIPLIER_FACTOR);
         const totalScore = baseScore * likeMultiplier;
         let name = '';
-        if (isAdmin) {
-          name = email ? email.split('@')[0] : '';
-          if (nameHeader && row[headerIndices[nameHeader]]) {
-            name = row[headerIndices[nameHeader]];
-          }
+        if (nameHeader && row[headerIndices[nameHeader]]) {
+          name = row[headerIndices[nameHeader]];
+        } else if (email) {
+          name = email.split('@')[0];
         }
         return {
           rowIndex: index + 2,
@@ -1250,11 +1249,10 @@ function getSheetDataForSpreadsheet(spreadsheet, sheetName, classFilter, sortBy)
         const likeMultiplier = 1 + (likes * SCORING_CONFIG.LIKE_MULTIPLIER_FACTOR);
         const totalScore = baseScore * likeMultiplier;
         let name = '';
-        if (isAdmin) {
-          name = email ? email.split('@')[0] : '';
-          if (nameHeader && row[headerIndices[nameHeader]]) {
-            name = row[headerIndices[nameHeader]];
-          }
+        if (nameHeader && row[headerIndices[nameHeader]]) {
+          name = row[headerIndices[nameHeader]];
+        } else if (email) {
+          name = email.split('@')[0];
         }
         return {
           rowIndex: index + 2,

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -137,7 +137,7 @@ test('getSheetData supports random sort', () => {
   expect(indexes).toEqual([2, 3]);
 });
 
-test('getSheetData omits names for non-admin', () => {
+test('getSheetData derives name from email for non-admin', () => {
   ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
   const data = [
     [
@@ -159,7 +159,7 @@ test('getSheetData omits names for non-admin', () => {
 
   const result = getSheetData('Sheet1');
 
-  expect(result.rows[0].name).toBe('');
+  expect(result.rows[0].name).toBe('a');
 });
 
 test('getSheetData returns names for admin users', () => {
@@ -227,7 +227,7 @@ test('reaction lists trim spaces and ignore empties', () => {
   expect(row.reactions.CURIOUS.count).toBe(0);
 });
 
-test('getSheetData supports custom headers from config', () => {
+test('getSheetData supports custom headers from config for non-admin', () => {
   global.getConfig = () => ({
     questionHeader: 'Question',
     answerHeader: 'Ans',
@@ -251,7 +251,7 @@ test('getSheetData supports custom headers from config', () => {
     ],
     ['a@example.com', '1-1', 'Answer1', 'Because', '2024-08-01T00:00:00Z', '', '', '', 'false', 'Alice']
   ];
-  setupMocks(data, 'a@example.com', 'a@example.com');
+  setupMocks(data, 'a@example.com', '');
 
   const result = getSheetData('Sheet1');
 


### PR DESCRIPTION
## Summary
- always populate `name` from the configured header when available
- fall back to deriving name from email even for non-admin users
- adjust unit tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d351ecc30832b84b7bcc0391a8f07