### PR TITLE
Fix admin layout width and grid

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -188,8 +188,8 @@
       <p id="loading-message" class="mt-4 text-gray-300">処理中...</p>
     </div>
   </div>
-  <header class="glass-panel backdrop-blur-md border-b border-gray-700 sticky top-0 z-50">
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4">
+  <header class="glass-panel compact backdrop-blur-md border-b border-gray-700 sticky top-0 z-50">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 py-2 sm:py-3">
       <div class="flex items-center justify-between">
         <!-- ロゴとタイトル -->
         <div class="flex items-center gap-3">
@@ -252,7 +252,7 @@
         </div>
     </div>
   </header>
-  <main class="flex flex-col flex-1 max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-8 min-h-0">
+  <main class="flex flex-col flex-1 max-w-4xl mx-auto px-4 sm:px-6 py-4 sm:py-8 min-h-0">
     
 
     <!-- メインコンテンツエリア -->
@@ -699,7 +699,7 @@
   
   <footer id="admin-footer" class="fixed bottom-0 left-0 w-full z-40 hidden">
     <div class="glass-panel rounded-none border-t border-gray-700/50 backdrop-blur-md">
-      <div class="max-w-6xl mx-auto px-6 py-4">
+      <div class="max-w-4xl mx-auto px-6 py-4">
         <div class="flex items-center justify-between">
           <!-- 左側: 公開中のボード情報 -->
           <div class="flex-1 min-w-0">

--- a/src/UnifiedStyles.html
+++ b/src/UnifiedStyles.html
@@ -1944,7 +1944,7 @@ input[type="radio"]:disabled {
 }
 
 /* Tablet Portrait */
-@media (min-width: 768px) and (max-width: 1023px) {
+@media (min-width: 640px) and (max-width: 1023px) {
   .responsive-grid.two-column,
   .admin-responsive-grid,
   .page-responsive-grid {


### PR DESCRIPTION
## Summary
- tweak header, main, and footer widths
- make header compact
- adjust admin grid breakpoint for tablets

## Testing
- `npm install`
- `npm test` *(fails: SCRIPT_PROPS_KEYS is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68774fabe9e8832b9fc9c06089934d44