### PR TITLE
Unify account switch handling

### DIFF
--- a/src/Registration.html
+++ b/src/Registration.html
@@ -529,52 +529,6 @@
       });
     }
 
-    // アカウント切り替え機能
-    function switchToAnotherAccount() {
-      if (confirm('別のGoogleアカウントでログインしますか？現在のセッションからログアウトされ、アカウント選択画面が表示されます。')) {
-        try {
-          // Google Apps Scriptの認証をリセット
-          google.script.run
-            .withSuccessHandler(function(result) {
-              if (result && result.success) {
-                // 成功時はページをリロードしてアカウント選択を促す
-                const currentUrl = new URL(window.location.href);
-                currentUrl.searchParams.set('force_account_selection', 'true');
-                window.location.replace(currentUrl.toString());
-              } else {
-                // フォールバック: 手動でのアカウント切り替え案内
-                showAccountSwitchFallback();
-              }
-            })
-            .withFailureHandler(function(error) {
-              console.warn('認証リセットエラー:', error);
-              // フォールバック: 手動でのアカウント切り替え案内
-              showAccountSwitchFallback();
-            })
-            .resetUserAuthentication();
-        } catch (error) {
-          console.warn('アカウント切り替えエラー:', error);
-          // フォールバック: 手動でのアカウント切り替え案内
-          showAccountSwitchFallback();
-        }
-      }
-    }
-
-    // アカウント切り替えのフォールバック案内
-    function showAccountSwitchFallback() {
-      const fallbackMessage = `
-        アカウントを切り替えるには以下の手順をお試しください：
-
-        1. 新しいブラウザタブでGoogle（google.com）にアクセス
-        2. 右上のプロフィール画像をクリック
-        3. 「別のアカウントを追加」または使用したいアカウントを選択
-        4. このページに戻って再度認証を開始
-
-        または、ブラウザのシークレット/プライベートモードで新しいタブを開いてこのページにアクセスしてください。
-      `;
-      
-      alert(fallbackMessage);
-    }
 
     // 既存ボードをチェックする関数
     function checkExistingBoard() {

--- a/src/SharedUtilities.html
+++ b/src/SharedUtilities.html
@@ -507,12 +507,45 @@ window.testSharedUtilities = function() {
 
 // Shared authentication functions for consistent behavior across pages
 window.sharedUtilities.auth = {
-  // Account switching functionality
+  // Account switching functionality shared across pages
   switchToAnotherAccount: function() {
-    if (confirm('別のGoogleアカウントでログインしますか？現在のセッションからログアウトされます。')) {
-      // Googleアカウントのログアウト処理
-      window.location.href = 'https://accounts.google.com/logout?continue=' + encodeURIComponent(window.location.href);
+    if (confirm('別のGoogleアカウントでログインしますか？現在のセッションからログアウトされ、アカウント選択画面が表示されます。')) {
+      try {
+        google.script.run
+          .withSuccessHandler(function(result) {
+            if (result && result.success) {
+              const url = new URL(window.location.href);
+              url.searchParams.set('force_account_selection', 'true');
+              window.location.replace(url.toString());
+            } else {
+              window.sharedUtilities.auth.showAccountSwitchFallback();
+            }
+          })
+          .withFailureHandler(function(error) {
+            console.warn('認証リセットエラー:', error);
+            window.sharedUtilities.auth.showAccountSwitchFallback();
+          })
+          .resetUserAuthentication();
+      } catch (error) {
+        console.warn('アカウント切り替えエラー:', error);
+        window.sharedUtilities.auth.showAccountSwitchFallback();
+      }
     }
+  },
+
+  // Fallback guidance when automatic switch fails
+  showAccountSwitchFallback: function() {
+    const msg = `
+        アカウントを切り替えるには以下の手順をお試しください：
+
+        1. 新しいブラウザタブでGoogle（google.com）にアクセス
+        2. 右上のプロフィール画像をクリック
+        3. 「別のアカウントを追加」または使用したいアカウントを選択
+        4. このページに戻って再度認証を開始
+
+        または、ブラウザのシークレット/プライベートモードで新しいタブを開いてこのページにアクセスしてください。
+      `;
+    alert(msg);
   },
   
   // Authentication verification with promise

--- a/src/config.gs
+++ b/src/config.gs
@@ -1194,6 +1194,24 @@ function verifyUserAuthentication() {
 }
 
 /**
+ * セッションをリセットして新しいアカウント選択を促す
+ * SharedUtilities のアカウント切り替え機能から呼び出される
+ * @returns {{success:boolean,error:(string|undefined)}}
+ */
+function resetUserAuthentication() {
+  try {
+    var email = Session.getActiveUser().getEmail();
+    if (typeof cleanupSessionOnAccountSwitch === 'function' && email) {
+      cleanupSessionOnAccountSwitch(email);
+    }
+    return { success: true };
+  } catch (e) {
+    console.error('resetUserAuthentication エラー: ' + e.message);
+    return { success: false, error: e.message };
+  }
+}
+
+/**
  * 指定されたシートのヘッダーを自動でマッピングし、その結果を返す。
  * この関数は AdminPanel.html から直接呼び出されることを想定しています。
  * @param {string} sheetName - 対象のスプレッドシート名。


### PR DESCRIPTION
## Summary
- centralize account switching logic in SharedUtilities
- reuse the shared logic from Registration
- expose `resetUserAuthentication` server function

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871922d7bf8832bb2c73ee759c9a03c