### PR TITLE
Fix user cache when database ID changes

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -171,6 +171,7 @@ function getPublishedSheetData(classFilter, sortOrder) {
     
     var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
+      handleMissingUser(currentUserId);
       throw new Error('ユーザー情報が見つかりません');
     }
     debugLog('getPublishedSheetData: userInfo=%s', JSON.stringify(userInfo));
@@ -292,6 +293,7 @@ function getAppConfig() {
     
     var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
+      handleMissingUser(currentUserId);
       throw new Error('ユーザー情報が見つかりません');
     }
     
@@ -617,6 +619,7 @@ function getActiveFormInfo(userId) {
     
     var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
+      handleMissingUser(currentUserId);
       return { status: 'error', message: 'ユーザー情報が見つかりません' };
     }
 

--- a/src/database.gs
+++ b/src/database.gs
@@ -135,6 +135,8 @@ function getUserWithFallback(userId) {
     var cache = CacheService.getScriptCache();
     cache.put('user_' + userId, JSON.stringify(user), USER_CACHE_TTL);
     cache.put('email_' + user.adminEmail, JSON.stringify(user), USER_CACHE_TTL);
+  } else {
+    handleMissingUser(userId);
   }
   return user;
 }
@@ -264,13 +266,21 @@ function initializeDatabaseSheet(spreadsheetId) {
 }
 
 /**
+ * ユーザーが見つからない場合のキャッシュ処理
+ * @param {string} userId - キャッシュ削除対象のユーザーID
+ */
+function handleMissingUser(userId) {
+  invalidateUserCache(userId);
+  clearDatabaseCache();
+}
+
+/**
  * 全キャッシュをクリア
  */
 function clearDatabaseCache() {
-  var cache = CacheService.getScriptCache();
-  // ユーザー関連のキャッシュをクリア
-  // GASのCacheServiceには一括削除機能がないため、個別削除は実装しない
-  debugLog('データベースキャッシュクリア要請を受信しました');
+  cacheManager.clearExpired();
+  PropertiesService.getUserProperties().deleteProperty('CURRENT_USER_ID');
+  debugLog('データベース関連キャッシュをクリアしました');
 }
 
 // =================================================================


### PR DESCRIPTION
## Summary
- clear caches when a user record isn't found
- automatically reset context when database lookup fails

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868710a7508832b87258e82b8d9c8c3