### PR TITLE
Fix missing getActiveUserEmail

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -83,6 +83,16 @@ function safeGetUserEmail() {
   }
 }
 
+/**
+ * フロントエンドから現在のユーザーのメールアドレスを取得するためのラッパー。
+ * Registration.html などから呼び出される。
+ *
+ * @return {string} ユーザーのメールアドレス
+ */
+function getActiveUserEmail() {
+  return safeGetUserEmail();
+}
+
 function isValidEmail(email) {
   if (!email || typeof email !== 'string') {
     return false;


### PR DESCRIPTION
## Summary
- add `getActiveUserEmail` server-side function used in Registration.html

## Testing
- `npm test --silent` *(fails: TypeError: saveWebAppUrl is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_685f7e205048832b9314a24269ba16f6