### PR TITLE
Improve per-user session tracking

### DIFF
--- a/src/session-utils.gs
+++ b/src/session-utils.gs
@@ -122,22 +122,20 @@ function validateAndRepairSession(userEmail) {
  */
 function detectAccountSwitch(currentEmail) {
   try {
-    const scriptProps = PropertiesService.getScriptProperties();
-    const lastAccessEmail = scriptProps.getProperty('LAST_ACCESS_EMAIL');
-    const lastAccessTime = scriptProps.getProperty('LAST_ACCESS_TIME');
-    
-    const isAccountSwitch = lastAccessEmail && lastAccessEmail !== currentEmail;
+    const userProps = PropertiesService.getUserProperties();
+    const lastAccessEmail = userProps.getProperty('LAST_ACCESS_EMAIL');
+    const lastAccessTime = userProps.getProperty('LAST_ACCESS_TIME');
+
+    const isAccountSwitch = !!lastAccessEmail && lastAccessEmail !== currentEmail;
     const currentTime = new Date().toISOString();
-    
+
     if (isAccountSwitch) {
       console.log('アカウント切り替えを検出:');
       console.log('前回: ' + lastAccessEmail + ' (' + lastAccessTime + ')');
       console.log('今回: ' + currentEmail + ' (' + currentTime + ')');
-      
-      // セッションクリーンアップを実行
+
       cleanupSessionOnAccountSwitch(currentEmail);
-      
-      // グローバルキャッシュもクリア
+
       try {
         if (typeof clearDatabaseCache === 'function') {
           clearDatabaseCache();
@@ -146,20 +144,19 @@ function detectAccountSwitch(currentEmail) {
         console.warn('グローバルキャッシュクリアでエラー: ' + globalCacheError.message);
       }
     }
-    
-    // 最後のアクセス情報を更新
-    scriptProps.setProperties({
+
+    userProps.setProperties({
       'LAST_ACCESS_EMAIL': currentEmail,
       'LAST_ACCESS_TIME': currentTime
     });
-    
+
     return {
       isAccountSwitch: isAccountSwitch,
       previousEmail: lastAccessEmail,
       currentEmail: currentEmail,
       switchTime: currentTime
     };
-    
+
   } catch (error) {
     console.error('アカウント切り替え検出でエラー: ' + error.message);
     return {

--- a/tests/detectAccountSwitch.test.js
+++ b/tests/detectAccountSwitch.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('detectAccountSwitch uses user properties', () => {
+  const code = fs.readFileSync('src/session-utils.gs', 'utf8');
+  let context;
+  let userStore;
+  beforeEach(() => {
+    userStore = {};
+    const userProps = {
+      getProperty: jest.fn(key => userStore[key]),
+      setProperty: jest.fn((key, value) => { userStore[key] = value; }),
+      setProperties: jest.fn(obj => { Object.assign(userStore, obj); }),
+      getProperties: jest.fn(() => userStore)
+    };
+
+    const scriptProps = {};
+
+    context = {
+      PropertiesService: {
+        getUserProperties: () => userProps,
+        getScriptProperties: jest.fn(() => scriptProps)
+      },
+      CacheService: {
+        getUserCache: () => ({ removeAll: jest.fn() }),
+        getScriptCache: () => ({ remove: jest.fn() })
+      },
+      cleanupSessionOnAccountSwitch: jest.fn(),
+      clearDatabaseCache: jest.fn(),
+      console: { log: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    };
+
+    vm.createContext(context);
+    vm.runInContext(code, context);
+  });
+
+  test('stores last access info per user', () => {
+    const first = context.detectAccountSwitch('one@example.com');
+    expect(first.isAccountSwitch).toBe(false);
+    expect(context.PropertiesService.getScriptProperties).not.toHaveBeenCalled();
+
+    const second = context.detectAccountSwitch('two@example.com');
+    expect(second.isAccountSwitch).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- store last access info in user properties instead of global script properties
- add regression test for `detectAccountSwitch`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870e12acb68832b91d6ed537ebbcbbe