### PR TITLE
Add explicit admin URL with userId parameter

### DIFF
--- a/src/url.gs
+++ b/src/url.gs
@@ -111,7 +111,8 @@ function generateAppUrls(userId) {
     
     return {
       webAppUrl: webAppUrl,
-      adminUrl: webAppUrl.replace(/\/dev$/, '/exec'), // 管理パネルは /exec で終わるアドレスに設定
+      adminUrl: webAppUrl.replace(/\/dev$/, '/exec') +
+        '?userId=' + encodedUserId + '&mode=admin',
       viewUrl: webAppUrl + '?userId=' + encodedUserId + '&mode=view',
       setupUrl: webAppUrl + '?setup=true',
       status: 'success'

--- a/tests/generateAppUrls.test.js
+++ b/tests/generateAppUrls.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('generateAppUrls admin url', () => {
+  const code = fs.readFileSync('src/url.gs', 'utf8');
+  let context;
+
+  beforeEach(() => {
+    context = {
+      cacheManager: {
+        store: {},
+        get(key, fn) { return fn(); },
+        remove() {}
+      },
+      ScriptApp: {
+        getService: () => ({ getUrl: () => 'https://script.google.com/macros/s/ID/dev' })
+      },
+      console: { error: () => {}, log: () => {}, warn: () => {} }
+    };
+    vm.createContext(context);
+    vm.runInContext(code, context);
+  });
+
+  test('returns adminUrl with userId and mode parameter', () => {
+    const urls = context.generateAppUrls('abc');
+    expect(urls.adminUrl).toBe('https://script.google.com/macros/s/ID/exec?userId=abc&mode=admin');
+  });
+});


### PR DESCRIPTION
## Summary
- append userId and mode query to admin URL generation
- cover generateAppUrls with new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68718ae2e934832bb40326786798241b