### PR TITLE
Fix modal button styles on registration page

### DIFF
--- a/src/Registration.html
+++ b/src/Registration.html
@@ -365,6 +365,36 @@
       text-align: center;
     }
 
+    /* Basic button styles for SharedModals */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.75rem 1.5rem;
+      border-radius: 0.75rem;
+      font-weight: 600;
+      transition: all 0.2s ease;
+      cursor: pointer;
+      border: none;
+      text-decoration: none;
+      min-height: 44px;
+      min-width: 44px;
+      position: relative;
+      overflow: hidden;
+      font-size: 14px;
+    }
+
+    .btn-primary {
+      background: linear-gradient(135deg, #06b6d4 0%, #a855f7 100%);
+      color: #fff;
+    }
+
+    .btn-secondary {
+      background: rgba(255, 255, 255, 0.1);
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
     .action-btn.primary {
       background: linear-gradient(135deg, #06b6d4 0%, #a855f7 100%);
       color: white;


### PR DESCRIPTION
## Summary
- add basic `.btn`, `.btn-primary`, and `.btn-secondary` styles to the registration page
- run unit tests (they currently fail) 

## Testing
- `npm test` *(fails: findOrCreateUserWithEmailLock is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687421c05fa0832b9e79682cdbeb7c7d