### PR TITLE
Fix sheet config save key mismatch

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -196,8 +196,8 @@ function getPublishedSheetData(classFilter, sortOrder) {
       throw new Error('公開対象のスプレッドシートまたはシートが設定されていません。');
     }
 
-    // シート固有の設定を取得
-    var sheetKey = 'sheet_' + publishedSpreadsheetId + '_' + publishedSheetName;
+    // シート固有の設定を取得 (sheetKey is based only on sheet name)
+    var sheetKey = 'sheet_' + publishedSheetName;
     var sheetConfig = configJson[sheetKey] || {};
     debugLog('getPublishedSheetData: sheetConfig=%s', JSON.stringify(sheetConfig));
     
@@ -437,8 +437,8 @@ function saveSheetConfig(spreadsheetId, sheetName, config) {
 
     var configJson = JSON.parse(userInfo.configJson || '{}');
 
-    // 新しいキー形式でシート設定を保存
-    var sheetKey = 'sheet_' + spreadsheetId + '_' + sheetName;
+    // save using sheet-specific key expected by getConfig
+    var sheetKey = 'sheet_' + sheetName;
     configJson[sheetKey] = config;
 
     updateUser(currentUserId, { configJson: JSON.stringify(configJson) });

--- a/src/main.gs
+++ b/src/main.gs
@@ -340,7 +340,7 @@ function doGet(e) {
         pageTemplate.spreadsheetId = spreadsheetId;
         pageTemplate.displayMode = configJson.displayMode || DISPLAY_MODES.ANONYMOUS;
         pageTemplate.showCounts = configJson.showCounts !== false;
-        var key = 'sheet_' + spreadsheetId + '_' + sheetName;
+        var key = 'sheet_' + sheetName;
         pageTemplate.mapping = configJson[key] || {};
         pageTemplate.ownerName = userInfo.adminEmail;
         var isOwner = (userEmail === userInfo.adminEmail);
@@ -390,7 +390,7 @@ function doGet(e) {
         pageTemplate.spreadsheetId = publishedSpreadsheetId;
         pageTemplate.displayMode = configJson.displayMode || DISPLAY_MODES.ANONYMOUS;
         pageTemplate.showCounts = configJson.showCounts !== false;
-        var key = 'sheet_' + publishedSpreadsheetId + '_' + publishedSheetName;
+        var key = 'sheet_' + publishedSheetName;
         pageTemplate.mapping = configJson[key] || {};
         pageTemplate.ownerName = userInfo.adminEmail;
         var isOwner = (userEmail === userInfo.adminEmail);


### PR DESCRIPTION
## Summary
- store sheet mappings using sheet name only
- read sheet config with the same key when rendering pages

## Testing
- `npm test` *(fails: findHeaderIndices is not a function, saveDeployId is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68689492f930832b8cf6ae8d95c14584