### PR TITLE
Fix domain check case sensitivity

### DIFF
--- a/src/AuthorizationService.gs
+++ b/src/AuthorizationService.gs
@@ -11,7 +11,11 @@ var AuthorizationService = (function() {
    * @returns {string} ドメイン部分
    */
   function getEmailDomain(email) {
-    return email.split('@')[1] || '';
+    if (!email) return '';
+    return String(email)
+      .split('@')[1]
+      .toLowerCase()
+      .trim() || '';
   }
 
   /**

--- a/src/config.gs
+++ b/src/config.gs
@@ -1341,7 +1341,7 @@ function enhancedDomainVerification(requestUserId) {
       email: activeUserEmail,
       userDomain: userDomain,
       systemAdminDomain: systemAdminDomain,
-      isSystemAdmin: activeUserEmail === adminEmail,
+      isSystemAdmin: String(activeUserEmail).toLowerCase() === String(adminEmail || '').toLowerCase(),
       isDomainMatch: userDomain === systemAdminDomain,
       isPersonalAccount: isPersonalGoogleAccount(activeUserEmail),
       isWorkspaceAccount: isWorkspaceAccount(activeUserEmail),
@@ -1441,8 +1441,11 @@ function resetUserAuthentication(requestUserId) {
  * @returns {string} アクセスレベル
  */
 function calculateAccessLevel(userEmail, adminEmail, userDomain, systemAdminDomain) {
+  const normalizedUserEmail = String(userEmail).toLowerCase();
+  const normalizedAdminEmail = String(adminEmail || '').toLowerCase();
+
   // システム管理者
-  if (userEmail === adminEmail) {
+  if (normalizedUserEmail === normalizedAdminEmail) {
     return 'SYSTEM_ADMIN';
   }
   


### PR DESCRIPTION
## Summary
- normalize email domains to lowercase when checking login domain
- compare emails case-insensitively in `enhancedDomainVerification`
- handle email comparison normalization in `calculateAccessLevel`

## Testing
- `npm test` *(fails: getServiceAccountTokenCached is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6876cbb96d44832b95ee849180a71a51