### PR TITLE
Fix published board config reload check

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -1991,7 +1991,7 @@ function setupEventListeners() {
           updateUIForSelectedSheet();
           
           // 公開中のシートの場合は列情報の読み込みをスキップ
-          if (!(currentStatus && currentStatus.appPublished && 
+          if (!(currentStatus && currentStatus.isPublished &&
                 (selectedSheet === currentActiveSheet || selectedSheet === currentStatus.publishedSheetName))) {
             loadConfigForSelected();
           }
@@ -2201,13 +2201,13 @@ function updateDatabaseInfo(status) {
   // 新しいUI要素を更新
   
   // 公開状態の更新
-  const isPublished = status && (status.appPublished || (status.activeSheetName && status.publishedSheetName));
+  const isPublished = status && (status.isPublished || (status.activeSheetName && status.publishedSheetName));
   const publishStatusEl = document.getElementById('info-publish-status');
   const publishIndicatorEl = document.getElementById('info-publish-indicator');
   const publishTextEl = document.getElementById('info-publish-text');
   
   console.log('🔍 [DEBUG] Publish status check:', {
-    appPublished: status?.appPublished,
+    isPublishedProp: status?.isPublished,
     activeSheetName: status?.activeSheetName,
     publishedSheetName: status?.publishedSheetName,
     isPublished: isPublished
@@ -2363,7 +2363,7 @@ function updateDatabaseInfo(status) {
       
       if (!step1Content || !step2Content || !step3Content) return;
       
-      const isPublished = status && (status.appPublished || (status.activeSheetName && status.publishedSheetName));
+      const isPublished = status && (status.isPublished || (status.activeSheetName && status.publishedSheetName));
       const hasSheets = status && status.allSheets && status.allSheets.length > 0;
       const hasSelectedSheet = selectedSheet && selectedSheet.length > 0;
 
@@ -2869,7 +2869,7 @@ function updateDatabaseInfo(status) {
       updateUIForSelectedSheet();
       
       // 公開済みで現在選択中のシートがアクティブシートの場合は、列情報の読み込みをスキップ
-      if (!(status.appPublished && (selectedSheet === status.activeSheetName || selectedSheet === status.publishedSheetName))) {
+      if (!(status.isPublished && (selectedSheet === status.activeSheetName || selectedSheet === status.publishedSheetName))) {
         loadConfigForSelected();
       }
       
@@ -3447,11 +3447,11 @@ function updateDatabaseInfo(status) {
       console.log('🔍 [DEBUG] Load config check:', {
         selectedSheet: selectedSheet,
         currentActiveSheet: currentActiveSheet,
-        appPublished: currentStatus?.appPublished,
+        isPublished: currentStatus?.isPublished,
         publishedSheetName: currentStatus?.publishedSheetName
       });
 
-      if (currentStatus && currentStatus.appPublished && 
+      if (currentStatus && currentStatus.isPublished &&
           (selectedSheet === currentActiveSheet || selectedSheet === currentStatus.publishedSheetName)) {
         console.log('✅ [DEBUG] 既に公開中のシートのため、列情報の読み込みをスキップします:', selectedSheet);
         return;


### PR DESCRIPTION
## Summary
- check `isPublished` field from status instead of nonexistent `appPublished`
- skip column load when board is already published

## Testing
- `npm test` *(fails: jest not found / tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_686ae9563294832ba3d0ed1ed1956705