### PR TITLE
Fix XFrameOptions constant

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -150,7 +150,9 @@ function applySecurityHeaders(output) {
     if (typeof output.setXFrameOptionsMode === 'function') {
       // Allow embedding within the same origin by default for enhanced security
       // unless a future embedding requirement mandates ALLOWALL.
-      output.setXFrameOptionsMode(HtmlService.XFrameOptionsMode.SAMEORIGIN);
+      // "SAMEORIGIN" isn't a valid constant. Use DEFAULT to enforce
+      // the same-origin policy, which preserves standard security behavior.
+      output.setXFrameOptionsMode(HtmlService.XFrameOptionsMode.DEFAULT);
     }
   }
   return output;


### PR DESCRIPTION
## Summary
- use correct XFrameOptionsMode enum constant

## Testing
- `npm test` *(fails: addReaction, publish permissions, getWebAppUrl, saveSheetConfig, saveDeployId)*

------
https://chatgpt.com/codex/tasks/task_e_68603cf8a650832b95e23c37979cdaee