### PR TITLE
Fix publishing status and cache user lookups

### DIFF
--- a/src/config.gs
+++ b/src/config.gs
@@ -764,6 +764,7 @@ function saveSheetConfigBatch(spreadsheetId, sheetName, config, displayOptions) 
     configJson.publishedSpreadsheetId = spreadsheetId;
     configJson.displayMode = displayOptions.showNames ? 'named' : 'anonymous';
     configJson.showCounts = displayOptions.showCounts;
+    configJson.appPublished = true;
     configJson.lastModified = new Date().toISOString();
     
     // 一回のAPI呼び出しで全ての設定を更新

--- a/src/database.gs
+++ b/src/database.gs
@@ -31,8 +31,12 @@ function getSheetsService() {
  * @returns {object|null} ユーザー情報
  */
 function findUserById(userId) {
-  // キャッシュを無効化してデータベースから直接取得
-  return fetchUserFromDatabase('userId', userId);
+  var cacheKey = 'user_' + userId;
+  return cacheManager.get(
+    cacheKey,
+    function() { return fetchUserFromDatabase('userId', userId); },
+    { ttl: 300, enableMemoization: true }
+  );
 }
 
 /**
@@ -41,8 +45,12 @@ function findUserById(userId) {
  * @returns {object|null} ユーザー情報
  */
 function findUserByEmail(email) {
-  // キャッシュを無効化してデータベースから直接取得
-  return fetchUserFromDatabase('adminEmail', email);
+  var cacheKey = 'email_' + email;
+  return cacheManager.get(
+    cacheKey,
+    function() { return fetchUserFromDatabase('adminEmail', email); },
+    { ttl: 300, enableMemoization: true }
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- set `appPublished` when activating a sheet so publishing works
- cache user lookups via `cacheManager` to cut redundant DB calls

## Testing
- `npm test` *(fails: PropertiesService is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6871c1602bc8832b8724bdd238b54b7b