### PR TITLE
Introduce AuthorizationService and config utilities

### DIFF
--- a/src/AuthorizationService.gs
+++ b/src/AuthorizationService.gs
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview 権限管理サービス
+ * システム内のリソースへのアクセス権を検証する機能を提供します。
+ */
+
+const AuthorizationService = (function() {
+
+  /**
+   * 現在の操作ユーザーが、対象のユーザーデータにアクセスする権限を持っているか検証します。
+   * @param {string} targetUserId - 操作対象のユーザーID。
+   * @returns {boolean} アクセスが許可される場合は true、それ以外は false。
+   * @throws {Error} 権限がない場合にエラーをスローします。
+   */
+  function verifyUserAccess(targetUserId) {
+    const activeUserEmail = Session.getActiveUser().getEmail();
+
+    // 1. システム管理者（デプロイユーザー）は常にアクセス可能
+    if (isDeployUser()) {
+      console.log(`[Auth] Access granted for ADMIN (${activeUserEmail}) to target: ${targetUserId}`);
+      return true;
+    }
+
+    // 2. 本人による操作か確認
+    const targetUser = findUserById(targetUserId); // データベースからユーザー情報を取得
+    if (targetUser && targetUser.adminEmail === activeUserEmail) {
+      console.log(`[Auth] Access granted for OWNER (${activeUserEmail}) to target: ${targetUserId}`);
+      return true;
+    }
+
+    // 3. 上記以外は権限なし
+    console.warn(`[Auth] Access DENIED for user (${activeUserEmail}) to target: ${targetUserId}`);
+    throw new Error(`権限エラー: ${activeUserEmail} はユーザーID ${targetUserId} のデータにアクセスする権限がありません。`);
+  }
+
+  return {
+    verifyUserAccess: verifyUserAccess,
+  };
+})();
+

--- a/src/Core.gs
+++ b/src/Core.gs
@@ -3922,7 +3922,7 @@ function createCustomFormUI(requestUserId, config) {
       console.warn('createCustomFormUI - user not found:', requestUserId);
     }
     
-    return {
+    const response = {
       status: 'success',
       message: 'カスタムフォームが正常に作成されました！',
       formUrl: result.formUrl,
@@ -3931,8 +3931,17 @@ function createCustomFormUI(requestUserId, config) {
       formTitle: result.formTitle,
       spreadsheetId: result.spreadsheetId,
       sheetName: result.sheetName,
-      autoPublishReady: true
+      autoPublishReady: true,
     };
+
+    saveFormCreationConfig(requestUserId, {
+      formUrl: response.formUrl,
+      editFormUrl: response.editFormUrl,
+      sheetName: response.sheetName,
+      opinionHeader: config.opinionHeader,
+    });
+
+    return response;
   } catch (error) {
     console.error('createCustomFormUI error:', error.message);
     return {
@@ -3952,7 +3961,7 @@ function createCustomFormUI(requestUserId, config) {
  */
 function autoSaveAndPublishAfterFormCreation(requestUserId, sheetName, formData) {
   try {
-    verifyUserAccess(requestUserId);
+    AuthorizationService.verifyUserAccess(requestUserId);
     console.log('autoSaveAndPublishAfterFormCreation 開始 - userId:', requestUserId, 'sheetName:', sheetName);
     
     // 基本設定オブジェクトを作成

--- a/tests/AuthorizationService.test.js
+++ b/tests/AuthorizationService.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('AuthorizationService', () => {
+  let context;
+
+  beforeEach(() => {
+    // 必要なモックをセットアップ
+    context = {
+      Session: { getActiveUser: jest.fn() },
+      isDeployUser: jest.fn(),
+      findUserById: jest.fn(),
+      console: { log: jest.fn(), warn: jest.fn() },
+    };
+    const code = fs.readFileSync('src/AuthorizationService.gs', 'utf8');
+    vm.createContext(context);
+    vm.runInContext(code, context);
+  });
+
+  test('システム管理者はどのユーザーのデータにもアクセスできる', () => {
+    context.isDeployUser.mockReturnValue(true);
+    expect(() => context.AuthorizationService.verifyUserAccess('any_user_id')).not.toThrow();
+  });
+
+  test('一般ユーザーは自分のデータにのみアクセスできる', () => {
+    context.isDeployUser.mockReturnValue(false);
+    context.Session.getActiveUser.mockReturnValue({ getEmail: () => 'user@example.com' });
+    context.findUserById.mockReturnValue({ adminEmail: 'user@example.com' });
+
+    expect(() => context.AuthorizationService.verifyUserAccess('my_user_id')).not.toThrow();
+  });
+
+  test('一般ユーザーが他人のデータにアクセスしようとするとエラーをスローする', () => {
+    context.isDeployUser.mockReturnValue(false);
+    context.Session.getActiveUser.mockReturnValue({ getEmail: () => 'user@example.com' });
+    context.findUserById.mockReturnValue({ adminEmail: 'another_user@example.com' });
+
+    expect(() => context.AuthorizationService.verifyUserAccess('another_user_id')).toThrow('権限エラー');
+  });
+});


### PR DESCRIPTION
## Summary
- add new `AuthorizationService.gs` implementing central auth checks
- integrate new auth check into `autoSaveAndPublishAfterFormCreation`
- store form creation info with `saveFormCreationConfig`
- provide helper config utilities for reading and writing user configs
- test AuthorizationService behavior

## Testing
- `npm test` *(fails: Test Suites: 7 failed, 1 skipped, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6874c6a9d6b8832bad36cffcddca8188