### PR TITLE
Fix duplicate message handler

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -1177,7 +1177,7 @@
     }
     
     // Check for duplicate messages and highlight if found
-    function handleDuplicateMessage(messageArea, message) {
+    function checkDuplicateMessage(messageArea, message) {
       var existingMessages = Array.from(messageArea.children);
       for (var i = 0; i < existingMessages.length; i++) {
         var existing = existingMessages[i];
@@ -1267,7 +1267,7 @@
         if (!messageArea) return;
         
         // Check for duplicates
-        if (handleDuplicateMessage(messageArea, message)) {
+        if (checkDuplicateMessage(messageArea, message)) {
           return;
         }
         


### PR DESCRIPTION
## Summary
- rename the local message dedupe function in AdminPanel to avoid clashing with the global one

## Testing
- `npm test` *(fails: Could not load script https://cdn.tailwindcss.com)*

------
https://chatgpt.com/codex/tasks/task_e_686edad94fe0832bb51ae0d933b2e058