### PR TITLE
Improve script lock acquisition

### DIFF
--- a/src/EmailSpecificLock.gs
+++ b/src/EmailSpecificLock.gs
@@ -10,6 +10,23 @@ const SCRIPT_LOCK_INFO_CACHE = CacheService.getScriptCache();
 const SCRIPT_LOCK_HOLDER_KEY = 'scriptLockHolder';
 
 /**
+ * Tries to acquire a script lock with retries.
+ * @param {number} totalTimeout - Total time to wait in ms.
+ * @param {number} [interval=1000] - Interval between attempts in ms.
+ * @returns {GoogleAppsScript.Lock.Lock|null} Obtained lock or null.
+ */
+function acquireScriptLockWithRetry(totalTimeout, interval) {
+  interval = interval || 1000;
+  var start = Date.now();
+  var lock = LockService.getScriptLock();
+
+  while (Date.now() - start < totalTimeout) {
+    if (lock.tryLock(interval)) return lock;
+  }
+  return null;
+}
+
+/**
  * メール特化ロック：同一メールの重複処理を防止
  * @param {string} adminEmail - メールアドレス
  * @returns {boolean} ロック取得成功かどうか
@@ -82,10 +99,10 @@ function findOrCreateUserWithEmailLock(adminEmail, additionalData = {}) {
     
     // Step 3: 新規ユーザー作成（スクリプトロック使用 - ユーザーロック廃止）
     console.log('findOrCreateUserWithEmailLock: 新規ユーザー作成開始', { adminEmail });
-    const lock = LockService.getScriptLock();
     const timeout = 30000; // 30秒に延長（フォーム・スプレッドシート作成時間を考慮）
+    const lock = acquireScriptLockWithRetry(timeout);
 
-    if (!lock.waitLock(timeout)) {
+    if (!lock) {
       const holder = SCRIPT_LOCK_INFO_CACHE.get(SCRIPT_LOCK_HOLDER_KEY);
       console.error('findOrCreateUserWithEmailLock: スクリプトロックタイムアウト', {
         adminEmail,


### PR DESCRIPTION
## Summary
- add `acquireScriptLockWithRetry` helper
- retry script lock acquisition in `findOrCreateUserWithEmailLock`

## Testing
- `npm test` *(fails: Session is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6876ad81b8a8832b815b190649e23bc4