### PR TITLE
Fix user config loading errors

### DIFF
--- a/src/CacheManager.gs
+++ b/src/CacheManager.gs
@@ -195,7 +195,8 @@ function getRosterMapCached(spreadsheetId) {
   return getCachedValue(key, function() {
     try {
       var service = getOptimizedSheetsService();
-      var response = batchGetSheetsData(service, spreadsheetId, [ROSTER_CONFIG.SHEET_NAME + '!A:Z']);
+      var rosterRange = getRosterSheetName() + '!A:Z';
+      var response = batchGetSheetsData(service, spreadsheetId, [rosterRange]);
       var values = response.valueRanges[0].values || [];
       
       if (values.length === 0) return {};

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -81,7 +81,8 @@ var SCORING_CONFIG = {
 };
 
 var ROSTER_CONFIG = {
-  SHEET_NAME: (typeof getConfig === 'function' ? getConfig().rosterSheetName : '名簿'),
+  // デフォルト値のみ定義し、実際のシート名は getRosterSheetName() で取得
+  SHEET_NAME: '名簿',
   EMAIL_COLUMN: 'メールアドレス',
   NAME_COLUMN: '名前',
   CLASS_COLUMN: 'クラス'
@@ -872,7 +873,7 @@ function getRosterMap(spreadsheetId) {
   
   try {
     var service = getSheetsService();
-    var range = ROSTER_CONFIG.SHEET_NAME + '!A:Z';
+    var range = getRosterSheetName() + '!A:Z';
     var response = service.spreadsheets.values.get(spreadsheetId, range);
     var values = response.values || [];
     

--- a/src/Core.gs
+++ b/src/Core.gs
@@ -616,7 +616,7 @@ function getSheetDataOptimized(userId, sheetName, classFilter, sortMode) {
     // バッチでデータ、ヘッダー、名簿を取得
     var ranges = [
       sheetName + '!A:Z',
-      getConfig().rosterSheetName + '!A:Z'
+      getRosterSheetName() + '!A:Z'
     ];
     
     var responses = batchGetSheetsData(service, spreadsheetId, ranges);

--- a/src/config.gs
+++ b/src/config.gs
@@ -88,6 +88,20 @@ function getConfig() {
 }
 
 /**
+ * 名簿シート名を取得
+ * @returns {string} 名簿シート名
+ */
+function getRosterSheetName() {
+  try {
+    var cfg = getConfig();
+    return cfg.rosterSheetName || '名簿';
+  } catch (e) {
+    console.warn('getRosterSheetName error: ' + e.message);
+    return '名簿';
+  }
+}
+
+/**
  * 簡易設定保存関数（AdminPanel.htmlとの互換性のため）
  * 新アーキテクチャでは実際の保存は行わない
  */


### PR DESCRIPTION
## Summary
- avoid calling `getConfig()` at global scope
- add helper to safely retrieve roster sheet name
- use helper in Core.gs and CacheManager.gs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686527c6ac38832ba9b5c9ce100a39a8