### PR TITLE
Fix modal closing selectors

### DIFF
--- a/src/Registration.html
+++ b/src/Registration.html
@@ -284,15 +284,16 @@
             return;
           }
 
-          const isClose =
-            e.target.classList.contains('modal-overlay') ||
+          const modal = e.target.closest('[id$="-modal"]');
+          if (!modal) return;
+
+          const shouldClose =
+            e.target === modal ||
             e.target.closest('.close-modal') ||
             e.target.closest('[id$="-cancel"]') ||
             e.target.closest('[id$="-close"]');
-          if (isClose) {
-            const modal = e.target.closest('.modal-overlay');
-            if (modal) hideModal(modal.id);
-          }
+
+          if (shouldClose) hideModal(modal.id);
         });
       };
 

--- a/src/SharedModals.html
+++ b/src/SharedModals.html
@@ -560,29 +560,12 @@ class SharedModals {
       }
     });
 
-    // クローズボタンの設定
-    const closeButtons = [
-      'digital-citizenship-modal-close',
-      'digital-citizenship-modal-close-btn',
-      'teacherGuideModal-close',
-      'teacherGuideModal-close-btn',
-      'usage-guide-modal-close',
-      'usage-guide-modal-close-btn'
-    ];
-    
-    closeButtons.forEach(buttonId => {
-      const button = document.getElementById(buttonId);
-      if (button) {
-        button.onclick = () => {
-          if (buttonId.includes('digital-citizenship')) {
-            this.hideModal('digital-citizenship-modal');
-          } else if (buttonId.includes('teacherGuide')) {
-            this.hideModal('teacherGuideModal');
-          } else if (buttonId.includes('usage-guide')) {
-            this.hideModal('usage-guide-modal');
-          }
-        };
-      }
+    // クローズ/キャンセルボタンの委任イベント
+    document.addEventListener('click', e => {
+      const closeTrigger = e.target.closest('[id$="-close"], [id$="-cancel"]');
+      if (!closeTrigger) return;
+      const modal = closeTrigger.closest('[id$="-modal"]');
+      if (modal) this.hideModal(modal.id);
     });
   }
 


### PR DESCRIPTION
## Summary
- improve modal closing logic in `setupModalControls`
- delegate close/cancel buttons in SharedModals to `hideModal`

## Testing
- `npm test` *(fails: AuthorizationService, integrationDuplicationTest, userDuplicationPrevention, userManagementDisplay)*

------
https://chatgpt.com/codex/tasks/task_e_68756f5efb88832bb6b4873cd116af24