### PR TITLE
Fix URL generation logic

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -2907,21 +2907,25 @@
 
     // ★ 修正点：サーバーに登録ページのURLを問い合わせる
     google.script.run
-      .withSuccessHandler(function(webAppUrl) { // getWebAppUrlCached() は webAppUrl を返す
+      .withSuccessHandler(function(webAppUrl) {
         // サーバーから取得した正規のURLにリダイレクト
         // doGet() が userId がない場合に Registration.html にリダイレクトするため、
         // ベースURLにリダイレクトすれば良い
         window.top.location.href = webAppUrl;
       })
-      .getWebAppUrlCached(); // getWebAppUrlCached() を呼び出す
+      .getWebAppUrl();
   }
     
     // ページ再読み込み（新しいアカウント用）
     function reloadPageForNewAccount() {
       sessionStorage.setItem('treat_as_new_account', 'true');
-      // 管理パネルから新規登録画面にリダイレクト
-      const currentUrl = window.location.href.split('?')[0];
-      window.location.href = currentUrl + '?t=' + Date.now();
+      google.script.run
+        .withSuccessHandler(function(url) {
+          const newUrl = new URL(url);
+          newUrl.searchParams.set('t', Date.now());
+          window.top.location.href = newUrl.toString();
+        })
+        .getWebAppUrl();
     }
 
     // クライアントサイドキャッシュクリア関数

--- a/src/Page.html
+++ b/src/Page.html
@@ -2471,10 +2471,13 @@ class StudyQuestApp {
     }
   }
   endAdminMode() {
-    // Redirect to admin URL with mode=admin parameter to show management interface
-    const currentUrl = new URL(window.location.href);
-    currentUrl.searchParams.set('mode', 'admin');
-    window.location.href = currentUrl.toString();
+    google.script.run
+      .withSuccessHandler(function(adminUrl) {
+        const url = new URL(adminUrl);
+        url.searchParams.set('mode', 'admin');
+        window.location.href = url.toString();
+      })
+      .getWebAppUrl();
   }
   updateReactionButtonUI(rowIndex, reaction, count, reacted) {
     document.querySelectorAll('[data-row-index="' + rowIndex + '"][data-reaction="' + reaction + '"]').forEach(btn => {

--- a/src/Registration.html
+++ b/src/Registration.html
@@ -748,8 +748,16 @@
                       updateStep(3);
                       showMessage('セットアップが必要です。管理者にセットアップページでの初期設定を依頼してください。', 'warning');
                       // セットアップページへのリンクを表示
-                      const setupUrl = window.location.href.split('?')[0] + '?setup=true';
-                      showMessage(`セットアップページ: <a href="${setupUrl}" target="_blank" style="color: #8be9fd;">こちら</a>`, 'info');
+                      google.script.run
+                        .withSuccessHandler((appUrl) => {
+                          const setupUrl = appUrl + '?setup=true';
+                          showMessage(`セットアップページ: <a href="${setupUrl}" target="_blank" style="color: #8be9fd;">こちら</a>`, 'info');
+                        })
+                        .withFailureHandler(() => {
+                          const setupUrl = window.location.href.split('?')[0] + '?setup=true';
+                          showMessage(`セットアップページ: <a href="${setupUrl}" target="_blank" style="color: #8be9fd;">こちら</a>`, 'info');
+                        })
+                        .getWebAppUrl();
                       break;
                     case 'existing_user':
                       updateStep(3);
@@ -1202,6 +1210,22 @@
       } catch (error) {
         console.warn('クライアントサイドキャッシュクリアでエラーが発生:', error);
       }
+    }
+
+    function reloadPageForNewAccount() {
+      sessionStorage.setItem('treat_as_new_account', 'true');
+      google.script.run
+        .withSuccessHandler(function(url) {
+          const newUrl = new URL(url);
+          newUrl.searchParams.set('t', Date.now());
+          window.top.location.href = newUrl.toString();
+        })
+        .withFailureHandler(function(error) {
+          console.error('URL取得に失敗しました:', error);
+          const currentUrl = window.location.href.split('?')[0];
+          window.top.location.href = currentUrl + '?t=' + Date.now();
+        })
+        .getWebAppUrl();
     }
     
     // URLパラメータをチェックして新規アカウント扱いにする

--- a/src/SetupPage.html
+++ b/src/SetupPage.html
@@ -130,9 +130,9 @@
                 🔍 システムテスト実行
             </button>
             <div class="mt-4">
-                <a id="start-studyquest-btn" class="inline-block btn bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-bold py-2 px-4 rounded-lg">
+                <button type="button" id="start-studyquest-btn" onclick="startApp()" class="inline-block btn bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-bold py-2 px-4 rounded-lg">
                     📚 StudyQuestを開始
-                </a>
+                </button>
             </div>
         </div>
 
@@ -254,18 +254,6 @@
                         .withSuccessHandler((result) => {
                             showMessage('✅ セットアップが正常に完了しました！', 'success');
                             document.getElementById('test-section').classList.remove('hidden');
-                            
-                            // Dynamically set the URL for the "Start StudyQuest" button
-                            google.script.run
-                                .withSuccessHandler((webAppUrl) => {
-                                    document.getElementById('start-studyquest-btn').href = webAppUrl;
-                                })
-                                .withFailureHandler((error) => {
-                                    console.error('Failed to get web app URL:', error);
-                                    showMessage('❌ アプリケーションURLの取得に失敗しました。', 'error');
-                                })
-                                .getWebAppUrlCached(); // Call the server-side function
-                            
                             resolve(result);
                         })
                         .withFailureHandler((error) => {
@@ -328,6 +316,27 @@
                 this.style.borderColor = '#ef4444';
             }
         });
+
+        function startApp() {
+            const btn = document.getElementById('start-studyquest-btn');
+            if (btn) {
+                btn.innerHTML = '<span>読み込み中...</span>';
+                btn.disabled = true;
+            }
+
+            google.script.run
+                .withSuccessHandler(function(url) {
+                    window.top.location.href = url;
+                })
+                .withFailureHandler(function(error) {
+                    alert('アプリケーションのURL取得に失敗しました: ' + error.message);
+                    if (btn) {
+                        btn.innerHTML = '📚 StudyQuestを開始';
+                        btn.disabled = false;
+                    }
+                })
+                .getWebAppUrl();
+        }
     </script>
 </body>
 </html>

--- a/src/url.gs
+++ b/src/url.gs
@@ -4,7 +4,7 @@
 
 // URL管理の定数
 var URL_CACHE_KEY = 'WEB_APP_URL';
-var URL_CACHE_TTL = 3600; // 1時間
+var URL_CACHE_TTL = 21600; // 6時間
 
 /**
  * WebアプリのURLを取得（キャッシュ利用）
@@ -25,7 +25,7 @@ function getWebAppUrlCached() {
       console.error('WebアプリURL取得エラー: ' + e.message);
       return getFallbackUrl();
     }
-  }, { ttl: 3600 });
+  }, { ttl: URL_CACHE_TTL });
 }
 
 /**


### PR DESCRIPTION
## Summary
- cache web app URL for 6 hours
- use server-side URL generation for links and redirects
- add `startApp` button in setup
- fix account-switch redirect logic
- add helper to reload registration page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686865f124fc832ba2ba1b384e5777a2