### PR TITLE
Fix duplicate critical setup

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -1052,6 +1052,13 @@ class StudyQuestApp {
       });
     }
   setupCriticalElements() {
+    if (this.elements.headingLabel) {
+      const opinionHeader = __OPINION_HEADER__.startsWith('<')
+        ? 'お題を読み込み中...'
+        : this.escapeHtml(__OPINION_HEADER__);
+      this.elements.headingLabel.textContent = opinionHeader;
+    }
+
     // Only setup absolutely critical event listeners
     this.setupEventDelegation();
     this.handlers.onAnswerModalCloseClick = () => this.hideAnswerModal();
@@ -1883,13 +1890,6 @@ setupEventDelegation() {
         <p class="mt-1 text-sm text-gray-400">最初の回答者になりましょう！</p>
       </div>
     `;
-  }
-
-  setupCriticalElements() {
-    if (this.elements.headingLabel) {
-      const opinionHeader = __OPINION_HEADER__.startsWith('<') ? 'お題を読み込み中...' : this.escapeHtml(__OPINION_HEADER__);
-      this.elements.headingLabel.textContent = opinionHeader;
-    }
   }
 
   // Add these two methods


### PR DESCRIPTION
## Summary
- merge heading label logic into the main `setupCriticalElements`
- remove later duplicate method
- keep event delegation call during initialization

## Testing
- `npm test` *(fails: cannot read properties of null reading 'private_key')*

------
https://chatgpt.com/codex/tasks/task_e_686b0275aaec832b97b493e252586471