### PR TITLE
Improve app config consistency

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -254,6 +254,29 @@ function getAppConfig() {
     }
     
     var configJson = JSON.parse(userInfo.configJson || '{}');
+
+    // --- Auto-healing for inconsistent setup states ---
+    var needsUpdate = false;
+    if (configJson.formUrl && !configJson.formCreated) {
+      configJson.formCreated = true;
+      needsUpdate = true;
+    }
+    if (configJson.formCreated && configJson.setupStatus !== 'completed') {
+      configJson.setupStatus = 'completed';
+      needsUpdate = true;
+    }
+    if (configJson.publishedSheet && !configJson.appPublished) {
+      configJson.appPublished = true;
+      needsUpdate = true;
+    }
+    if (needsUpdate) {
+      try {
+        updateUserOptimized(currentUserId, { configJson: JSON.stringify(configJson) });
+      } catch (updateErr) {
+        console.warn('Config auto-heal failed: ' + updateErr.message);
+      }
+    }
+
     var sheets = getSheetsListOptimized(currentUserId);
     var appUrls = generateAppUrlsOptimized(currentUserId);
     


### PR DESCRIPTION
## Summary
- auto-heal inconsistent `configJson` values so the admin panel reflects the real board status

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: CacheService is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6865b6fa114c832b83c523c13bf65668