### PR TITLE
Fix deleted references and adjust tests

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -81,7 +81,7 @@ var SCORING_CONFIG = {
 };
 
 var ROSTER_CONFIG = {
-  SHEET_NAME: getConfig().rosterSheetName,
+  SHEET_NAME: (typeof getConfig === 'function' ? getConfig().rosterSheetName : '名簿'),
   EMAIL_COLUMN: 'メールアドレス',
   NAME_COLUMN: '名前',
   CLASS_COLUMN: 'クラス'
@@ -117,7 +117,7 @@ function debugLog() {
  * @returns {object} Sheets APIサービス
  */
 function getSheetsService() {
-  var accessToken = getServiceAccountToken();
+  var accessToken = getServiceAccountTokenCached();
   
   return {
     spreadsheets: {

--- a/src/Page.html
+++ b/src/Page.html
@@ -827,7 +827,7 @@ class StudyQuestApp {
     ];
     this.gas = {
       getPublishedSheetData: (sheetName, classFilter, sort) => this.runGas('getPublishedSheetData', sheetName, classFilter, sort),
-      getAvailableSheets: () => this.runGas('getSheetsListOptimized'),
+      getAvailableSheets: () => this.runGas('getAvailableSheets'),
       addReaction: (rowIndex, reaction, sheetName) => this.runGas('addReaction', rowIndex, reaction, sheetName),
       toggleHighlight: (rowIndex, sheetName) => this.runGas('toggleHighlight', rowIndex, sheetName),
       checkAdmin: () => this.runGas('checkAdmin')

--- a/tests/addLike.test.js
+++ b/tests/addLike.test.js
@@ -1,4 +1,5 @@
-const { addReaction, COLUMN_HEADERS } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { addReaction, COLUMN_HEADERS } = loadCode();
 
 function buildSheet() {
   const headerRow = [

--- a/tests/addLikeColumn.test.js
+++ b/tests/addLikeColumn.test.js
@@ -1,4 +1,5 @@
-const { addReaction, COLUMN_HEADERS } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { addReaction, COLUMN_HEADERS } = loadCode();
 
 function buildSheet() {
   const headerRow = [

--- a/tests/buildBoardData.test.js
+++ b/tests/buildBoardData.test.js
@@ -1,5 +1,5 @@
-const { buildBoardData } = require('../src/Code.gs');
-const { COLUMN_HEADERS } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { buildBoardData, COLUMN_HEADERS } = loadCode();
 
 function setup({configRows, dataRows}) {
   global.SpreadsheetApp = {

--- a/tests/checkAdmin.test.js
+++ b/tests/checkAdmin.test.js
@@ -1,4 +1,5 @@
-const { checkAdmin } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { checkAdmin } = loadCode();
 
 function setup(admins, currentEmail) {
   global.PropertiesService = {

--- a/tests/doGetUnpublished.test.js
+++ b/tests/doGetUnpublished.test.js
@@ -1,4 +1,5 @@
-const { doGet } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { doGet } = loadCode();
 
 afterEach(() => {
   delete global.PropertiesService;

--- a/tests/doGetView.test.js
+++ b/tests/doGetView.test.js
@@ -1,4 +1,5 @@
-const { doGet } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { doGet } = loadCode();
 
 afterEach(() => {
   delete global.HtmlService;

--- a/tests/findHeaderIndices.test.js
+++ b/tests/findHeaderIndices.test.js
@@ -1,4 +1,5 @@
-const { findHeaderIndices } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { findHeaderIndices } = loadCode();
 
 test('findHeaderIndices returns indices for existing headers', () => {
   const headers = ['A', 'B', 'C'];

--- a/tests/getAdminSettings.test.js
+++ b/tests/getAdminSettings.test.js
@@ -1,4 +1,5 @@
-const { getAdminSettings } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { getAdminSettings } = loadCode();
 function setup() {
   global.PropertiesService = {
     getScriptProperties: () => ({

--- a/tests/getHeaderIndices.test.js
+++ b/tests/getHeaderIndices.test.js
@@ -1,4 +1,5 @@
-const { getHeaderIndices, COLUMN_HEADERS } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { getHeaderIndices, COLUMN_HEADERS } = loadCode();
 
 function setup(headers) {
   const sheet = {

--- a/tests/getSheetData.test.js
+++ b/tests/getSheetData.test.js
@@ -1,3 +1,4 @@
+const { loadCode } = require('./shared-mocks');
 let getSheetData;
 let COLUMN_HEADERS;
 
@@ -53,7 +54,7 @@ afterEach(() => {
 });
 
 test('getSheetData filters and scores rows', () => {
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -72,7 +73,7 @@ test('getSheetData filters and scores rows', () => {
   ];
   setupMocks(data, 'b@example.com', 'b@example.com');
 
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
 
   const result = getSheetData('Sheet1', undefined, 'score');
 
@@ -85,7 +86,7 @@ test('getSheetData filters and scores rows', () => {
 });
 
 test('getSheetData sorts by newest when specified', () => {
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -103,7 +104,7 @@ test('getSheetData sorts by newest when specified', () => {
   ];
   setupMocks(data, '', '');
 
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
 
   const result = getSheetData('Sheet1', undefined, 'newest');
 
@@ -111,7 +112,7 @@ test('getSheetData sorts by newest when specified', () => {
 });
 
 test('getSheetData supports random sort', () => {
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -129,7 +130,7 @@ test('getSheetData supports random sort', () => {
   ];
   setupMocks(data, '', '');
 
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
 
   const result = getSheetData('Sheet1', undefined, 'random');
 
@@ -138,7 +139,7 @@ test('getSheetData supports random sort', () => {
 });
 
 test('getSheetData derives name from email for non-admin', () => {
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -155,7 +156,7 @@ test('getSheetData derives name from email for non-admin', () => {
   ];
   setupMocks(data, 'a@example.com', '');
 
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
 
   const result = getSheetData('Sheet1');
 
@@ -163,7 +164,7 @@ test('getSheetData derives name from email for non-admin', () => {
 });
 
 test('getSheetData returns names for admin users', () => {
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -180,7 +181,7 @@ test('getSheetData returns names for admin users', () => {
   ];
   setupMocks(data, 'a@example.com', 'a@example.com');
 
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
 
   const result = getSheetData('Sheet1');
 
@@ -188,7 +189,7 @@ test('getSheetData returns names for admin users', () => {
 });
 
 test('reaction lists trim spaces and ignore empties', () => {
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -215,7 +216,7 @@ test('reaction lists trim spaces and ignore empties', () => {
   ];
   setupMocks(data, 'a@example.com', 'a@example.com');
 
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
 
   const result = getSheetData('Sheet1');
 
@@ -235,7 +236,7 @@ test('getSheetData supports custom headers from config for non-admin', () => {
     nameHeader: 'Name',
     classHeader: 'Class'
   });
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -269,7 +270,7 @@ test('getSheetData uses question column when answer header missing', () => {
     classHeader: 'Class'
   });
 
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
   const data = [
     [
       COLUMN_HEADERS.EMAIL,
@@ -302,7 +303,7 @@ test('getSheetData uses answer column when question header missing', () => {
     classHeader: 'Class'
   });
 
-  ({ getSheetData, COLUMN_HEADERS } = require('../src/Code.gs'));
+  ({ getSheetData, COLUMN_HEADERS } = require('./shared-mocks').loadCode());
   const data = [
     [
       COLUMN_HEADERS.EMAIL,

--- a/tests/getSheetHeaders.test.js
+++ b/tests/getSheetHeaders.test.js
@@ -1,4 +1,5 @@
-const { getSheetHeaders } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { getSheetHeaders } = loadCode();
 
 function setup(headers) {
   const sheet = {

--- a/tests/getWebAppUrl.test.js
+++ b/tests/getWebAppUrl.test.js
@@ -1,4 +1,5 @@
-const { getWebAppUrl } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { getWebAppUrl } = loadCode();
 
 function setup(stored, current) {
   const propsObj = {

--- a/tests/guessHeadersFromArray.test.js
+++ b/tests/guessHeadersFromArray.test.js
@@ -1,4 +1,5 @@
-const { guessHeadersFromArray } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { guessHeadersFromArray } = loadCode();
 
 test('guessHeadersFromArray detects japanese synonyms', () => {
   const headers = ['問い', 'コメント', 'わけ', 'ニックネーム', '班'];

--- a/tests/parseReactionString.test.js
+++ b/tests/parseReactionString.test.js
@@ -1,4 +1,5 @@
-const { parseReactionString } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { parseReactionString } = loadCode();
 
 test('parseReactionString trims spaces and filters empties', () => {
   expect(parseReactionString(' a@example.com , b@example.com  ')).toEqual([

--- a/tests/perBoardAdmin.test.js
+++ b/tests/perBoardAdmin.test.js
@@ -1,4 +1,5 @@
-const { isUserAdmin } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { isUserAdmin } = loadCode();
 
 function setup({ currentEmail, userId, boardId, adminLists }) {
   const scriptProps = {

--- a/tests/prepareSheetForBoard.test.js
+++ b/tests/prepareSheetForBoard.test.js
@@ -1,4 +1,5 @@
-const { prepareSheetForBoard, COLUMN_HEADERS } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { prepareSheetForBoard, COLUMN_HEADERS } = loadCode();
 
 function setup(headers) {
   const sheet = {

--- a/tests/saveDeployId.test.js
+++ b/tests/saveDeployId.test.js
@@ -1,4 +1,5 @@
-const { saveDeployId } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { saveDeployId } = loadCode();
 
 function setup() {
   const props = { setProperties: jest.fn(), deleteProperty: jest.fn(), getProperty: jest.fn(() => '') };

--- a/tests/saveSheetConfig.test.js
+++ b/tests/saveSheetConfig.test.js
@@ -1,4 +1,5 @@
-const { saveSheetConfig } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { saveSheetConfig } = loadCode();
 
 function setup(initialRows) {
   const rows = initialRows.slice();

--- a/tests/saveWebAppUrl.test.js
+++ b/tests/saveWebAppUrl.test.js
@@ -1,4 +1,5 @@
-const { saveWebAppUrl } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { saveWebAppUrl } = loadCode();
 
 function setup() {
   const props = { setProperties: jest.fn(), deleteProperty: jest.fn() };

--- a/tests/shared-mocks.js
+++ b/tests/shared-mocks.js
@@ -218,16 +218,24 @@ let codeEvaluated = false;
 
 function ensureCodeEvaluated() {
   if (!codeEvaluated) {
-    console.log('🔧 Evaluating Code.gs...');
-    const codeGsPath = path.join(__dirname, '../src/Code.gs');
-    const codeContent = fs.readFileSync(codeGsPath, 'utf8');
-    
-    // Use eval in global context to ensure functions are globally available
-    (1, eval)(codeContent);
-    
+    console.log('🔧 Evaluating GAS source files...');
+
+    const srcDir = path.join(__dirname, '../src');
+    const files = fs.readdirSync(srcDir).filter(f => f.endsWith('.gs'));
+    files.forEach(file => {
+      const content = fs.readFileSync(path.join(srcDir, file), 'utf8');
+      (1, eval)(content);
+    });
+
     codeEvaluated = true;
-    console.log('✅ Code.gs evaluation completed');
+    console.log('✅ GAS source evaluation completed');
   }
+}
+
+function loadCode() {
+  setupGlobalMocks();
+  ensureCodeEvaluated();
+  return global;
 }
 
 function resetMocks() {
@@ -241,6 +249,7 @@ function resetMocks() {
 module.exports = {
   setupGlobalMocks,
   ensureCodeEvaluated,
+  loadCode,
   resetMocks,
   mockDatabase,
   mockSpreadsheetData

--- a/tests/toggleHighlight.test.js
+++ b/tests/toggleHighlight.test.js
@@ -1,4 +1,5 @@
-const { toggleHighlight, COLUMN_HEADERS } = require('../src/Code.gs');
+const { loadCode } = require('./shared-mocks');
+const { toggleHighlight, COLUMN_HEADERS } = loadCode();
 
 function buildSheet(name = 'Sheet1') {
   const headerRow = [


### PR DESCRIPTION
## Summary
- remove lingering `getServiceAccountToken` call and fallback to cached token
- guard `ROSTER_CONFIG` against missing `getConfig`
- call `getAvailableSheets` from `Page.html`
- load all `.gs` files in Jest helper and provide `loadCode()` helper
- update tests to import functions via `loadCode`

## Testing
- `npm test` *(fails: getSheetData and others rely on unmocked GAS services)*

------
https://chatgpt.com/codex/tasks/task_e_6865133500ec832b8a061bd396bb53ec