### PR TITLE
Fix GAS call context

### DIFF
--- a/src/SharedUtilities.html
+++ b/src/SharedUtilities.html
@@ -395,15 +395,15 @@ class GASUtilities {
           throw new Error(`GAS function ${functionName} is not available`);
         }
 
-        const gasFunction = google.script.run
+        const runner = google.script.run
           .withSuccessHandler(successHandler)
-          .withFailureHandler(failureHandler)
-          [functionName];
+          .withFailureHandler(failureHandler);
+        const gasFunction = runner[functionName];
 
         if (Array.isArray(args) && args.length > 0) {
-          gasFunction.apply(null, args);
+          gasFunction.apply(runner, args);
         } else {
-          gasFunction();
+          gasFunction.call(runner);
         }
       } catch (error) {
         console.error(`GAS call error for ${functionName}:`, error);


### PR DESCRIPTION
## Summary
- ensure GAS function calls use correct context
- run test suite

## Testing
- `npm test` *(fails: Script transformation errors and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68773b1460a8832bb96e955954b910c9