### PR TITLE
Improve stateless multi-tenant handling

### DIFF
--- a/src/config.gs
+++ b/src/config.gs
@@ -690,11 +690,11 @@ function saveAndPublishMultiTenant(requestUserId, sheetName, config) {
     console.log('saveAndPublishMultiTenant: 公開処理開始');
 
     // 2. 設定を保存
-    saveSheetConfig(spreadsheetId, sheetName, config);
+    saveSheetConfig(requestUserId, spreadsheetId, sheetName, config);
     console.log('saveAndPublishMultiTenant: 設定保存完了');
 
     // 3. シートをアクティブ化
-    switchToSheet(spreadsheetId, sheetName);
+    switchToSheet(requestUserId, spreadsheetId, sheetName);
     console.log('saveAndPublishMultiTenant: シート切り替え完了');
 
     // 4. 表示オプションを更新
@@ -840,7 +840,7 @@ function saveDraftConfigMultiTenant(requestUserId, sheetName, config) {
     }
 
     // 設定を保存
-    saveSheetConfig(userInfo.spreadsheetId, sheetName, config);
+    saveSheetConfig(requestUserId, userInfo.spreadsheetId, sheetName, config);
 
     // 関連キャッシュをクリア
     invalidateUserCache(userInfo.userId, userInfo.adminEmail, userInfo.spreadsheetId, false);
@@ -896,7 +896,7 @@ function activateSheetMultiTenant(requestUserId, spreadsheetId, sheetName) {
     }
 
     // シートをアクティブ化（効率化）
-    const switchResult = switchToSheet(spreadsheetId, sheetName);
+    const switchResult = switchToSheet(requestUserId, spreadsheetId, sheetName);
     console.log('activateSheetMultiTenant: シート切り替え完了');
 
     // 最新のステータスを取得（キャッシュ活用）
@@ -1496,11 +1496,11 @@ function saveAndPublishMultiTenant(requestUserId, sheetName, config) {
     console.log('saveAndPublishMultiTenant: 公開処理開始');
 
     // 2. 設定を保存
-    saveSheetConfig(spreadsheetId, sheetName, config);
+    saveSheetConfig(requestUserId, spreadsheetId, sheetName, config);
     console.log('saveAndPublishMultiTenant: 設定保存完了');
 
     // 3. シートをアクティブ化
-    switchToSheet(spreadsheetId, sheetName);
+    switchToSheet(requestUserId, spreadsheetId, sheetName);
     console.log('saveAndPublishMultiTenant: シート切り替え完了');
 
     // 4. 表示オプションを更新
@@ -1646,7 +1646,7 @@ function saveDraftConfigMultiTenant(requestUserId, sheetName, config) {
     }
 
     // 設定を保存
-    saveSheetConfig(userInfo.spreadsheetId, sheetName, config);
+    saveSheetConfig(requestUserId, userInfo.spreadsheetId, sheetName, config);
 
     // 関連キャッシュをクリア
     invalidateUserCache(userInfo.userId, userInfo.adminEmail, userInfo.spreadsheetId, false);

--- a/src/database.gs
+++ b/src/database.gs
@@ -949,9 +949,8 @@ function getDbSheet() {
  * 現在のユーザーのアカウント情報をデータベースから完全に削除する
  * @returns {string} 成功メッセージ
  */
-function deleteCurrentUserAccount() {
+function deleteUserAccount(userId) {
   try {
-    const userId = getUserId();
     if (!userId) {
       throw new Error('ユーザーが特定できません。');
     }


### PR DESCRIPTION
## Summary
- rework `getAppConfigMultiTenant` to rely solely on passed `userId`
- update sheet config helpers to accept explicit `userId`
- update multi-tenant flows to use the new stateless helpers
- refactor account deletion helper to accept `userId`

## Testing
- `npm test` *(fails: PropertiesService, ScriptApp undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68720689a914832baf1b5adb785b1af4