### PR TITLE
Fix updateUser row index handling

### DIFF
--- a/src/database.gs
+++ b/src/database.gs
@@ -674,6 +674,19 @@ function updateUser(userId, updateData) {
         }
       }
     }
+
+    // キャッシュが古く行番号が範囲外の場合は再計算
+    if (rowIndex < 1 || rowIndex > values.length) {
+      for (var i = 1; i < values.length; i++) {
+        if (values[i][userIdIndex] === userId) {
+          rowIndex = i + 1; // 1-based index
+          break;
+        }
+      }
+      if (rowIndex < 1 || rowIndex > values.length) {
+        throw new Error('更新対象のユーザーが見つかりません');
+      }
+    }
     
     if (rowIndex === -1) {
       throw new Error('更新対象のユーザーが見つかりません');


### PR DESCRIPTION
## Summary
- handle stale row index cache in `updateUser`

## Testing
- `npm install`
- `npm test` *(fails: getServiceAccountTokenCached is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68749dfc12a4832ba74a23f89aafdafd