### PR TITLE
Fix extra parenthesis in AdminPanel

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -2915,12 +2915,11 @@
     function guessHeaders(headers) {
       
       
-      var find = function(keywords) {
-        return headers.find(function(h) {
-          return keywords.some(function(k) { return h && String(h).toLowerCase().includes(k); });
-        });
-        ) || '';
-      };
+        var find = function(keywords) {
+          return (headers.find(function(h) {
+            return keywords.some(function(k) { return h && String(h).toLowerCase().includes(k); });
+          }) || '');
+        };
       
       var isGoogleForm = headers.some(function(h) { return String(h || '').includes('タイムスタンプ') || String(h || '').includes('メールアドレス'); });
       


### PR DESCRIPTION
## Summary
- fix closing parenthesis in `find` helper of **AdminPanel.html**

## Testing
- `npm test --silent` *(fails: getHeaderIndices ignores unrelated header differences, prepareSheetForBoard appends missing reaction columns, checkAdmin returns true for admin user, saveDeployId stores trimmed id when format valid, guessHeadersFromArray detects japanese synonyms, serviceAccountDatabase.test.js, advancedDatabase.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6868e07f39dc832ba4beab69ce645a0d