### PR TITLE
Fix AdminPanel layout and overlay visibility

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -404,14 +404,14 @@
   }
     
   main.flex-1 {
-    display: flex !important;
-    flex-direction: column !important;
-    align-items: stretch !important;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
   }
-  
+
   .left-panel {
-    flex: 1 !important;
-    min-height: 0 !important;
+    flex: 1;
+    min-height: 0;
   }
   
   /* Status Indicators */
@@ -517,9 +517,9 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
             </svg>
           </div>
-          <div class="hidden sm:block" style="display: block !important;">
-            <h1 class="text-xl sm:text-2xl font-bold text-white leading-tight" style="display: block !important; visibility: visible !important;">みんなの回答ボード 管理パネル</h1>
-            <p class="text-sm text-gray-400" style="display: block !important; visibility: visible !important;">StudyQuest</p>
+          <div class="hidden sm:block">
+            <h1 class="text-xl sm:text-2xl font-bold text-white leading-tight">みんなの回答ボード 管理パネル</h1>
+            <p class="text-sm text-gray-400">StudyQuest</p>
           </div>
           <div class="sm:hidden" style="display: none;">
             <h1 class="text-xl font-bold text-white">みんなの回答ボード</h1>
@@ -571,13 +571,13 @@
         </div>
     </div>
   </header>
-  <main class="flex-1 max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-8 min-h-0">
+  <main class="flex flex-col flex-1 max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-8 min-h-0">
     
 
     <!-- メインコンテンツエリア -->
     <div class="admin-responsive-grid">
       <!-- 左側：セットアップフロー（メインパネル） -->
-      <div class="left-panel space-y-6">
+      <div class="left-panel flex-1 min-h-0 space-y-6">
         
         <!-- ステップ1: データ準備 -->
         <div class="glass-panel backdrop-blur-lg p-6 transition-all duration-300 hover:shadow-xl" id="data-setup-section">
@@ -1016,7 +1016,7 @@
     </div>
   </main>
   
-  <footer id="admin-footer" class="fixed bottom-0 left-0 w-full z-40 hidden" style="display: none !important;">
+  <footer id="admin-footer" class="fixed bottom-0 left-0 w-full z-40 hidden">
     <div class="glass-panel rounded-none border-t border-gray-700/50 backdrop-blur-md">
       <div class="max-w-6xl mx-auto px-6 py-4">
         <div class="flex items-center justify-between">

--- a/src/ClientOptimizer.html
+++ b/src/ClientOptimizer.html
@@ -297,10 +297,15 @@ const loadingCSS = `
   right: 0;
   bottom: 0;
   background: rgba(0, 0, 0, 0.5);
-  display: flex;
   align-items: center;
   justify-content: center;
   z-index: 9999;
+}
+.loading-overlay.hidden {
+  display: none;
+}
+.loading-overlay:not(.hidden) {
+  display: flex;
 }
 
 .loading-content {

--- a/src/Page.html
+++ b/src/Page.html
@@ -305,10 +305,15 @@ header {
   right: 0;
   bottom: 0;
   background: rgba(26, 27, 38, 0.8);
-  display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
+}
+.loading-overlay.hidden {
+  display: none;
+}
+.loading-overlay:not(.hidden) {
+  display: flex;
 }
 .spinner {
   width: 40px;

--- a/src/UnifiedStyles.html
+++ b/src/UnifiedStyles.html
@@ -622,10 +622,15 @@ body.unified-theme::before {
   width: 100%;
   height: 100%;
   background: rgba(0,0,0,0.8);
-  display: flex;
   align-items: center;
   justify-content: center;
   z-index: var(--z-overlay);
+}
+.loading-overlay.hidden {
+  display: none;
+}
+.loading-overlay:not(.hidden) {
+  display: flex;
 }
 
 /* Glassmorphism Spinner System */


### PR DESCRIPTION
## Summary
- remove `!important` styles from AdminPanel
- ensure main and left panel use Tailwind classes instead
- adjust loading overlay CSS so `hidden` class works reliably

## Testing
- `npm test` *(fails: getServiceAccountTokenCached is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6876f4a84d1c832b8b68a136462b8041