### PR TITLE
Fix callGAS to accept string names

### DIFF
--- a/src/SharedJavaScript.html
+++ b/src/SharedJavaScript.html
@@ -146,12 +146,15 @@ function callGAS(gasFunction, successCallback, errorCallback, args = [], context
         errorCallback(error, errorMessage);
       }
     });
-  
+
+  // Support both function objects and function names (string)
+  const functionName = typeof gasFunction === 'string' ? gasFunction : gasFunction.name;
+
   // Apply arguments to the function call
   if (args.length === 0) {
-    runner[gasFunction.name]();
+    runner[functionName]();
   } else {
-    runner[gasFunction.name].apply(runner, args);
+    runner[functionName].apply(runner, args);
   }
 }
 


### PR DESCRIPTION
## Summary
- update callGAS to handle function names passed as strings

## Testing
- `npm test` *(fails: userDuplicationPrevention.test.js et al.)*

------
https://chatgpt.com/codex/tasks/task_e_687731c8eb20832b9bf661dc4b06df5c