### PR TITLE
Fix unsupported meta tag in Code.gs

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -143,10 +143,10 @@ function secureHandleError(prefix, error, returnObject = false) {
 
 function applySecurityHeaders(output) {
   if (output && typeof output.addMetaTag === 'function') {
-    output.addMetaTag(
-      'Content-Security-Policy',
-      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
-    );
+    // NOTE: Apps Script does not allow setting the Content-Security-Policy
+    // header via addMetaTag. Attempting to do so results in
+    // "The specified meta tag cannot be used in this context" errors.
+    // Keep other security related headers only.
     if (typeof output.setXFrameOptionsMode === 'function') {
       // Allow embedding within the same origin by default for enhanced security
       // unless a future embedding requirement mandates ALLOWALL.


### PR DESCRIPTION
## Summary
- remove Content-Security-Policy meta tag from security headers

## Testing
- `npm install`
- `npm test` *(fails: getWebAppUrl updates url when origin differs, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68603b996ae0832ba3f740b79a2a2637