### PR TITLE
Fix view mode access

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -335,6 +335,13 @@ function doGet(e) {
       return createSecureRedirect(correctUrl, '管理パネルにリダイレクトしています...');
     }
 
+    if (params.isDirectPageAccess) {
+      const publicInfo = findUserById(params.userId);
+      if (publicInfo) {
+        return renderAnswerBoard(publicInfo, params);
+      }
+    }
+
     return showRegistrationPage();
   } catch (error) {
     console.error(`doGetで致命的なエラー: ${error.stack}`);
@@ -672,7 +679,9 @@ function renderAnswerBoard(userInfo, params) {
   const isPublished = !!(config.appPublished && config.publishedSpreadsheetId && config.publishedSheetName);
   const sheetConfigKey = 'sheet_' + (config.publishedSheetName || params.sheetName);
   const sheetConfig = config[sheetConfigKey] || {};
-  const showBoard = params.isDirectPageAccess || isPublished;
+  const currentUserEmail = Session.getActiveUser().getEmail();
+  const isOwner = currentUserEmail === userInfo.adminEmail;
+  const showBoard = isOwner || isPublished;
   const file = showBoard ? 'Page' : 'Unpublished';
   const template = HtmlService.createTemplateFromFile(file);
   template.include = include;
@@ -693,7 +702,6 @@ function renderAnswerBoard(userInfo, params) {
       template.displayMode = config.displayMode || 'anonymous';
       template.showCounts = config.showCounts !== undefined ? config.showCounts : false;
       template.showScoreSort = template.showCounts;
-      const currentUserEmail = Session.getActiveUser().getEmail();
       const isOwner = currentUserEmail === userInfo.adminEmail;
       template.showAdminFeatures = isOwner;
       template.isAdminUser = isOwner;
@@ -707,7 +715,6 @@ function renderAnswerBoard(userInfo, params) {
       template.displayMode = 'anonymous';
       template.showCounts = false;
       template.showScoreSort = false;
-      const currentUserEmail = Session.getActiveUser().getEmail();
       const isOwner = currentUserEmail === userInfo.adminEmail;
       template.showAdminFeatures = isOwner;
       template.isAdminUser = isOwner;

--- a/tests/doGetFlows.test.js
+++ b/tests/doGetFlows.test.js
@@ -38,7 +38,15 @@ describe.skip('doGet flows', () => {
     expect(result).toBe('admin');
   });
 
+  test('renders board for direct view without user session', () => {
+    context.parseRequestParams.mockReturnValue({ userId: '1', mode: 'view', isDirectPageAccess: true });
+    context.validateUserSession.mockReturnValue({ userEmail: null, userInfo: null });
+    const result = context.doGet({});
+    expect(result).toBe('board');
+  });
+
   test('shows registration when userInfo missing', () => {
+    context.parseRequestParams.mockReturnValue({ mode: 'admin', isDirectPageAccess: false });
     context.validateUserSession.mockReturnValue({ userEmail: null, userInfo: null });
     const result = context.doGet({});
     expect(result).toBe('register');


### PR DESCRIPTION
## Summary
- ensure board access checks email ownership

## Testing
- `npm install`
- `npm test` *(fails: getSheetsService error, mockReturnValue not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68737149261c832b814552d04a6f6221