### PR TITLE
Add admin check before rendering AdminPanel

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -579,6 +579,17 @@ function doGet(e) {
   
     // 管理モードの場合
     if (mode === 'admin') {
+      // 管理者権限のチェック
+      if (!(viewerEmail === userInfo.adminEmail || isUserAdmin(viewerEmail))) {
+        auditLog('ADMIN_ACCESS_DENIED', validatedUserId, { viewerEmail });
+        if (typeof HtmlService !== 'undefined') {
+          const output = HtmlService.createHtmlOutput('権限がありません。');
+          applySecurityHeaders(output);
+          return output.setTitle('アクセス拒否');
+        }
+        throw new Error('権限がありません。');
+      }
+
       const template = HtmlService.createTemplateFromFile('AdminPanel');
       template.userId = validatedUserId;
       template.userInfo = userInfo;

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -93,3 +93,11 @@ test('different domain user receives permission error', () => {
   doGet({ parameter: { userId: 'user1234567' } });
   expect(HtmlService.createHtmlOutput).toHaveBeenCalledWith(expect.stringContaining('システムエラー'));
 });
+
+test('non admin requesting admin mode receives permission error', () => {
+  setup({ userEmail: 'viewer@example.com' });
+  const output = { setTitle: jest.fn(() => output) };
+  global.HtmlService.createHtmlOutput = jest.fn(() => output);
+  doGet({ parameter: { userId: 'user1234567', mode: 'admin' } });
+  expect(HtmlService.createHtmlOutput).toHaveBeenCalledWith(expect.stringContaining('権限'));
+});


### PR DESCRIPTION
## Summary
- validate admin privileges inside `doGet` when `mode === 'admin'`
- return an access denied message when a non-admin requests admin mode
- add test for this new admin check

## Testing
- `npm test` *(fails: SyntaxError: Identifier 'config' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_685fefdd0288832ba8b4885f85625b9c