### PR TITLE
feat(admin): add detailed error logging

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -17,18 +17,38 @@
   <script>
     // グローバルエラーハンドリング
     window.addEventListener('error', function(event) {
-      console.error('Global error caught:', event.error);
-      // document.writeエラーの場合は特別な処理
-      if (event.error && event.error.message && event.error.message.includes('document.write')) {
-        console.warn('document.write エラーが検出されました。安全なDOM操作に切り替えています。');
-        event.preventDefault();
+      try {
+        console.error('Global error caught:', event.error);
+        console.error('Message:', event.message);
+        console.error('Filename:', event.filename);
+        console.error('Line:', event.lineno, 'Column:', event.colno);
+        if (event.error && event.error.stack) {
+          console.error('Stack Trace:\n', event.error.stack);
+        }
+        // document.writeエラーの場合は特別な処理
+        if (
+          event.error &&
+          event.error.message &&
+          event.error.message.includes('document.write')
+        ) {
+          console.warn('document.write エラーが検出されました。安全なDOM操作に切り替えています。');
+          event.preventDefault();
+        }
+      } catch (loggingError) {
+        console.error('Error while logging global error:', loggingError);
       }
     });
-    
+
     // Promise rejection のキャッチ
     window.addEventListener('unhandledrejection', function(event) {
-      console.error('Unhandled promise rejection:', event.reason);
-      event.preventDefault();
+      try {
+        console.error('Unhandled promise rejection:', event.reason);
+        if (event.reason && event.reason.stack) {
+          console.error('Stack Trace:\n', event.reason.stack);
+        }
+      } finally {
+        event.preventDefault();
+      }
     });
   </script>
   <style>


### PR DESCRIPTION
## Summary
- enhance global error handler in `AdminPanel.html` to log message, filename, line, column and stack trace

## Testing
- `npm install`
- `npm test` *(fails: buildBoardData is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6868b6d0dc80832bafdc7faed443aeda