### PR TITLE
Fix admin panel frame options

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -987,10 +987,8 @@ function renderAdminPanel(userInfo, mode) {
   adminTemplate.correctUrl = correctUrl;
   adminTemplate.shouldUpdateUrl = true;
   
-  return adminTemplate.evaluate()
-    .setTitle('みんなの回答ボード 管理パネル')
-    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.SAMEORIGIN)
-    .setSandboxMode(HtmlService.SandboxMode.IFRAME);
+  const output = adminTemplate.evaluate().setTitle('みんなの回答ボード 管理パネル');
+  return safeSetXFrameOptionsAllowAll(output);
 }
 
 /**


### PR DESCRIPTION
## Summary
- guard `renderAdminPanel` frame option settings with `safeSetXFrameOptionsAllowAll`

## Testing
- `npm test` *(fails: getServiceAccountTokenCached is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6876c118947c832bbf4fd3756f788cf2