### PR TITLE
Fix unescaped ampersand in Page.html

### DIFF
--- a/src/Page.html
+++ b/src/Page.html
@@ -12,7 +12,7 @@
 <!-- Preload Google Fonts for better performance -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&amp;display=swap" rel="stylesheet">
 <!-- Global error handling and TailwindCSS setup -->
 <script>
 // Global error handling for document.write and other issues


### PR DESCRIPTION
## Summary
- fix ampersand escaping in Google Fonts link
- run existing tests

## Testing
- `npm test` *(fails: Test Suites: 13 failed, 8 skipped, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686b7b437450832bb01ad910277bc405