### PR TITLE
Fix login fallback and clear index cache

### DIFF
--- a/src/database.gs
+++ b/src/database.gs
@@ -1589,9 +1589,10 @@ function createUserAtomic(userData) {
   const service = getSheetsService();
   appendSheetsData(service, dbId, "'" + sheetName + "'!A1", [newRow]);
   console.log('User created via Service Account');
-  
+
   // キャッシュ無効化
   invalidateUserCache(userData.userId, userData.adminEmail, userData.spreadsheetId, false);
+  cacheManager.clearByPattern('db_index_');
   
   return userData;
 }

--- a/src/main.gs
+++ b/src/main.gs
@@ -880,9 +880,14 @@ function validateUserSession(currentUserEmail, params) {
       }
       
       console.log('validateUserSession - valid user found:', userInfo.userId);
-    } else {
-      console.warn('validateUserSession - userId not found:', params.userId);
-    }
+      } else {
+        console.warn('validateUserSession - userId not found:', params.userId);
+        var fallbackByEmail = findUserByEmail(currentUserEmail);
+        if (fallbackByEmail) {
+          console.log('validateUserSession - fallback found user by email:', fallbackByEmail.userId);
+          userInfo = fallbackByEmail;
+        }
+      }
   } else if (params.isDirectPageAccess) {
     // 直接ページアクセスの場合は、emailベースでフォールバック
     console.log('validateUserSession - direct page access, looking up by email');


### PR DESCRIPTION
## Summary
- fall back to email lookup in `validateUserSession`
- clear DB index cache whenever creating a user

## Testing
- `npm test` *(fails: getServiceAccountTokenCached is not defined, multiple test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876aff1efd4832b85bde968d73e7017