### PR TITLE
Fix registration modal layout

### DIFF
--- a/src/Registration.html
+++ b/src/Registration.html
@@ -414,7 +414,6 @@
   <!-- External includes - carefully controlled -->
   <!-- <?!= include('UnifiedStyles'); ?> Disabled to prevent conflicts -->
   <?!= include('SharedUtilities'); ?>
-  <?!= include('SharedModals'); ?>
 </head>
 <body>
   <div class="glass-container" id="main-container">
@@ -460,6 +459,8 @@
       <a href="#" class="action-btn secondary" id="admin-panel-btn">管理画面を開く</a>
     </div>
   </div>
+
+  <?!= include('SharedModals'); ?>
 
   <script>
     let userEmail = '';


### PR DESCRIPTION
## Summary
- ensure shared modals are injected inside `<body>` on the registration page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741d4251fc832ba853e5d1a6d20dbc