### PR TITLE
Add tests for doGet flows and Core functions

### DIFF
--- a/tests/coreFunctions.test.js
+++ b/tests/coreFunctions.test.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('Core.gs utilities', () => {
+  const code = fs.readFileSync('src/Core.gs', 'utf8');
+  let context;
+  beforeEach(() => {
+    context = { debugLog: () => {}, console };
+    vm.createContext(context);
+    vm.runInContext(code, context);
+  });
+
+  describe('getOpinionHeaderSafely', () => {
+    beforeEach(() => {
+      context.findUserById = jest.fn();
+    });
+
+    test('returns default when user not found', () => {
+      context.findUserById.mockReturnValue(null);
+      const header = context.getOpinionHeaderSafely('uid', 'Sheet1');
+      expect(header).toBe('お題');
+    });
+
+    test('returns configured header', () => {
+      context.findUserById.mockReturnValue({
+        configJson: JSON.stringify({
+          publishedSheetName: 'Sheet1',
+          sheet_Sheet1: { opinionHeader: 'テーマ' }
+        })
+      });
+      const header = context.getOpinionHeaderSafely('uid', 'Sheet1');
+      expect(header).toBe('テーマ');
+    });
+  });
+
+  describe('registerNewUser', () => {
+    beforeEach(() => {
+      Object.assign(context, {
+        Session: { getActiveUser: () => ({ getEmail: () => 'admin@example.com' }) },
+        Utilities: { getUuid: () => 'UUID' },
+        findUserByEmail: jest.fn(),
+        createUser: jest.fn(),
+        updateUser: jest.fn(),
+        invalidateUserCache: jest.fn(),
+        generateAppUrls: jest.fn(() => ({ adminUrl: 'admin', viewUrl: 'view' }))
+      });
+    });
+
+    test('creates user when none exists', () => {
+      context.findUserByEmail.mockReturnValue(null);
+      const res = context.registerNewUser('admin@example.com');
+      expect(context.createUser).toHaveBeenCalled();
+      expect(res.isExistingUser).toBe(false);
+    });
+
+    test('updates existing user', () => {
+      context.findUserByEmail.mockReturnValue({ userId: 'U', configJson: '{}', spreadsheetId: 'SS' });
+      const res = context.registerNewUser('admin@example.com');
+      expect(context.updateUser).toHaveBeenCalled();
+      expect(res.isExistingUser).toBe(true);
+    });
+  });
+});

--- a/tests/doGetFlows.test.js
+++ b/tests/doGetFlows.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('doGet flows', () => {
+  const code = fs.readFileSync('src/main.gs', 'utf8');
+  let context;
+  beforeEach(() => {
+    context = {
+      cacheManager: { get: (_k, fn) => fn() },
+      debugLog: () => {},
+      HtmlService: { createHtmlOutput: jest.fn(() => 'redirect') },
+      Session: { getActiveUser: () => ({ getEmail: () => 'me@example.com' }) }
+    };
+    vm.createContext(context);
+    vm.runInContext(code, context);
+    context.renderAnswerBoard = jest.fn(() => 'board');
+    context.renderAdminPanel = jest.fn(() => 'admin');
+    context.showRegistrationPage = jest.fn(() => 'register');
+    context.handleSetupPages = jest.fn(() => null);
+    context.validateUserSession = jest.fn(() => ({
+      userEmail: 'me@example.com',
+      userInfo: { userId: '1', adminEmail: 'me@example.com' }
+    }));
+    context.parseRequestParams = jest.fn(() => ({ mode: 'admin', isDirectPageAccess: false }));
+  });
+
+  test('returns setup page when handleSetupPages outputs', () => {
+    context.handleSetupPages.mockReturnValue('setup');
+    const result = context.doGet({});
+    expect(result).toBe('setup');
+  });
+
+  test('renders answer board for direct access', () => {
+    context.parseRequestParams.mockReturnValue({ userId: '1', mode: 'view', isDirectPageAccess: true });
+    const result = context.doGet({});
+    expect(context.renderAnswerBoard).toHaveBeenCalled();
+    expect(result).toBe('board');
+  });
+
+  test('renders admin panel for admin mode', () => {
+    context.parseRequestParams.mockReturnValue({ mode: 'admin', isDirectPageAccess: false });
+    const result = context.doGet({});
+    expect(context.renderAdminPanel).toHaveBeenCalled();
+    expect(result).toBe('admin');
+  });
+
+  test('shows registration when userInfo missing', () => {
+    context.validateUserSession.mockReturnValue({ userEmail: null, userInfo: null });
+    const result = context.doGet({});
+    expect(result).toBe('register');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering doGet control flow
- add Core.gs unit tests for getOpinionHeaderSafely and registerNewUser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687197cc0884832b9f4b08b3e745fdd6