### PR TITLE
Fix: refresh publish status after header load

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -3418,6 +3418,8 @@ function updateDatabaseInfo(status) {
         updateConfigButtons();
       } finally {
         setLoading(false);
+        // 列情報取得後に最新の公開状態を確認する
+        loadStatus(true);
       }
     }
     
@@ -3428,12 +3430,16 @@ function updateDatabaseInfo(status) {
         updateConfigButtons();
       } finally {
         setLoading(false);
+        // エラーの場合も公開状態を更新する
+        loadStatus(true);
       }
     }
     
     function handleGuessedHeadersError(error) {
       setLoading(false);
       showError(error);
+      // ヘッダー取得失敗時も公開状態を再確認
+      loadStatus(true);
     }
     
     function _loadConfigForSelectedInternal() {


### PR DESCRIPTION
## Summary
- update AdminPanel to reload status after header guesses

## Testing
- `npm install`
- `npm test` *(fails: toggleHighlight, guessHeadersFromArray, checkAdmin, saveDeployId, findHeaderIndices, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686af0d9c81c832b94d7a59c52ffbfb7