### PR TITLE
Refactor Page.html scripts

### DIFF
--- a/src/client/scripts/Page.js.html
+++ b/src/client/scripts/Page.js.html
@@ -1,4 +1,30 @@
 <script>
+// Global error handling for document.write and other issues
+window.addEventListener('error', function(event) {
+  if (event.error && event.error.message) {
+    if (event.error.message.includes('document.write') ||
+        event.error.message.includes('Unexpected token')) {
+      console.warn('Document.write or syntax error caught and handled:', event.error.message);
+      event.preventDefault();
+      return false;
+    }
+  }
+});
+
+// Handle unhandled promise rejections
+window.addEventListener('unhandledrejection', function(event) {
+  console.warn('Unhandled promise rejection:', event.reason);
+  event.preventDefault();
+});
+
+// TailwindCSS configuration to suppress production warnings
+window.tailwind = {
+  config: {
+    mode: 'jit',
+    corePlugins: { preflight: false }
+  }
+};
+
 console.log('🔧 Page.js.html script starting...');
 const DEBUG_MODE = true;
 

--- a/src/client/views/Page.html
+++ b/src/client/views/Page.html
@@ -13,33 +13,6 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&amp;display=swap" rel="stylesheet">
-<script>
-// Global error handling for document.write and other issues
-window.addEventListener('error', function(event) {
-  if (event.error && event.error.message) {
-    if (event.error.message.includes('document.write') ||
-        event.error.message.includes('Unexpected token')) {
-      console.warn('Document.write or syntax error caught and handled:', event.error.message);
-      event.preventDefault();
-      return false;
-    }
-  }
-});
-
-// Handle unhandled promise rejections
-window.addEventListener('unhandledrejection', function(event) {
-  console.warn('Unhandled promise rejection:', event.reason);
-  event.preventDefault();
-});
-
-// TailwindCSS configuration to suppress production warnings
-window.tailwind = {
-  config: {
-    mode: 'jit',
-    corePlugins: { preflight: false }
-  }
-};
-</script>
 <script src="https://cdn.tailwindcss.com" defer onload="console.log('TailwindCSS loaded successfully')" onerror="console.warn('TailwindCSS failed to load')"></script>
     <?!= include('styles/Page.css.html'); ?>
 </head>


### PR DESCRIPTION
## Summary
- move inline script from `Page.html` to `Page.js.html`
- keep Tailwind loader in `Page.html`

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db5566b80832badf6502e057bbd5b