### PR TITLE
Fix admin panel status refresh loop

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -3418,8 +3418,8 @@ function updateDatabaseInfo(status) {
         updateConfigButtons();
       } finally {
         setLoading(false);
-        // 列情報取得後に最新の公開状態を確認する
-        loadStatus(true);
+        // 列情報取得後はUIのみ更新
+        updateUIForSelectedSheet();
       }
     }
     
@@ -3430,16 +3430,16 @@ function updateDatabaseInfo(status) {
         updateConfigButtons();
       } finally {
         setLoading(false);
-        // エラーの場合も公開状態を更新する
-        loadStatus(true);
+        // UIのみ更新し、公開状態の再取得は行わない
+        updateUIForSelectedSheet();
       }
     }
     
     function handleGuessedHeadersError(error) {
       setLoading(false);
       showError(error);
-      // ヘッダー取得失敗時も公開状態を再確認
-      loadStatus(true);
+      // ヘッダー取得失敗時はステータスを更新しない
+      updateUIForSelectedSheet();
     }
     
     function _loadConfigForSelectedInternal() {


### PR DESCRIPTION
## Summary
- avoid repeated `loadStatus` calls when loading sheet config
- just update the UI instead of re-fetching status

## Testing
- `npm install`
- `npm run test` *(fails: TypeError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686af2b02e44832bbc3a31e0a6414689