### PR TITLE
Optimize user lookups and unify header detection

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -2711,9 +2711,16 @@ function syncCheckboxStates(status) {
       }
       setLoading(true, 'AI搭載高精度列判定システムが分析中...');
       
-      runGas('getGuessedHeaders', selectedSheet)
-        .then(function(guessed) {
-          populateConfig(guessed);
+      runGas('getSheetDetails', currentStatus.userInfo.spreadsheetId, selectedSheet)
+        .then(function(details) {
+          const configToUse = {
+            ...details.guessedConfig,
+            ...details.existingConfig,
+            showNames: details.existingConfig?.showNames || false,
+            showCounts: details.existingConfig?.showCounts !== undefined ? details.existingConfig.showCounts : false
+          };
+          populateHeaderOptions(details.allHeaders);
+          populateConfig(configToUse);
           showMessage('🤖 AIによる列判定が完了しました。', 'info');
           setLoading(false);
         })

--- a/src/Core.gs
+++ b/src/Core.gs
@@ -219,7 +219,7 @@ function executeGetPublishedSheetData(classFilter, sortOrder, adminMode) {
         throw new Error('ユーザーコンテキストが設定されていません');
       }
       
-      var userInfo = getUserWithFallback(currentUserId);
+      var userInfo = findUserById(currentUserId);
       if (!userInfo) {
         handleMissingUser(currentUserId);
         // Fallback to active user email if property points to missing user
@@ -351,7 +351,7 @@ function getIncrementalSheetData(classFilter, sortOrder, adminMode, sinceRowCoun
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = getUserInfoCached();
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -545,7 +545,7 @@ function getAppConfig() {
       }
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       handleMissingUser(currentUserId);
       var fallbackEmail = Session.getActiveUser().getEmail();
@@ -682,7 +682,7 @@ function saveSheetConfig(spreadsheetId, sheetName, config) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
 
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -723,7 +723,7 @@ function switchToSheet(spreadsheetId, sheetName) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
 
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -931,7 +931,7 @@ function getActiveFormInfo(userId) {
       }
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       handleMissingUser(currentUserId);
       var fallbackEmail = Session.getActiveUser().getEmail();
@@ -992,7 +992,7 @@ function refreshBoardData(userId) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -1031,7 +1031,7 @@ function addFormUrl(formUrl) {
       throw new Error('フォームURLからIDを抽出できませんでした');
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -1069,7 +1069,7 @@ function createAdditionalForm(title) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -1142,7 +1142,7 @@ function createAdditionalFormWithConfig(config) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = getUserInfoCached();
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -1215,7 +1215,7 @@ function updateFormSettings(title, description) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -1264,7 +1264,7 @@ function saveSystemConfig(config) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -1306,7 +1306,7 @@ function toggleHighlight(rowIndex, sheetName) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -2004,7 +2004,7 @@ function saveClassChoices(classChoices) {
       throw new Error('ユーザーコンテキストが設定されていません');
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       throw new Error('ユーザー情報が見つかりません');
     }
@@ -2037,7 +2037,7 @@ function getSavedClassChoices() {
       return { status: 'error', message: 'ユーザーコンテキストが設定されていません' };
     }
     
-    var userInfo = getUserWithFallback(currentUserId);
+    var userInfo = findUserById(currentUserId);
     if (!userInfo) {
       return { status: 'error', message: 'ユーザー情報が見つかりません' };
     }

--- a/src/config.gs
+++ b/src/config.gs
@@ -5,6 +5,19 @@
 
 const CONFIG_SHEET_NAME = 'Config';
 
+var runtimeUserInfo = null;
+
+/**
+ * 実行中に一度だけユーザー情報を取得して再利用する。
+ * @returns {object|null} ユーザー情報
+ */
+function getUserInfoCached() {
+  if (runtimeUserInfo) return runtimeUserInfo;
+  var userId = getUserId();
+  runtimeUserInfo = findUserById(userId);
+  return runtimeUserInfo;
+}
+
 /**
  * 現在のユーザーのスプレッドシートを取得
  * AdminPanel.htmlから呼び出される
@@ -111,9 +124,7 @@ function clearOldUserCache(currentEmail) {
 
 // 他の関数も同様に、存在することを確認
 function getUserInfo() {
-  const userId = getUserId();
-  // findUserById関数を呼び出すなど、ユーザー情報を取得するロジック
-  return findUserById(userId);
+  return getUserInfoCached();
 }
 
 /**

--- a/src/database.gs
+++ b/src/database.gs
@@ -115,8 +115,8 @@ function getUserWithFallback(userId) {
     return null;
   }
 
-  // キャッシュを使わずデータベースから直接取得
-  var user = fetchUserFromDatabase('userId', userId);
+  // 可能な限りキャッシュを利用
+  var user = findUserById(userId);
   if (!user) {
     handleMissingUser(userId);
   }


### PR DESCRIPTION
## Summary
- cache runtime user info to avoid repeated database fetches
- use cached user info in core logic
- update fallback function to leverage cache
- remove extra API call for header guessing in admin UI

## Testing
- `npm install`
- `npm test` *(fails: ReferenceError: PropertiesService is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6871d013c624832bae85917efe9af0b0