### PR TITLE
Update quickstart class options

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -1713,7 +1713,7 @@ function getQuestionConfig(questionType, customConfig) {
     classQuestion: {
       title: 'クラス',
       helpText: '',
-      choices: ['1年1組', '1年2組', '1年3組', '2年1組', '2年2組', '2年3組', '3年1組', '3年2組', '3年3組', '4年1組', '4年2組', '4年3組', '5年1組', '5年2組', '5年3組', '6年1組', '6年2組', '6年3組']
+      choices: ['クラス1', 'クラス2', 'クラス3', 'クラス4']
     },
     nameQuestion: {
       title: '名前',

--- a/tests/questionConfig.test.js
+++ b/tests/questionConfig.test.js
@@ -10,7 +10,7 @@ describe('getQuestionConfig simple', () => {
   test('returns simple config', () => {
     const cfg = context.getQuestionConfig('simple');
     expect(cfg.classQuestion.title).toBe('クラス');
-    expect(cfg.classQuestion.choices.length).toBe(18);
+    expect(cfg.classQuestion.choices.length).toBe(4);
     expect(cfg.nameQuestion.title).toBe('名前');
   });
 });


### PR DESCRIPTION
## Summary
- limit quickstart class options to Class1-Class4
- adjust unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68707558f7c4832b89457731bb4bf416