### PR TITLE
Fix header layout issue in AdminPanel

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -191,7 +191,7 @@
   </div>
   <header class="glass-panel compact backdrop-blur-md border-b border-gray-700 sticky top-0 z-50">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 py-2 sm:py-3">
-      <div class="flex items-center justify-between">
+      <div class="flex items-center justify-start gap-4 sm:gap-8">
         <!-- ロゴとタイトル -->
         <div class="flex items-center gap-3">
           <div class="w-8 h-8 bg-gradient-to-r from-cyan-400 to-purple-400 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -203,7 +203,7 @@
             <h1 class="text-xl sm:text-2xl font-bold text-white leading-tight">みんなの回答ボード 管理パネル</h1>
             <p class="text-sm text-gray-400">StudyQuest</p>
           </div>
-          <div class="sm:hidden" style="display: none;">
+          <div class="sm:hidden">
             <h1 class="text-xl font-bold text-white">みんなの回答ボード</h1>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- adjust header layout to avoid extra wide spacing
- remove inline style that hid the mobile title

## Testing
- `npm test --silent` *(fails: SyntaxError in userDuplicationPrevent...)

------
https://chatgpt.com/codex/tasks/task_e_6877982bd79c832ba45546faea0010b6