### PR TITLE
Fix admin panel layout columns

### DIFF
--- a/src/AdminPanelLogic.html
+++ b/src/AdminPanelLogic.html
@@ -815,7 +815,7 @@ function injectAdminLayoutFix() {
 body.admin-grid-layout .admin-responsive-grid,
 .admin-responsive-grid {
   display: grid !important;
-  grid-template-columns: 2fr 1fr !important;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) !important;
   gap: 2rem !important;
   align-items: start !important;
   max-width: 84rem !important;
@@ -951,7 +951,7 @@ function fixAdminPanelLayout() {
     adminGrid.classList.add('emergency-2col');
     adminGrid.style.cssText = `
       display: grid !important;
-      grid-template-columns: 2fr 1fr !important;
+      grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) !important;
       gap: 2rem !important;
       max-width: 84rem !important;
       margin: 0 auto !important;

--- a/src/PageSpecific/AdminPanel.styles.html
+++ b/src/PageSpecific/AdminPanel.styles.html
@@ -195,7 +195,7 @@
   body .admin-responsive-grid,
   html body .admin-responsive-grid {
     display: grid !important;
-    grid-template-columns: 2fr 1fr !important;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) !important;
     gap: var(--spacing-xl) !important;
     align-items: start !important;
     max-width: 84rem !important;
@@ -210,7 +210,7 @@
   [class*="grid"].admin-responsive-grid,
   [class*="flex"].admin-responsive-grid {
     display: grid !important;
-    grid-template-columns: 2fr 1fr !important;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) !important;
   }
 
   /* レスポンシブ対応：画面幅が1024px以下で1カラムに */

--- a/src/TailwindConfig.html
+++ b/src/TailwindConfig.html
@@ -252,7 +252,7 @@ window.unifiedLayoutSystem = {
 body.admin-grid-layout .admin-responsive-grid,
 .admin-responsive-grid {
   display: grid !important;
-  grid-template-columns: 2fr 1fr !important;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) !important;
   gap: 2rem !important;
   align-items: start !important;
   max-width: 84rem !important;
@@ -332,7 +332,7 @@ body.iframe-environment .admin-responsive-grid {
 body.admin-grid-layout .tailwind-override-protection .admin-responsive-grid,
 html body.admin-grid-layout .tailwind-override-protection .admin-responsive-grid {
   display: grid !important;
-  grid-template-columns: 2fr 1fr !important;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) !important;
   gap: 2rem !important;
   width: 100% !important;
   box-sizing: border-box !important;
@@ -343,7 +343,7 @@ html body.admin-grid-layout .tailwind-override-protection .admin-responsive-grid
 body .admin-responsive-grid.emergency-2col,
 html body .admin-responsive-grid.emergency-2col {
   display: grid !important;
-  grid-template-columns: 2fr 1fr !important;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) !important;
   gap: 2rem !important;
   align-items: start !important;
   max-width: 84rem !important;
@@ -387,7 +387,7 @@ html body .admin-responsive-grid.emergency-2col .right-panel {
 body.iframe-environment .iframe-force-admin-grid,
 html body.iframe-environment .iframe-force-admin-grid {
   display: grid !important;
-  grid-template-columns: 2fr 1fr !important;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) !important;
   gap: 2rem !important;
   contain: layout style paint !important;
   isolation: isolate !important;
@@ -516,6 +516,7 @@ html body.iframe-environment .iframe-force-admin-grid {
     
     // 様々な2fr 1frの形式を検証
     const validPatterns = [
+      /minmax\(0(?:px)?,\s*2fr\)\s+minmax\(0(?:px)?,\s*1fr\)/,
       /2fr\s+1fr/,
       /2fr 1fr/,
       /(.*)\s*2fr\s+(.*)\s*1fr.*/,
@@ -576,7 +577,7 @@ html body.iframe-environment .iframe-force-admin-grid {
     
     // CSS変数を直接設定
     adminGrid.style.setProperty('display', 'grid', 'important');
-    adminGrid.style.setProperty('grid-template-columns', '2fr 1fr', 'important');
+    adminGrid.style.setProperty('grid-template-columns', 'minmax(0, 2fr) minmax(0, 1fr)', 'important');
     adminGrid.style.setProperty('gap', '2rem', 'important');
     adminGrid.style.setProperty('align-items', 'start', 'important');
     adminGrid.style.setProperty('max-width', '84rem', 'important');

--- a/src/UnifiedStyles.html
+++ b/src/UnifiedStyles.html
@@ -2077,7 +2077,7 @@ input[type="radio"]:disabled {
 
 @media (min-width: 1024px) {
   .page-grid {
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
     gap: 2rem;
     padding: 2rem;
   }


### PR DESCRIPTION
## Summary
- keep grid columns from collapsing by using `minmax(0, …)`
- update layout validation to accept the new format

## Testing
- `npm test` *(fails: SCRIPT_PROPS_KEYS is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687824089b58832b89b4f666775fc1bd