### PR TITLE
Implement two-phase user setup

### DIFF
--- a/src/database.gs
+++ b/src/database.gs
@@ -103,7 +103,7 @@ function getAllUsersForAdmin() {
     const service = getSheetsService();
     const sheetName = DB_SHEET_CONFIG.SHEET_NAME;
     
-    const data = batchGetSheetsData(service, dbId, [`'${sheetName}'!A:H`]);
+    const data = batchGetSheetsData(service, dbId, [`'${sheetName}'!A:I`]);
     const values = data.valueRanges[0].values || [];
     
     if (values.length <= 1) {
@@ -196,7 +196,7 @@ function deleteUserAccountByAdmin(targetUserId, reason) {
       }
       
       // データを取得してユーザー行を特定
-      const data = batchGetSheetsData(service, dbId, [`'${sheetName}'!A:H`]);
+      const data = batchGetSheetsData(service, dbId, [`'${sheetName}'!A:I`]);
       const values = data.valueRanges[0].values || [];
       
       let rowToDelete = -1;
@@ -450,7 +450,7 @@ function fetchUserFromDatabase(field, value) {
     var service = getSheetsService();
     var sheetName = DB_SHEET_CONFIG.SHEET_NAME;
     
-    var data = batchGetSheetsData(service, dbId, ["'" + sheetName + "'!A:H"]);
+    var data = batchGetSheetsData(service, dbId, ["'" + sheetName + "'!A:I"]);
     var values = data.valueRanges[0].values || [];
     
     if (values.length === 0) return null;
@@ -521,7 +521,7 @@ function updateUser(userId, updateData) {
     var sheetName = DB_SHEET_CONFIG.SHEET_NAME;
     
     // 現在のデータを取得
-    var data = batchGetSheetsData(service, dbId, ["'" + sheetName + "'!A:H"]);
+    var data = batchGetSheetsData(service, dbId, ["'" + sheetName + "'!A:I"]);
     var values = data.valueRanges[0].values || [];
     
     if (values.length === 0) {
@@ -1196,7 +1196,7 @@ function getAllUsers() {
     var service = getSheetsService();
     var sheetName = DB_SHEET_CONFIG.SHEET_NAME;
     
-    var data = batchGetSheetsData(service, dbId, ["'" + sheetName + "'!A:H"]);
+    var data = batchGetSheetsData(service, dbId, ["'" + sheetName + "'!A:I"]);
     var values = data.valueRanges[0].values || [];
     
     if (values.length <= 1) {
@@ -1342,7 +1342,7 @@ function deleteUserAccount(userId) {
       console.log('Found database sheet with sheetId:', targetSheetId);
       
       // データを取得
-      var data = batchGetSheetsData(service, dbId, ["'" + sheetName + "'!A:H"]);
+      var data = batchGetSheetsData(service, dbId, ["'" + sheetName + "'!A:I"]);
       var values = data.valueRanges[0].values || [];
       
       // ユーザーIDに基づいて行を探す（A列がIDと仮定）

--- a/src/main.gs
+++ b/src/main.gs
@@ -41,7 +41,7 @@ var DB_SHEET_CONFIG = {
   SHEET_NAME: 'Users',
   HEADERS: [
     'userId', 'adminEmail', 'spreadsheetId', 'spreadsheetUrl',
-    'createdAt', 'configJson', 'lastAccessedAt', 'isActive'
+    'createdAt', 'configJson', 'setupStatus', 'lastAccessedAt', 'isActive'
   ]
 };
 

--- a/tests/allFormScenarios.test.js
+++ b/tests/allFormScenarios.test.js
@@ -47,6 +47,7 @@ describe('All form creation scenarios reaction columns', () => {
     // Load both Core.gs and config.gs
     vm.runInContext(coreCode, context);
     vm.runInContext(configCode, context);
+    context.getSheetsList = jest.fn();
   });
 
   describe('addSpreadsheetUrl scenario', () => {

--- a/tests/coreFunctions.test.js
+++ b/tests/coreFunctions.test.js
@@ -5,8 +5,8 @@ describe('Core.gs utilities', () => {
   const code = fs.readFileSync('src/Core.gs', 'utf8');
   let context;
   beforeEach(() => {
-    context = { 
-      debugLog: () => {}, 
+    context = {
+      debugLog: () => {},
       console,
       cacheManager: {
         remove: jest.fn(),
@@ -17,6 +17,11 @@ describe('Core.gs utilities', () => {
         sleep: jest.fn(),
         getUuid: () => 'UUID'
       },
+      findOrCreateUserWithEmailLock: jest.fn(() => ({
+        userId: 'UUID',
+        isNewUser: true,
+        userInfo: { userId: 'UUID', adminEmail: 'admin@example.com', configJson: '{}' }
+      })),
       fetchUserFromDatabase: jest.fn(),
       comprehensiveUserSearch: jest.fn(),
       registerNewUser: jest.fn(() => ({ userId: 'UUID', adminUrl: 'admin', viewUrl: 'view' }))

--- a/tests/userDuplicationPrevention.test.js
+++ b/tests/userDuplicationPrevention.test.js
@@ -18,6 +18,7 @@ describe('User Duplication Prevention Tests', () => {
       LockService: {
         getScriptLock: jest.fn(() => ({
           waitLock: jest.fn(() => true),
+          tryLock: jest.fn(() => true),
           releaseLock: jest.fn()
         }))
       },
@@ -41,7 +42,7 @@ describe('User Duplication Prevention Tests', () => {
       },
       DB_SHEET_CONFIG: {
         SHEET_NAME: 'Users',
-        HEADERS: ['userId', 'adminEmail', 'spreadsheetId', 'spreadsheetUrl', 'createdAt', 'configJson', 'lastAccessedAt', 'isActive']
+        HEADERS: ['userId', 'adminEmail', 'spreadsheetId', 'spreadsheetUrl', 'createdAt', 'configJson', 'setupStatus', 'lastAccessedAt', 'isActive']
       },
       // Mock functions
       findUserByEmail: jest.fn(),

--- a/tests/userManagementDisplay.test.js
+++ b/tests/userManagementDisplay.test.js
@@ -27,12 +27,13 @@ describe('User Management Display', () => {
     
     vm.createContext(context);
     vm.runInContext(code, context);
+    context.batchGetSheetsData = jest.fn();
   });
 
   describe('getAllUsersForAdmin', () => {
     test('should return users with createdAt field from database', () => {
       // Mock database response
-      const mockHeaders = ['userId', 'adminEmail', 'spreadsheetId', 'spreadsheetUrl', 'createdAt', 'configJson', 'lastAccessedAt', 'isActive'];
+      const mockHeaders = ['userId', 'adminEmail', 'spreadsheetId', 'spreadsheetUrl', 'createdAt', 'configJson', 'setupStatus', 'lastAccessedAt', 'isActive'];
       const mockUserData = [
         'user123', 
         '35t22@naha-okinawa.ed.jp', 
@@ -93,7 +94,7 @@ describe('User Management Display', () => {
   describe('Database column mapping', () => {
     test('should verify DB_SHEET_CONFIG.HEADERS contains createdAt', () => {
       // This test documents the expected database structure
-      const expectedHeaders = ['userId', 'adminEmail', 'spreadsheetId', 'spreadsheetUrl', 'createdAt', 'configJson', 'lastAccessedAt', 'isActive'];
+      const expectedHeaders = ['userId', 'adminEmail', 'spreadsheetId', 'spreadsheetUrl', 'createdAt', 'configJson', 'setupStatus', 'lastAccessedAt', 'isActive'];
       
       expect(expectedHeaders).toContain('createdAt');
       expect(expectedHeaders).not.toContain('registrationDate');


### PR DESCRIPTION
## Summary
- add `setupStatus` column to DB_SHEET_CONFIG
- update sheet range usage for new column
- rework `quickStartSetup` to reserve users with a short lock
- add helpers for resource creation and finalization
- adjust tests for new structure

## Testing
- `npm test` *(fails: 24 failed, 4 skipped, 30 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68743ad1a9fc832bb5716bcac0ff083a