### PR TITLE
Change default reaction counts to hidden

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -311,7 +311,7 @@ function getPublishedSheetData(classFilter, sortOrder) {
     var result = {
       header: headerTitle,
       sheetName: publishedSheetName, // targetSheetからpublishedSheetNameに変更
-      showCounts: configJson.showCounts !== false,
+      showCounts: configJson.showCounts === true,
       displayMode: sheetData.displayMode || DISPLAY_MODES.ANONYMOUS,
       data: formattedData,
       rows: formattedData // 後方互換性のため
@@ -428,7 +428,7 @@ function getAppConfig() {
       appUrls: appUrls,
       // AdminPanel.htmlが期待する表示設定プロパティ
       showNames: configJson.showNames || false,
-      showCounts: configJson.showCounts !== undefined ? configJson.showCounts : true,
+      showCounts: configJson.showCounts === true,
       // データベース詳細情報
       userInfo: {
         userId: currentUserId,
@@ -1221,7 +1221,7 @@ function quickStartSetup(userId) {
       nameHeader: '名前',
       classHeader: 'クラス',
       showNames: false,
-      showCounts: true,
+      showCounts: false,
       lastModified: new Date().toISOString()
     };
     

--- a/src/config.gs
+++ b/src/config.gs
@@ -125,7 +125,7 @@ function getConfig(sheetName, forceRefresh = false) {
       nameHeader: '',
       classHeader: '',
       showNames: false,
-      showCounts: true, 
+      showCounts: false,
       availableHeaders: headers || [],
       hasExistingConfig: false
     };
@@ -144,7 +144,7 @@ function getConfig(sheetName, forceRefresh = false) {
       finalConfig.nameHeader = savedSheetConfig.nameHeader || '';
       finalConfig.classHeader = savedSheetConfig.classHeader || '';
       finalConfig.showNames = savedSheetConfig.showNames || false;
-      finalConfig.showCounts = savedSheetConfig.showCounts !== undefined ? savedSheetConfig.showCounts : true;
+      finalConfig.showCounts = savedSheetConfig.showCounts !== undefined ? savedSheetConfig.showCounts : false;
 
     } else if (headers && headers.length > 0) {
       // 4.【保存設定がない場合のみ】新しい自動マッピングを実行
@@ -576,7 +576,7 @@ function saveAndActivateSheet(spreadsheetId, sheetName, config) {
     // 4. 表示オプションを設定
     const displayOptions = {
       showNames: !!config.showNames, // booleanに変換
-      showCounts: config.showCounts !== undefined ? !!config.showCounts : true // booleanに変換、デフォルトtrue
+      showCounts: config.showCounts !== undefined ? !!config.showCounts : false // booleanに変換、デフォルトfalse
     };
     setDisplayOptions(displayOptions);
     console.log('saveAndActivateSheet: 表示オプション設定完了');
@@ -628,7 +628,7 @@ function saveAndPublish(sheetName, config) {
     // 4. 表示オプションを更新
     const displayOptions = {
       showNames: !!config.showNames,
-      showCounts: config.showCounts !== undefined ? !!config.showCounts : true
+      showCounts: config.showCounts !== undefined ? !!config.showCounts : false
     };
     setDisplayOptions(displayOptions);
     console.log('saveAndPublish: 表示オプション設定完了');

--- a/src/main.gs
+++ b/src/main.gs
@@ -384,7 +384,7 @@ function doGet(e) {
           template.cacheTimestamp = Date.now(); // キャッシュバスター
           
           template.displayMode = config.displayMode || 'anonymous';
-          template.showCounts = config.showCounts !== undefined ? config.showCounts : true;
+          template.showCounts = config.showCounts !== undefined ? config.showCounts : false;
           template.showAdminFeatures = false; // Page.html is for public view, not admin
           template.isAdminUser = false; // Page.html is for public view, not admin
           
@@ -405,7 +405,7 @@ function doGet(e) {
           template.ownerName = userInfo.adminEmail;
           template.sheetName = escapeJavaScript(sheetName);
           template.displayMode = 'anonymous';
-          template.showCounts = true;
+          template.showCounts = false;
           template.showAdminFeatures = false; // Page.html is for public view, not admin
           template.isAdminUser = false; // Page.html is for public view, not admin
         }
@@ -467,7 +467,7 @@ function doGet(e) {
             template.cacheTimestamp = Date.now(); // キャッシュバスター
             
             template.displayMode = config.displayMode || 'anonymous';
-            template.showCounts = config.showCounts !== undefined ? config.showCounts : true;
+            template.showCounts = config.showCounts !== undefined ? config.showCounts : false;
             template.showAdminFeatures = false; // Page.html is for public view, not admin
             template.isAdminUser = false; // Page.html is for public view, not admin
 
@@ -479,7 +479,7 @@ function doGet(e) {
             template.ownerName = userInfo.adminEmail;
             template.sheetName = escapeJavaScript(sheetName);
             template.displayMode = 'anonymous';
-            template.showCounts = true;
+            template.showCounts = false;
             template.showAdminFeatures = false; // Page.html is for public view, not admin
             template.isAdminUser = false; // Page.html is for public view, not admin
           }


### PR DESCRIPTION
## Summary
- set `showCounts` defaults to `false`
- update quick start config to hide counts
- adjust page template logic for new default

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6870c125a820832b83e1f7a05186f8c0