### PR TITLE
Fix sharedUtilities re-initialization

### DIFF
--- a/src/SharedJavaScript.html
+++ b/src/SharedJavaScript.html
@@ -593,7 +593,8 @@ if (document.readyState === 'loading') {
 // =============================================================================
 
 // Export utilities to global scope for easy access
-window.sharedUtilities = {
+window.sharedUtilities = window.sharedUtilities || {};
+Object.assign(window.sharedUtilities, {
   message: {
     show: showMessage,
     showSimple: displaySimpleMessage
@@ -628,6 +629,6 @@ window.sharedUtilities = {
     copyToClipboard: copyToClipboard,
     formatDate: formatJapaneseDate
   }
-};
+});
 
 </script>


### PR DESCRIPTION
## Summary
- preserve existing properties when initializing `sharedUtilities`

## Testing
- `npm install`
- `npm test` *(fails: PropertiesService is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68771554c8e8832ba1fa18ab24c51d88