### PR TITLE
Improve admin panel layout

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -542,11 +542,25 @@
           </div>
         </div>
         
-        <!-- システム状況表示 -->
+        <!-- システム状況表示とドメイン情報 -->
         <div class="flex items-center gap-3">
           <div id="system-status-indicator" class="flex items-center gap-2 glass-panel bg-gray-800/50 rounded-lg px-3 py-2 border border-gray-700">
             <div id="header-status-dot" class="w-3 h-3 bg-blue-400 rounded-full animate-pulse flex-shrink-0"></div>
             <span id="header-status-text" class="text-sm text-gray-300">初期化中...</span>
+          </div>
+          <div id="header-domain-info" class="flex items-center gap-2">
+            <div id="header-domain-match" class="hidden items-center gap-1 text-green-300">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+              <span id="header-domain-match-text"></span>
+            </div>
+            <div id="header-domain-mismatch" class="hidden items-center gap-1 text-yellow-300">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"/></svg>
+              <span id="header-domain-mismatch-text"></span>
+            </div>
+            <div id="header-domain-initial" class="flex items-center gap-1">
+              <div class="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
+              <span class="text-gray-300">確認中...</span>
+            </div>
           </div>
         </div>
     </div>
@@ -814,38 +828,6 @@
       <!-- 右パネル：システム情報 -->
       <div class="right-panel space-y-6">
         
-        <!-- ドメイン情報 -->
-        <div class="glass-panel p-6">
-          <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-            <svg class="w-5 h-5 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2h10a2 2 0 002-2v-1a2 2 0 012-2h1.945C21.43 7.125 17.642 4 12.5 4S3.57 7.125 3.055 11z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 14a7 7 0 0014 0H5z"></path></svg>
-            ドメイン情報
-          </h3>
-          <div id="domain-info-content">
-            <!-- ドメイン一致 -->
-            <div id="domain-match-badge" class="hidden items-center gap-3 bg-green-900/50 border border-green-500/30 rounded-lg p-3">
-              <svg class="w-6 h-6 text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-              <div>
-                <div id="domain-match-text" class="font-semibold text-green-300">G Suite ドメイン</div>
-                <div class="text-xs text-green-400">セキュアアクセス有効</div>
-              </div>
-            </div>
-            <!-- ドメイン不一致 -->
-            <div id="domain-mismatch-badge" class="hidden items-center gap-3 bg-yellow-900/50 border border-yellow-500/30 rounded-lg p-3">
-              <svg class="w-6 h-6 text-yellow-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"></path></svg>
-              <div>
-                <div id="domain-mismatch-text" class="font-semibold text-yellow-300">ドメイン不一致</div>
-                <div class="text-xs text-yellow-400">アクセス制限あり</div>
-              </div>
-            </div>
-            <!-- 初期状態 -->
-            <div id="domain-initial-badge" class="flex items-center gap-3 bg-gray-800/50 border border-gray-700 rounded-lg p-3">
-              <div class="w-4 h-4 bg-blue-500 rounded-full animate-pulse"></div>
-              <div>
-                <div class="font-semibold text-gray-300">ドメイン確認中...</div>
-              </div>
-            </div>
-          </div>
-        </div>
 
         <!-- システム状況 -->
         <div class="glass-panel p-6">
@@ -1833,7 +1815,6 @@ elements = {
   setupProgressMobile: document.getElementById('setup-progress-mobile'),
   setupProgressText: document.getElementById('setup-progress-text'),
   setupProgressTextMobile: document.getElementById('setup-progress-text-mobile'),
-  headerDomainName: document.getElementById('header-domain-name'),
   headerStatusDot: document.getElementById('header-status-dot'),
   headerStatusText: document.getElementById('header-status-text'),
   configStatus: document.getElementById('config-status'),


### PR DESCRIPTION
## Summary
- move domain info section into the header next to status indicator
- remove the redundant domain info card from the right panel

## Testing
- `npm test` *(fails: Integration Test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876c7ac77e4832bb7e85e01d456f398