### PR TITLE
Improve header guessing and add tests

### DIFF
--- a/tests/guessHeadersFromArray.test.js
+++ b/tests/guessHeadersFromArray.test.js
@@ -1,0 +1,25 @@
+const { guessHeadersFromArray } = require('../src/Code.gs');
+
+test('guessHeadersFromArray detects japanese synonyms', () => {
+  const headers = ['問い', 'コメント', 'わけ', 'ニックネーム', '班'];
+  const result = guessHeadersFromArray(headers);
+  expect(result).toEqual({
+    questionHeader: '問い',
+    answerHeader: 'コメント',
+    reasonHeader: 'わけ',
+    nameHeader: 'ニックネーム',
+    classHeader: '班'
+  });
+});
+
+test('guessHeadersFromArray handles full width and spacing', () => {
+  const headers = [' Ｑｕｅｓｔｉｏｎ ', 'Ａｎｓｗｅｒ', ' Reason ', ' NAME ', 'CLASSROOM'];
+  const result = guessHeadersFromArray(headers);
+  expect(result).toEqual({
+    questionHeader: ' Ｑｕｅｓｔｉｏｎ ',
+    answerHeader: 'Ａｎｓｗｅｒ',
+    reasonHeader: ' Reason ',
+    nameHeader: ' NAME ',
+    classHeader: 'CLASSROOM'
+  });
+});


### PR DESCRIPTION
## Summary
- expand keyword lists and normalize header matching logic in `guessHeadersFromArray`
- export `guessHeadersFromArray`
- test new header matching patterns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d3868f750832bbfe4edbff9903426