### PR TITLE
Fix sheet config auto-save

### DIFF
--- a/tests/saveSheetConfig.test.js
+++ b/tests/saveSheetConfig.test.js
@@ -56,7 +56,7 @@ test.skip('saveSheetConfig appends new row', () => {
   const headers = ['表示シート名','問題文ヘッダー','回答ヘッダー','理由ヘッダー','名前列ヘッダー','クラス列ヘッダー'];
   const { sheet, rows } = setup([headers]);
   const cfg = { questionHeader:'Q', answerHeader:'A', reasonHeader:'R', nameHeader:'名前', classHeader:'クラス' };
-  saveSheetConfig('Sheet1', cfg);
+  saveSheetConfig('spreadsheet-id-123', 'Sheet1', cfg);
   expect(sheet.appendRow).toHaveBeenCalled();
   expect(rows[1]).toEqual(['Sheet1','Q','A','R','名前','クラス']);
 });


### PR DESCRIPTION
## Summary
- remove unused legacy sheet config functions
- save auto-mapping using new `saveSheetConfig`
- fix syntax error in config.gs
- update test imports

## Testing
- `npm test --silent` *(fails: buildBoardData, findHeaderIndices, saveDeployId, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6868756899a8832bac07691f92f843b5