### PR TITLE
Fix registration lock timeout

### DIFF
--- a/src/EnhancedLockSystem.gs
+++ b/src/EnhancedLockSystem.gs
@@ -51,7 +51,7 @@ function findOrCreateUserEnhanced(adminEmail, additionalData = {}) {
  * @returns {object|null} 成功時は結果、失敗時はnull
  */
 function attemptWithAdaptiveLock(adminEmail, additionalData) {
-  const lock = LockService.getScriptLock();
+  const lock = LockService.getUserLock();
   const timeout = 10000; // 10秒
   
   try {
@@ -133,7 +133,7 @@ function attemptWithAdaptiveLock(adminEmail, additionalData) {
  * @returns {object|null} 成功時は結果、失敗時はnull
  */
 function attemptWithMediumLock(adminEmail, additionalData) {
-  const lock = LockService.getScriptLock();
+  const lock = LockService.getUserLock();
   const timeout = 5000; // 5秒
   
   try {


### PR DESCRIPTION
## Summary
- avoid cross-user lock contention by using `LockService.getUserLock`

## Testing
- `npm test` *(fails: findOrCreateUser is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687389f1c4b8832bbd7787e8a6cd5e9a