### PR TITLE
Remove hover color effect

### DIFF
--- a/src/UnifiedStyles.html
+++ b/src/UnifiedStyles.html
@@ -237,8 +237,7 @@ body.unified-theme::before {
 /* Glass Panel States */
 .unified-theme .glass-panel:hover,
 .glass-panel:hover {
-  background: var(--glass-bg-hover);
-  border-color: var(--border-hover);
+  /* Hover background and border removed for a static look */
   box-shadow: var(--glass-shadow-hover);
   transform: translateY(-1px);
 }


### PR DESCRIPTION
## Summary
- remove background color on hover for glass panels to keep sections static

## Testing
- `npm test` *(fails: SCRIPT_PROPS_KEYS is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6877a1480c70832b9b495f7acb7e2163