### PR TITLE
Add spreadsheet open action

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -432,6 +432,12 @@
                 </a>
               </div>
             </div>
+            <button type="button" id="open-spreadsheet-btn" class="btn btn-secondary w-full">
+              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-6h13v6M9 9V7a2 2 0 012-2h8a2 2 0 012 2v2" />
+              </svg>
+              スプレッドシートを開く
+            </button>
           </div>
         </div>
       </div>
@@ -1017,7 +1023,8 @@
       copyFormUrlBtn: document.getElementById('copy-form-url-btn'),
       openFormUrlLink: document.getElementById('open-form-url-link'),
       endBoardBtn: document.getElementById('end-board-btn'),
-      openFormBtn: document.getElementById('open-form-btn')
+      openFormBtn: document.getElementById('open-form-btn'),
+      openSpreadsheetBtn: document.getElementById('open-spreadsheet-btn')
       };
 
     // ドメイン情報を取得して表示
@@ -1107,6 +1114,20 @@
       }
       if (elements.copyFormUrlBtn) {
         elements.copyFormUrlBtn.addEventListener('click', () => copyUrl(elements.formUrlInput, 'フォームURLをコピーしました'));
+      }
+      if (elements.openSpreadsheetBtn) {
+        elements.openSpreadsheetBtn.addEventListener('click', () => {
+          google.script.run
+            .withSuccessHandler(url => {
+              if (url) {
+                window.open(url, '_blank');
+              } else {
+                showMessage('スプレッドシートURLが取得できません', 'yellow');
+              }
+            })
+            .withFailureHandler(showError)
+            .openActiveSpreadsheet();
+        });
       }
 
       // Open Form Button - 初期設定（updateFormInfo() 関数で上書きされます）

--- a/src/config.gs
+++ b/src/config.gs
@@ -31,6 +31,21 @@ function getCurrentSpreadsheet() {
 }
 
 /**
+ * アクティブなスプレッドシートのURLを取得
+ * AdminPanel.htmlから呼び出される
+ * @returns {string} スプレッドシートURL
+ */
+function openActiveSpreadsheet() {
+  try {
+    var ss = getCurrentSpreadsheet();
+    return ss.getUrl();
+  } catch (e) {
+    console.error('openActiveSpreadsheet エラー: ' + e.message);
+    throw new Error('スプレッドシートのURL取得に失敗しました: ' + e.message);
+  }
+}
+
+/**
  * 簡易設定取得関数（AdminPanel.htmlとの互換性のため）
  * 新アーキテクチャでは基本的にデフォルト設定を使用
  */


### PR DESCRIPTION
## Summary
- enable admins to open the active spreadsheet from Quick Actions
- expose `openActiveSpreadsheet` server function

## Testing
- `npm install`
- `npm test` *(fails: ReferenceError: getConfig is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6864d1801ae4832ba77830297e14af92