### PR TITLE
Fix board fetch params and footer topic

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#1a1b26" />
   <meta name="description" content="StudyQuestの回答ボード管理パネル - 直感的で使いやすい教育ツール" />
-  <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), ambient-light-sensor=(), speaker-selection=(), vibrate=(), vr=()" />
+  <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), speaker-selection=()" />
   <!-- User ID from server template -->
   <meta name="user-id" content="<?= typeof userId !== 'undefined' ? userId : '' ?>" id="user-id-meta">
 
@@ -2757,34 +2757,31 @@ function syncCheckboxStates(status) {
         // トピックテキストを設定（問題文を表示）
         const topicTextElement = document.getElementById('current-topic-text');
         if (topicTextElement) {
-          let topic = '（問題文未設定）';
-          
-          // 1. カスタムフォーム情報から優先的に取得
-          if (status.customFormInfo && status.customFormInfo.mainQuestion) {
-            topic = status.customFormInfo.mainQuestion;
-            console.log('✅ [DEBUG] Using custom form main question:', topic);
-          } 
-          // 2. configJsonのmainQuestionから取得（新規フォーム用）
-          else if (status.userInfo && status.userInfo.configJson) {
-            try {
-              const config = JSON.parse(status.userInfo.configJson);
-              if (config.mainQuestion) {
-                topic = config.mainQuestion;
-                console.log('✅ [DEBUG] Using config.mainQuestion:', topic);
+          let topic = status.currentTopic || '（問題文未設定）';
+
+          if (!status.currentTopic) {
+            if (status.customFormInfo && status.customFormInfo.mainQuestion) {
+              topic = status.customFormInfo.mainQuestion;
+              console.log('✅ [DEBUG] Using custom form main question:', topic);
+            } else if (status.userInfo && status.userInfo.configJson) {
+              try {
+                const config = JSON.parse(status.userInfo.configJson);
+                if (config.mainQuestion) {
+                  topic = config.mainQuestion;
+                  console.log('✅ [DEBUG] Using config.mainQuestion:', topic);
+                } else if (status.publishedSheetName) {
+                  const sheetKey = 'sheet_' + status.publishedSheetName;
+                  const sheetConfig = config[sheetKey] || {};
+                  topic = sheetConfig.opinionHeader || status.publishedSheetName || '（問題文未設定）';
+                  console.log('✅ [DEBUG] Using sheet config opinionHeader:', topic);
+                }
+              } catch (e) {
+                console.warn('ConfigJson parsing error:', e);
+                topic = status.publishedSheetName || '（問題文未設定）';
               }
-              // 3. フォールバック: 公開中のシート設定から問題文を取得
-              else if (status.publishedSheetName) {
-                const sheetKey = 'sheet_' + status.publishedSheetName;
-                const sheetConfig = config[sheetKey] || {};
-                topic = sheetConfig.opinionHeader || status.publishedSheetName || '（問題文未設定）';
-                console.log('✅ [DEBUG] Using sheet config opinionHeader:', topic);
-              }
-            } catch (e) {
-              console.warn('ConfigJson parsing error:', e);
-              topic = status.publishedSheetName || '（問題文未設定）';
             }
           }
-          
+
           topicTextElement.textContent = topic;
           console.log(`✅ [DEBUG] Set footer topic text to: ${topic}`);
         }

--- a/src/AppSetupPage.html
+++ b/src/AppSetupPage.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>StudyQuest - アプリ設定</title>
-    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), ambient-light-sensor=(), speaker-selection=(), vibrate=(), vr=()" />
+    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), speaker-selection=()" />
     <script src="https://cdn.tailwindcss.com"></script>
     <?!= include('UnifiedStyles'); ?>
     <?!= include('SharedUtilities'); ?>

--- a/src/Core.gs
+++ b/src/Core.gs
@@ -3373,7 +3373,18 @@ function getStatus(requestUserId, forceRefresh = false) {
     
     // 公開状態の判定
     const isPublished = !!(configJson.appPublished && configJson.publishedSpreadsheetId && configJson.publishedSheetName);
-    
+
+    let topic = '（問題文未設定）';
+    if (customFormInfo && customFormInfo.mainQuestion) {
+      topic = customFormInfo.mainQuestion;
+    } else if (configJson.mainQuestion) {
+      topic = configJson.mainQuestion;
+    } else if (configJson.publishedSheetName) {
+      const sheetKey = 'sheet_' + configJson.publishedSheetName;
+      const sheetConfig = configJson[sheetKey] || {};
+      topic = sheetConfig.opinionHeader || configJson.publishedSheetName;
+    }
+
     return {
       status: 'success',
       userInfo: userInfo,
@@ -3386,7 +3397,8 @@ function getStatus(requestUserId, forceRefresh = false) {
       formUrl: formUrl || null,
       webAppUrl: getWebAppUrlCached(),
       appUrls: generateAppUrls(requestUserId),
-      customFormInfo: customFormInfo
+      customFormInfo: customFormInfo,
+      currentTopic: topic
     };
     
   } catch (error) {

--- a/src/Page.html
+++ b/src/Page.html
@@ -8,7 +8,7 @@
 <!-- Content Security Policy for enhanced security -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'self' https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://fonts.googleapis.com https://script.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.tailwindcss.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; img-src 'self' data: https:;">
 <!-- Permissions Policy to silence console warnings -->
-<meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), ambient-light-sensor=(), speaker-selection=(), vibrate=(), vr=()">
+<meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), speaker-selection=()">
 <!-- Preload Google Fonts for better performance -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -2176,7 +2176,7 @@ setupEventDelegation() {
             this.hideLoadingOverlay();
           }
         })
-        .getPublishedSheetData(classFilter, sortOrder, this.state.showAdminFeatures, false);
+        .getPublishedSheetData(this.state.sheetName, classFilter, sortOrder, this.state.showAdminFeatures, false);
       
       
       // Post-processing after successful data load


### PR DESCRIPTION
## Summary
- fix Permissions-Policy meta tags to avoid console warnings
- call `getPublishedSheetData` with the correct sheet name
- expose `currentTopic` from `getStatus`
- show topic in admin footer using new field

## Testing
- `npm test` *(fails: getDeployUserDomainInfo not defined, addUnifiedQuestions expected calls)*

------
https://chatgpt.com/codex/tasks/task_e_6872d963dd20832b91f4fee50f070b41