### PR TITLE
Fix email validation regex

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -43,6 +43,7 @@ const TIME_CONSTANTS = {
 };
 
 const REACTION_KEYS = ["UNDERSTAND","LIKE","CURIOUS"];
+const EMAIL_REGEX = /^[^\n@]+@[^\n@]+\.[^\n@]+$/;
 var getConfig;
 var handleError;
 
@@ -86,11 +87,7 @@ function isValidEmail(email) {
   if (!email || typeof email !== 'string') {
     return false;
   }
-  const emailRegex = /^[^
-@]+@[^
-@]+\.[^
-@]+$/;
-  return emailRegex.test(email);
+  return EMAIL_REGEX.test(email);
 }
 
 function getEmailDomain(email) {


### PR DESCRIPTION
## Summary
- fix regex syntax in `Code.gs`
- use constant for email validation

## Testing
- `npm test` *(fails: Cannot read properties of undefined or missing functions)*

------
https://chatgpt.com/codex/tasks/task_e_685f77e7bc4c832b8ec9e7f722de40d2