### PR TITLE
Fix missing createUserInDb wrapper

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -463,6 +463,10 @@ function findUserByEmail(email) {
   return findUserByEmailOptimized(email);
 }
 
+function createUserInDb(userData) {
+  return createUserOptimized(userData);
+}
+
 function updateUserInDb(userId, updateData) {
   return updateUserOptimized(userId, updateData);
 }


### PR DESCRIPTION
## Summary
- add missing `createUserInDb` wrapper that calls `createUserOptimized`

## Testing
- `npm test` *(fails: getSheetData and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_6865366433f8832b8d67f1d7f9cb221d