### PR TITLE
Implement cache fallback and invalidation

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -169,7 +169,7 @@ function getPublishedSheetData(classFilter, sortOrder) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = findUserById(currentUserId);
+    var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -290,7 +290,7 @@ function getAppConfig() {
       }
     }
     
-    var userInfo = findUserById(currentUserId);
+    var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -411,7 +411,7 @@ function saveSheetConfig(spreadsheetId, sheetName, config) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
 
-    var userInfo = findUserById(currentUserId);
+    var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -452,7 +452,7 @@ function switchToSheet(spreadsheetId, sheetName) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
 
-    var userInfo = findUserById(currentUserId);
+    var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -615,7 +615,7 @@ function getActiveFormInfo(userId) {
       }
     }
     
-    var userInfo = findUserById(currentUserId);
+    var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       return { status: 'error', message: 'ユーザー情報が見つかりません' };
     }
@@ -664,7 +664,7 @@ function toggleHighlight(rowIndex, sheetName) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = findUserById(currentUserId);
+    var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -706,7 +706,7 @@ function checkAdmin() {
       return false;
     }
     
-    var userInfo = findUserById(currentUserId);
+    var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       return false;
     }


### PR DESCRIPTION
## Summary
- invalidate caches after database updates
- provide `getUserWithFallback` to fetch user data from DB when cache miss occurs
- use fallback function in Core logic

## Testing
- `npm install`
- `npm test` *(fails: guessHeadersFromArray is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68686ec760e0832bad68f7e6dfd86f85