### PR TITLE
Limit app setup link to deploy user

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -66,6 +66,10 @@
     }
   }
   </script>
+  <script>
+  const __IS_DEPLOY_USER__ = '<?= typeof isDeployUser !== "undefined" ? isDeployUser : false ?>';
+  window.isDeployUser = __IS_DEPLOY_USER__.startsWith('<') ? false : __IS_DEPLOY_USER__ === 'true';
+  </script>
   <!-- 統合CSS -->
   <?!= include('UnifiedStyles'); ?>
   
@@ -755,7 +759,7 @@
       </div>
       
       <!-- アプリ設定リンク -->
-      <div class="bg-blue-900/10 border border-blue-500/30 rounded-lg p-3 transition-all hover:border-blue-500/50">
+      <div id="app-setup-link" class="bg-blue-900/10 border border-blue-500/30 rounded-lg p-3 transition-all hover:border-blue-500/50">
         <button type="button" onclick="openAppSetupPage()" class="w-full flex items-center justify-between text-sm font-medium text-blue-300 hover:text-blue-200 transition-colors">
           <div class="flex items-center">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1605,6 +1609,10 @@ elements = {
   currentTopicText: document.getElementById('current-topic-text')
   // ★★★ ここまで追加 ★★★
 };
+      if (!window.isDeployUser) {
+        var link = document.getElementById('app-setup-link');
+        if (link) link.style.display = 'none';
+      }
       if (!IS_TEST_ENV) {
         showSystemFlow(); // デバッグフロー表示
         loadStatus();

--- a/src/Core.gs
+++ b/src/Core.gs
@@ -3494,3 +3494,28 @@ function getDriveService() {
     }
   };
 }
+
+/**
+ * デプロイユーザーかどうか判定
+ * データベーススプレッドシートの編集権限を基準にする
+ * @returns {boolean} 編集権限を持つ場合 true
+ */
+function isDeployUser() {
+  try {
+    var userEmail = Session.getActiveUser().getEmail();
+    if (!userEmail) return false;
+
+    var dbId = PropertiesService.getScriptProperties()
+      .getProperty(SCRIPT_PROPS_KEYS.DATABASE_SPREADSHEET_ID);
+    if (!dbId) return false;
+
+    var file = DriveApp.getFileById(dbId);
+    var editors = file.getEditors().map(function(e) { return e.getEmail(); });
+    var ownerEmail = file.getOwner().getEmail();
+    if (ownerEmail) editors.push(ownerEmail);
+    return editors.indexOf(userEmail) !== -1;
+  } catch (e) {
+    console.error('isDeployUser エラー: ' + e.message);
+    return false;
+  }
+}

--- a/src/main.gs
+++ b/src/main.gs
@@ -414,6 +414,7 @@ function renderAdminPanel(userInfo, mode) {
   adminTemplate.mode = mode;
   adminTemplate.displayMode = 'named';
   adminTemplate.showAdminFeatures = true;
+  adminTemplate.isDeployUser = isDeployUser();
   return safeSetXFrameOptionsDeny(
     adminTemplate.evaluate()
       .setTitle('みんなの回答ボード 管理パネル')

--- a/tests/isDeployUser.test.js
+++ b/tests/isDeployUser.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('isDeployUser checks spreadsheet editors', () => {
+  const code = fs.readFileSync('src/Core.gs', 'utf8');
+  let context;
+  beforeEach(() => {
+    const scriptProps = { getProperty: jest.fn(() => 'SPREADSHEET_ID') };
+    const file = {
+      getEditors: () => [{ getEmail: () => 'editor@example.com' }],
+      getOwner: () => ({ getEmail: () => 'owner@example.com' })
+    };
+    context = {
+      PropertiesService: { getScriptProperties: () => scriptProps },
+      Session: { getActiveUser: () => ({ getEmail: () => 'editor@example.com' }) },
+      DriveApp: { getFileById: jest.fn(() => file) },
+      SCRIPT_PROPS_KEYS: { DATABASE_SPREADSHEET_ID: 'DATABASE_SPREADSHEET_ID' },
+      console
+    };
+    vm.createContext(context);
+    vm.runInContext(code, context);
+  });
+
+  test('returns true for editor email', () => {
+    context.Session.getActiveUser = () => ({ getEmail: () => 'editor@example.com' });
+    expect(context.isDeployUser()).toBe(true);
+  });
+
+  test('returns false for non editor', () => {
+    context.Session.getActiveUser = () => ({ getEmail: () => 'other@example.com' });
+    expect(context.isDeployUser()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `isDeployUser` utility to check database edit permission
- expose deploy-user status to the admin template
- hide "アプリ設定管理" section unless current user can edit the database
- test `isDeployUser`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687191f7f248832ba0e13b588e6dc4a0