### PR TITLE
Fix form creation flow and admin unpublish behavior

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -2824,17 +2824,8 @@ function syncCheckboxStates(status) {
         .then(function(response) {
           console.log('公開停止レスポンス:', response);
           showMessage(response.message || '✅ 回答ボードの公開を停止しました。', 'success');
-          
-          // 2秒後に回答ボード（未公開状態）にリダイレクト
-          setTimeout(function() {
-            // 現在のURLを取得してviewモードのURLを生成
-            const currentUrl = new URL(window.location.href);
-            const baseUrl = currentUrl.origin + currentUrl.pathname;
-            const viewUrl = baseUrl + '?mode=view';
-            
-            console.log('公開停止後、回答ボードにリダイレクト:', viewUrl);
-            window.location.href = viewUrl;
-          }, 2000);
+          setLoading(false);
+          loadStatus(true); // 更新された状態を取得
         })
         .catch(function(error) {
           handleError(error, 'unpublishBoard');

--- a/src/Core.gs
+++ b/src/Core.gs
@@ -3520,7 +3520,15 @@ function isDeployUser() {
     
     try {
       var editors = file.getEditors().map(function(e) { return e.getEmail(); });
-      var ownerEmail = file.getOwner().getEmail();
+      var ownerEmail = '';
+      try {
+        var owner = file.getOwner();
+        if (owner && typeof owner.getEmail === 'function') {
+          ownerEmail = owner.getEmail();
+        }
+      } catch (ownerErr) {
+        console.warn('getOwner failed:', ownerErr.message);
+      }
       if (ownerEmail) editors.push(ownerEmail);
       return editors.indexOf(userEmail) !== -1;
     } catch (permissionError) {

--- a/src/config.gs
+++ b/src/config.gs
@@ -254,7 +254,7 @@ function autoMapHeaders(headers, sheetName = null) {
     }
   };
 
-  const result = {};
+  let result = {};
   const usedHeaders = new Set();
   const headerScores = {}; // ヘッダー毎のスコア記録
 


### PR DESCRIPTION
## Summary
- avoid constant reassignment error when mapping headers
- guard against missing owner in `isDeployUser`
- stop redirecting after unpublishing from admin panel

## Testing
- `npm test` *(fails: PropertiesService is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6871c79bbefc832ba3559aa59e7c67c7