### PR TITLE
Fix user recovery when property cache invalid

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -172,7 +172,16 @@ function getPublishedSheetData(classFilter, sortOrder) {
     var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       handleMissingUser(currentUserId);
-      throw new Error('ユーザー情報が見つかりません');
+      // Fallback to active user email if property points to missing user
+      var fallbackEmail = Session.getActiveUser().getEmail();
+      var altUser = findUserByEmail(fallbackEmail);
+      if (altUser) {
+        currentUserId = altUser.userId;
+        props.setProperty('CURRENT_USER_ID', currentUserId);
+        userInfo = altUser;
+      } else {
+        throw new Error('ユーザー情報が見つかりません');
+      }
     }
     debugLog('getPublishedSheetData: userInfo=%s', JSON.stringify(userInfo));
     
@@ -294,7 +303,15 @@ function getAppConfig() {
     var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       handleMissingUser(currentUserId);
-      throw new Error('ユーザー情報が見つかりません');
+      var fallbackEmail = Session.getActiveUser().getEmail();
+      var altUser = findUserByEmail(fallbackEmail);
+      if (altUser) {
+        currentUserId = altUser.userId;
+        props.setProperty('CURRENT_USER_ID', currentUserId);
+        userInfo = altUser;
+      } else {
+        throw new Error('ユーザー情報が見つかりません');
+      }
     }
     
     var configJson = JSON.parse(userInfo.configJson || '{}');
@@ -620,7 +637,15 @@ function getActiveFormInfo(userId) {
     var userInfo = getUserWithFallback(currentUserId);
     if (!userInfo) {
       handleMissingUser(currentUserId);
-      return { status: 'error', message: 'ユーザー情報が見つかりません' };
+      var fallbackEmail = Session.getActiveUser().getEmail();
+      var altUser = findUserByEmail(fallbackEmail);
+      if (altUser) {
+        currentUserId = altUser.userId;
+        props.setProperty('CURRENT_USER_ID', currentUserId);
+        userInfo = altUser;
+      } else {
+        return { status: 'error', message: 'ユーザー情報が見つかりません' };
+      }
     }
 
     var configJson = JSON.parse(userInfo.configJson || '{}');


### PR DESCRIPTION
## Summary
- patch user recovery logic in `getPublishedSheetData`
- handle invalid cache in `getAppConfig`
- recover user info in `getActiveFormInfo`

## Testing
- `npm test` *(fails: getHeaderIndices, buildBoardData, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686873b29d14832b8d3c306d6adfb33e