### PR TITLE
Improve admin saveConfig tests and add server tests

### DIFF
--- a/tests/configFunctions.test.js
+++ b/tests/configFunctions.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Server config functions', () => {
+  const configFile = fs.readFileSync(path.resolve(__dirname, '../src/config.gs'), 'utf8');
+  const saveConfigScript = /function saveConfig\([\s\S]*?\n\}/.exec(configFile)[0];
+
+  test('saveConfig calls saveSheetConfig with user spreadsheet id', () => {
+    const ctx = {
+      getUserInfo: jest.fn(() => ({ spreadsheetId: 'sheet123' })),
+      saveSheetConfig: jest.fn(),
+      console,
+    };
+    vm.createContext(ctx);
+    vm.runInContext(saveConfigScript, ctx);
+    const result = ctx.saveConfig('MySheet', { a: 1 });
+
+    expect(ctx.getUserInfo).toHaveBeenCalled();
+    expect(ctx.saveSheetConfig).toHaveBeenCalledWith('sheet123', 'MySheet', { a: 1 });
+    expect(result).toEqual({ success: true, message: '設定が正常に保存されました。' });
+  });
+
+  test('saveConfig throws error when sheetName is missing', () => {
+    const ctx = {
+      getUserInfo: jest.fn(() => ({ spreadsheetId: 'sheet123' })),
+      saveSheetConfig: jest.fn(),
+      console,
+    };
+    vm.createContext(ctx);
+    vm.runInContext(saveConfigScript, ctx);
+    expect(() => ctx.saveConfig('', { a: 1 })).toThrow('sheetName');
+  });
+});

--- a/tests/saveConfig.test.js
+++ b/tests/saveConfig.test.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+function extractSaveConfigScript(html) {
+  const start = html.indexOf('function saveConfig()');
+  if (start === -1) return null;
+  let depth = 0;
+  let end = start;
+  for (; end < html.length; end++) {
+    const c = html[end];
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) { end++; break; }
+    }
+  }
+  return html.slice(start, end);
+}
+
+describe('AdminPanel saveConfig', () => {
+  test('calls google.script.run.saveConfig and stores pending config', () => {
+    const htmlPath = path.resolve(__dirname, '../src/AdminPanel.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    const script = extractSaveConfigScript(html);
+    expect(script).toBeTruthy();
+
+    const dom = new JSDOM(`<!DOCTYPE html><body>
+      <select id="sheet-select"><option value="Sheet1"></option></select>
+      <input id="opinionHeader" value="opinion" />
+      <input id="reasonHeader" value="reason" />
+      <input id="nameHeader" value="name" />
+      <input id="classHeader" value="class" />
+      <input type="checkbox" id="showNames" />
+      <input type="checkbox" id="showCounts" checked />
+    </body>`);
+
+    const ctx = {
+      window: dom.window,
+      document: dom.window.document,
+      elements: {
+        sheetSelect: dom.window.document.getElementById('sheet-select'),
+        opinionHeader: dom.window.document.getElementById('opinionHeader'),
+        reasonHeader: dom.window.document.getElementById('reasonHeader'),
+        nameHeader: dom.window.document.getElementById('nameHeader'),
+        classHeader: dom.window.document.getElementById('classHeader'),
+        saveConfigBtn: {},
+        saveConfigText: { textContent: '' },
+      },
+      currentStatus: { userInfo: { spreadsheetId: 'id123' } },
+      showMessage: jest.fn(),
+      addVisualFeedback: jest.fn(),
+      showError: jest.fn(),
+      setLoading: jest.fn(),
+      showPublishModal: jest.fn(),
+    };
+
+    const runStub = {
+      success: null,
+      failure: null,
+      withSuccessHandler(fn) { this.success = fn; return this; },
+      withFailureHandler(fn) { this.failure = fn; return this; },
+      saveConfig: jest.fn(function (sheetName, cfg) { if (this.success) this.success('ok'); }),
+    };
+    ctx.google = { script: { run: runStub } };
+
+    vm.createContext(ctx);
+    vm.runInContext(script, ctx);
+    ctx.saveConfig();
+
+    expect(runStub.saveConfig).toHaveBeenCalledWith('Sheet1', {
+      opinionHeader: 'opinion',
+      reasonHeader: 'reason',
+      nameHeader: 'name',
+      classHeader: 'class',
+      showNames: false,
+      showCounts: true,
+    });
+
+    expect(ctx.window.pendingConfig).toEqual({
+      spreadsheetId: 'id123',
+      sheetName: 'Sheet1',
+      config: {
+        opinionHeader: 'opinion',
+        reasonHeader: 'reason',
+        nameHeader: 'name',
+        classHeader: 'class',
+        showNames: false,
+        showCounts: true,
+      },
+    });
+
+    expect(ctx.showPublishModal).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- refine AdminPanel saveConfig unit test to robustly extract script
- add Jest tests for server-side saveConfig logic

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d6c10342c832ba440bbdedf2f4af3