### PR TITLE
Add preview mode with mock data

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -1344,7 +1344,7 @@
         return;
       }
       const baseUrl = window.location.origin + window.location.pathname;
-      const previewUrl = `${baseUrl}?userId=${userId}`;
+      const previewUrl = `${baseUrl}?mode=preview`;
       window.open(previewUrl, '_blank');
     }
 

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -429,6 +429,14 @@ function doGet(e) {
     const params = e.parameter || {};
     const userId = params.userId;
     const mode = params.mode;
+
+    // プレビューモードはモックデータを表示
+    if (mode === 'preview') {
+      return HtmlService.createTemplateFromFile('Preview')
+        .evaluate()
+        .setTitle('StudyQuest - プレビュー')
+        .addMetaTag('viewport', 'width=device-width, initial-scale=1');
+    }
     
     // ユーザーIDがない場合は登録画面を表示
     if (!userId) {

--- a/src/Preview.html
+++ b/src/Preview.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>StudyQuest - プレビュー</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { background-color: #1f2937; color: white; margin: 0; }
+  </style>
+</head>
+<body class="p-4">
+  <h1 class="text-2xl font-bold mb-4">回答プレビュー</h1>
+  <main class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+    <div class="bg-gray-700 p-4 rounded shadow">
+      <h3 class="text-cyan-200 text-xl font-semibold">サンプル回答</h3>
+      <p class="mt-2">ここに理由が表示されます。</p>
+      <div class="mt-4 flex justify-between items-center">
+        <span class="text-sm text-gray-300">ニックネーム</span>
+        <div class="flex gap-2">
+          <button class="bg-green-600 text-sm px-2 py-1 rounded">👍 0</button>
+          <button class="bg-blue-600 text-sm px-2 py-1 rounded">🤔 0</button>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `Preview.html` with sample content
- allow `mode=preview` in `doGet` to show mock preview
- update Admin panel to open the preview

## Testing
- `npm run pull` *(fails: `clasp` not found)*
- `npm run push` *(fails: No credentials found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f1dc61c60832bb996a3b8210b214f