### PR TITLE
Implement simple form creation flow

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -295,7 +295,7 @@
                       <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
                       </svg>
-                      <span id="create-additional-form-text" class="text-gray-200">追加のフォームを作成</span>
+                      <span id="create-additional-form-text" class="text-gray-200">新規のフォームを作成</span>
                     </button>
                     <p class="text-xs text-gray-400 mt-1">現在のボードに連携する新しいフォームを作成</p>
                   </div>
@@ -2670,18 +2670,21 @@ function syncCheckboxStates(status) {
     }
     
     /**
-     * 追加のフォームを作成する
+     * 新規フォームを作成する
      */
     function createAdditionalForm() {
         showConfirmationModal(
-            '追加フォームの作成',
-            '現在のスプレッドシートに連携する新しいGoogleフォームを作成します。よろしいですか？',
+            '新規フォームの作成',
+            '新しいGoogleフォームを作成して現在のボードに連携します。よろしいですか？',
             function() {
                 setLoading(true, '新しいフォームを作成しています...');
                 runGas('createAdditionalForm')
                     .then(function(result) {
                         if (result.status === 'success') {
                             showMessage('✅ 新しいフォームが作成され、連携されました！', 'success');
+                            if (result.editFormUrl) {
+                                window.open(result.editFormUrl, '_blank');
+                            }
                             loadStatus(true);
                         } else {
                             throw new Error(result.message || 'フォーム作成に失敗しました。');

--- a/tests/questionConfig.test.js
+++ b/tests/questionConfig.test.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('getQuestionConfig simple', () => {
+  const code = fs.readFileSync('src/Core.gs', 'utf8');
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(code, context);
+
+  test('returns simple config', () => {
+    const cfg = context.getQuestionConfig('simple');
+    expect(cfg.classQuestion.title).toBe('クラス');
+    expect(cfg.classQuestion.choices.length).toBe(4);
+    expect(cfg.nameQuestion.title).toBe('名前');
+  });
+});


### PR DESCRIPTION
## Summary
- simplify form factory description and title
- add `simple` question template and create dropdown for class
- update additional form creation to auto-activate new sheet
- open edit URL after form creation
- rename admin button text
- add unit test for question config
- default new forms to simple question template

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fc234501c832b94b16a02476d4094