### PR TITLE
Fix isActive boolean handling

### DIFF
--- a/src/AppSetupPage.html
+++ b/src/AppSetupPage.html
@@ -167,7 +167,7 @@
 
         // ステータス表示を更新
         function updateStatusDisplay(userInfo) {
-            const isActive = userInfo.isActive === 'true';
+            const isActive = userInfo.isActive === true || String(userInfo.isActive).toLowerCase() === 'true';
             const statusElement = document.getElementById('current-status');
             const adminElement = document.getElementById('current-admin');
             const lastUpdatedElement = document.getElementById('last-updated');

--- a/src/Core.gs
+++ b/src/Core.gs
@@ -2493,7 +2493,7 @@ function getCurrentUserStatus() {
     }
 
     // 編集者権限があるか確認
-    if (userInfo.isActive !== 'true') {
+    if (!isTrue(userInfo.isActive)) {
       return {
         status: 'error',
         message: 'このユーザーは編集者権限がありません'
@@ -2539,7 +2539,7 @@ function updateIsActiveStatus(isActive) {
     }
 
     // 編集者権限があるか確認（自分自身の状態変更も含む）
-    if (userInfo.isActive !== 'true') {
+    if (!isTrue(userInfo.isActive)) {
       return {
         status: 'error',
         message: 'この操作を実行する権限がありません'
@@ -2591,7 +2591,7 @@ function hasSetupPageAccess() {
 
     // データベースに登録され、かつisActiveがtrueのユーザーのみアクセス可能
     var userInfo = findUserByEmail(activeUserEmail);
-    return userInfo && userInfo.isActive === 'true';
+    return userInfo && isTrue(userInfo.isActive);
   } catch (e) {
     console.error('hasSetupPageAccess エラー: ' + e.message);
     return false;

--- a/src/config.gs
+++ b/src/config.gs
@@ -1037,7 +1037,7 @@ function checkAdmin() {
     }
 
     for (var i = 1; i < data.length; i++) {
-      if (data[i][emailIndex] === activeUserEmail && data[i][isActiveIndex] === 'true') {
+      if (data[i][emailIndex] === activeUserEmail && isTrue(data[i][isActiveIndex])) {
         return true;
       }
     }
@@ -1108,7 +1108,7 @@ function getExistingBoard() {
     var activeUserEmail = Session.getActiveUser().getEmail();
     var userInfo = findUserByEmail(activeUserEmail);
     
-    if (userInfo && userInfo.isActive === 'true') {
+    if (userInfo && isTrue(userInfo.isActive)) {
       var appUrls = generateAppUrls(userInfo.userId);
       return {
         status: 'existing_user',
@@ -1116,7 +1116,7 @@ function getExistingBoard() {
         adminUrl: appUrls.adminUrl,
         viewUrl: appUrls.viewUrl
       };
-    } else if (userInfo && userInfo.isActive === 'false') {
+    } else if (userInfo && String(userInfo.isActive).toLowerCase() === 'false') {
       return {
         status: 'setup_required',
         userId: userInfo.userId

--- a/src/main.gs
+++ b/src/main.gs
@@ -81,6 +81,18 @@ var EMAIL_REGEX = /^[^\n@]+@[^\n@]+\.[^\n@]+$/;
 var DEBUG = true;
 
 /**
+ * Determine if a value represents boolean true.
+ * Accepts boolean true, 'true', or 'TRUE'.
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isTrue(value) {
+  if (typeof value === 'boolean') return value === true;
+  if (value === undefined || value === null) return false;
+  return String(value).toLowerCase() === 'true';
+}
+
+/**
  * HTMLエスケープ関数（Utilities.htmlEncodeの代替）
  * @param {string} text - エスケープするテキスト
  * @returns {string} エスケープされたテキスト


### PR DESCRIPTION
## Summary
- add `isTrue` utility to normalize boolean values
- accept boolean `isActive` values in server-side checks
- adjust admin page JS to handle boolean status

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687034bc7e38832ba0c739f7cecb634e