### PR TITLE
Implement layout refinements

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -201,11 +201,10 @@
       <p id="loading-message" class="mt-4 text-gray-300">処理中...</p>
     </div>
   </div>
-  <header class="glass-panel border-b border-gray-700 sticky top-0 z-50">
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4">
-      <div class="flex items-center justify-between">
+  <header id="admin-header" class="glass-panel border-b border-gray-700 sticky top-0 z-50">
+    <div class="max-w-6xl mx-auto w-full flex items-center">
         <!-- ロゴとタイトル -->
-        <div class="flex items-center gap-3">
+        <div class="logo-title flex items-center gap-3">
           <div class="w-8 h-8 bg-gradient-to-r from-cyan-400 to-purple-400 rounded-lg flex items-center justify-center flex-shrink-0">
             <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
@@ -268,7 +267,7 @@
   <main class="flex-1 max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-8 pb-40">
     <!-- シンプル統合ステータスバー -->
     <section class="mb-4">
-      <div class="glass-panel p-4 rounded-lg">
+      <div class="status-bar glass-panel rounded-lg">
         <div class="flex items-center justify-between">
           <!-- 左側: ステータス表示 -->
           <div class="flex items-center gap-3">
@@ -290,19 +289,19 @@
           </div>
           
           <!-- 右側: コンパクトステップナビゲーション -->
-          <div class="flex items-center gap-2">
+          <div class="steps flex items-center gap-2">
             <div class="flex items-center gap-1" id="step-1-indicator">
-              <div class="w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center font-bold text-xs transition-all">1</div>
+              <div class="step-badge w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center font-bold text-xs transition-all">1</div>
               <span class="text-xs text-gray-300 hidden sm:inline">データ準備</span>
             </div>
             <div class="w-4 h-px bg-gray-600"></div>
             <div class="flex items-center gap-1" id="step-2-indicator">
-              <div class="w-6 h-6 bg-gray-600 text-white rounded-full flex items-center justify-center font-bold text-xs transition-all">2</div>
+              <div class="step-badge w-6 h-6 bg-gray-600 text-white rounded-full flex items-center justify-center font-bold text-xs transition-all">2</div>
               <span class="text-xs text-gray-300 hidden sm:inline">シート選択</span>
             </div>
             <div class="w-4 h-px bg-gray-600"></div>
             <div class="flex items-center gap-1" id="step-3-indicator">
-              <div class="w-6 h-6 bg-gray-600 text-white rounded-full flex items-center justify-center font-bold text-xs transition-all">3</div>
+              <div class="step-badge w-6 h-6 bg-gray-600 text-white rounded-full flex items-center justify-center font-bold text-xs transition-all">3</div>
               <span class="text-xs text-gray-300 hidden sm:inline">設定・公開</span>
             </div>
           </div>
@@ -313,7 +312,7 @@
     <!-- メインコンテンツエリア -->
     <div class="responsive-grid">
       <!-- 左側：セットアップフロー（メインパネル） -->
-      <div class="left-panel space-y-4 lg:space-y-6">
+      <div class="left-panel">
         
         <!-- ステップ1: データ準備 -->
         <div class="glass-panel p-4 lg:p-6" id="data-setup-section">
@@ -870,9 +869,9 @@
   </main>
   
   <!-- 統合フッター -->
-  <footer id="admin-footer" class="fixed bottom-0 left-0 right-0 glass-panel border-t border-gray-700 hidden">
-    <div class="max-w-6xl mx-auto px-6 py-4">
-      <div class="flex items-center justify-between">
+  <footer id="admin-footer" class="fixed bottom-0 left-0 right-0 glass-panel hidden">
+    <div class="max-w-6xl mx-auto">
+      <div class="flex items-center">
         <!-- 左側: 公開中の問題文 -->
         <div class="flex-1">
           <div class="flex items-center gap-2 mb-1">
@@ -883,22 +882,14 @@
           </div>
           <p class="text-blue-300 font-medium text-lg" id="current-topic-text">読み込み中...</p>
         </div>
-        
         <!-- 右側: ボードURL操作 -->
-        <div class="flex items-center gap-3">
-          <input type="text" id="board-url" readonly
-                 class="px-4 py-2 bg-gray-800 border border-gray-600 rounded-lg text-sm cursor-pointer hover:bg-gray-700 focus:ring-2 focus:ring-green-400 min-w-[300px]"
-                 onclick="this.select()" placeholder="URLが生成されます">
-          <button type="button" onclick="copyBoardUrl()" class="btn btn-secondary px-3 py-2 flex items-center" title="URLをコピー" aria-label="生徒用URLをコピー">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
-            </svg>
+        <div class="url-container">
+          <label for="board-url" class="url-label">公開中URL:</label>
+          <input type="text" id="board-url" readonly class="url-input px-2 bg-gray-800 border border-gray-600 rounded-lg text-sm cursor-pointer hover:bg-gray-700 focus:ring-2 focus:ring-green-400" onclick="this.select()" placeholder="URLが生成されます">
+          <button type="button" onclick="copyBoardUrl()" class="btn-copy btn btn-secondary px-3" title="URLをコピー" aria-label="生徒用URLをコピー">
+            コピー
           </button>
-          <a id="view-board-link" href="#" target="_blank" rel="noopener noreferrer" class="btn btn-primary px-3 py-2 flex items-center" title="回答ボードを開く" aria-label="新しいタブで回答ボードを開く">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
-            </svg>
-          </a>
+          <a id="view-board-link" href="#" target="_blank" rel="noopener noreferrer" class="btn-open btn btn-primary px-3" title="回答ボードを開く" aria-label="新しいタブで回答ボードを開く">開く</a>
         </div>
       </div>
     </div>
@@ -1370,6 +1361,15 @@
         document.body.style.paddingBottom = footerHeight + baseBodyPadding + 'px';
       }
     }
+
+    function adjustFooterPadding() {
+      const footer = document.getElementById('admin-footer');
+      if (footer) {
+        document.body.style.paddingBottom = footer.offsetHeight + 'px';
+      }
+    }
+
+    window.addEventListener('load', adjustFooterPadding);
 
     // プライバシーモーダルの制御関数
     function showPrivacyModal(onContinue) {

--- a/src/UnifiedStyles.html
+++ b/src/UnifiedStyles.html
@@ -96,13 +96,13 @@ html, body, div, span, h1, h2, h3, h4, h5, h6, p, button, a {
 }
 
 /* Glass Panel Effects - Glassmorphism System */
-.glass-panel { 
-  background: var(--color-surface) !important;
-  -webkit-backdrop-filter: blur(var(--backdrop-blur)) !important;
-  backdrop-filter: blur(var(--backdrop-blur)) !important;
-  border: 1px solid var(--color-border) !important;
-  box-shadow: var(--shadow-glass) !important;
-  border-radius: 24px !important;
+.glass-panel {
+  background: rgba(255, 255, 255, 0.05) !important;
+  -webkit-backdrop-filter: blur(6px) !important;
+  backdrop-filter: blur(6px) !important;
+  border: 1px solid rgba(255, 255, 255, 0.15) !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4) !important;
+  border-radius: 12px !important;
   transition: all var(--transition-duration) var(--transition-easing);
   position: relative !important;
   /* Prevent creating new stacking context that blocks modals */
@@ -836,8 +836,101 @@ html, body, div, span, h1, h2, h3, h4, h5, h6, p, button, a {
   cursor: pointer !important; 
 }
 
-.footer a:hover { 
-  color: white !important; 
+.footer a:hover {
+  color: white !important;
+}
+
+/* Admin Panel Header */
+#admin-header {
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+}
+
+.logo-title {
+  margin-right: auto;
+}
+
+#header-domain-info {
+  margin-left: auto;
+}
+
+#admin-header {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5) !important;
+}
+
+/* Status Bar */
+.status-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 24px;
+}
+
+.status-bar .steps {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.status-bar .steps > div > div {
+  width: 28px;
+  height: 28px;
+  font-size: 14px;
+}
+
+/* Left Panel Cards */
+.left-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.left-panel > .glass-panel {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+/* URL Container */
+.url-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 24px;
+  background: rgba(30, 31, 37, 0.6);
+  border-radius: 12px;
+  backdrop-filter: blur(6px);
+}
+
+.url-label {
+  flex: 0 0 auto;
+  font-size: 14px;
+  color: #a0a0a0;
+}
+
+.url-input {
+  flex: 1;
+  height: 36px;
+}
+
+.btn-copy,
+.btn-open {
+  flex: 0 0 auto;
+  height: 36px;
+}
+
+/* Admin Footer */
+#admin-footer {
+  background: rgba(26, 27, 38, 0.8);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 12px 24px;
+}
+
+#admin-footer .flex {
+  justify-content: space-between;
 }
 
 /* Modal System */


### PR DESCRIPTION
## Summary
- update `glass-panel` style for consistent glassmorphism
- tweak header, status bar and left panel CSS
- restructure AdminPanel header and status bar markup
- introduce compact URL container and footer styles
- auto adjust footer padding on load

## Testing
- `npm test` *(fails: jest not found / tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6875cf3c709c832bbfd1a863fdd63a7f