### PR TITLE
Fix form link for unregistered users

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -720,6 +720,9 @@ function getActiveFormInfo(userId) {
       }
     }
 
+    // Ensure CURRENT_USER_ID is stored for subsequent requests
+    props.setProperty('CURRENT_USER_ID', currentUserId);
+
     var configJson = JSON.parse(userInfo.configJson || '{}');
     
     // フォーム回答数を取得

--- a/src/Page.html
+++ b/src/Page.html
@@ -3764,7 +3764,7 @@ function loadFormLink() {
     .withFailureHandler(error => {
       console.warn('フォーム情報の取得に失敗しました:', error);
     })
-    .getActiveFormInfo();
+    .getActiveFormInfo(USER_ID);
 }
 
 try {


### PR DESCRIPTION
## Summary
- ensure CURRENT_USER_ID is stored when fetching form info
- pass board owner ID from Page when requesting form link

## Testing
- `npm install` *(fails: TypeError: pkgDir.sync is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6870b136d53c832ba97bfa45c2fd1a0d