### PR TITLE
Fix setup detection when creds missing

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -254,7 +254,8 @@ function isSystemSetup() {
   var props = PropertiesService.getScriptProperties();
   var dbSpreadsheetId = props.getProperty('DATABASE_SPREADSHEET_ID');
   var adminEmail = props.getProperty('ADMIN_EMAIL');
-  return !!dbSpreadsheetId && !!adminEmail;
+  var serviceAccountCreds = props.getProperty('SERVICE_ACCOUNT_CREDS');
+  return !!dbSpreadsheetId && !!adminEmail && !!serviceAccountCreds;
 }
 
 /**

--- a/tests/isSystemSetup.test.js
+++ b/tests/isSystemSetup.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const vm = require('vm');
 
-describe('isSystemSetup requires ADMIN_EMAIL', () => {
+describe('isSystemSetup requires ADMIN_EMAIL and SERVICE_ACCOUNT_CREDS', () => {
   const code = fs.readFileSync('src/main.gs', 'utf8');
   let context;
 
@@ -22,10 +22,20 @@ describe('isSystemSetup requires ADMIN_EMAIL', () => {
     expect(context.isSystemSetup()).toBe(false);
   });
 
-  test('returns true when both properties exist', () => {
+  test('returns false when service account missing', () => {
     scriptProps.getProperty = (key) => {
       if (key === 'DATABASE_SPREADSHEET_ID') return 'id';
       if (key === 'ADMIN_EMAIL') return 'admin@example.com';
+      return null;
+    };
+    expect(context.isSystemSetup()).toBe(false);
+  });
+
+  test('returns true when all properties exist', () => {
+    scriptProps.getProperty = (key) => {
+      if (key === 'DATABASE_SPREADSHEET_ID') return 'id';
+      if (key === 'ADMIN_EMAIL') return 'admin@example.com';
+      if (key === 'SERVICE_ACCOUNT_CREDS') return '{"client_email":"a","private_key":"b"}';
       return null;
     };
     expect(context.isSystemSetup()).toBe(true);


### PR DESCRIPTION
## Summary
- ensure `isSystemSetup` checks for `SERVICE_ACCOUNT_CREDS`
- update tests for new setup rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872233a86a8832b9b2ffecea88229ed