### PR TITLE
Fix layout spacing on App Setup screen

### DIFF
--- a/src/UnifiedStyles.html
+++ b/src/UnifiedStyles.html
@@ -224,7 +224,6 @@ body.unified-theme::before {
   position: relative;
   z-index: var(--z-raised);
   padding: var(--spacing-xl);
-  margin: 0;
   width: 100%;
   
   /* Interactive States */


### PR DESCRIPTION
## Summary
- remove default margin from `glass-panel` so per-element spacing works

## Testing
- `npm test` *(fails: All form creation scenario and others)*

------
https://chatgpt.com/codex/tasks/task_e_68774ec0b5ac832b8cace1779ba8e1df