### PR TITLE
Redirect exec to login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ sequenceDiagram
 ### 4.1. 画面一覧
 
   * **`SetupPage.html`**: 初回システムセットアップ画面。
-  * **`Registration.html`**: 新規ユーザー登録画面。
+  * **`Login.html`**: ログイン画面。
   * **`AdminPanel.html`**: 教師向けの管理画面。
   * **`Page.html`**: 生徒や一般閲覧者向けのメインの回答ボード画面。
 
@@ -183,10 +183,10 @@ sequenceDiagram
     1.  **サーバー**: `doGet(e)` は `PropertiesService` にシステム設定がないことを確認し、`SetupPage.html` を返す。
     2.  **クライアント**: 管理者が情報を入力し、`google.script.run.setupApplication()` を実行。
 
-  * **フロー2: 新規ユーザー登録 (`Registration.html`)**
+  * **フロー2: ログイン (`Login.html`)**
 
-    1.  **サーバー**: `doGet(e)` はユーザーが中央DBに未登録と判断し、`Registration.html` を返す。
-    2.  **クライアント**: `google.script.run.getExistingBoard()` を実行し未登録を確認後、`registerNewUser()` を実行。
+    1.  **サーバー**: `/exec` へのアクセス時は必ず `Login.html` を返す。
+    2.  **クライアント**: `google.script.run.getExistingBoard()` を実行し、登録済みの場合は管理パネルURLへリダイレクトする。
     3.  **キャッシュ**: `getExistingBoard` はサーバーサイドでユーザー情報をキャッシュし、DBへの不要なアクセスを削減。
 
   * **フロー3: 管理画面 (`AdminPanel.html`)**

--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -221,10 +221,10 @@
         
         <!-- ドメイン・ステータス情報 -->
         <div class="flex items-center gap-2 sm:gap-3">
-          <!-- ドメイン情報（Registration.htmlスタイル） -->
+          <!-- ドメイン情報（Login.htmlスタイル） -->
           <div id="header-domain-info">
             <!-- ドメイン一致表示（緑色パネル） -->
-            <!-- ドメイン一致表示（Registration.htmlスタイル） -->
+            <!-- ドメイン一致表示（Login.htmlスタイル） -->
             <div id="header-domain-match" class="glass-panel bg-gradient-to-r from-green-500/10 to-emerald-500/10 rounded-lg p-3 border border-green-400/30 hidden">
               <div class="flex items-center gap-2">
                 <svg class="w-5 h-5 text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -237,7 +237,7 @@
               </div>
             </div>
             
-            <!-- ドメイン不一致表示（Registration.htmlスタイル） -->
+            <!-- ドメイン不一致表示（Login.htmlスタイル） -->
             <div id="header-domain-mismatch" class="glass-panel bg-gradient-to-r from-yellow-500/10 to-orange-500/10 rounded-lg p-3 border border-yellow-400/30 hidden">
               <div class="flex items-center gap-2">
                 <svg class="w-5 h-5 text-yellow-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1790,7 +1790,7 @@ elements = {
       }, 1000);
     });
     // ===== 共通ドメイン情報処理関数 =====
-    // AdminPanel.html と Registration.html で共通使用
+    // AdminPanel.html と Login.html で共通使用
     
     /**
      * ドメイン情報を取得して表示する共通関数
@@ -2162,7 +2162,7 @@ function handleDeleteRequest() {
             setLoading(false);
             showMessage(response, 'success');
             setTimeout(function() {
-              window.top.location.href = '?page=Registration';
+              window.top.location.href = '?page=Login';
             }, 2000);
           })
           .catch(function(error) {

--- a/src/Login.html
+++ b/src/Login.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <base target="_top">
-  <title>StudyQuest - 新規ユーザー登録</title>
+  <title>StudyQuest - ログイン</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- TailwindCSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -21,7 +21,7 @@
     <div class="glass-panel rounded-xl p-6 sm:p-8 max-w-4xl mx-auto shadow-2xl">
     <div class="text-center mb-6">
       <h1 class="text-4xl sm:text-5xl font-bold bg-gradient-to-r from-yellow-400 to-amber-400 bg-clip-text text-transparent mb-3 text-glow">StudyQuest -みんなの回答ボード-</h1>
-      <p class="text-lg text-gray-400">新規ユーザー登録</p>
+      <p class="text-lg text-gray-400">ログイン</p>
     </div>
     
     <!-- ドメイン情報表示 -->

--- a/src/Page.html
+++ b/src/Page.html
@@ -3813,7 +3813,7 @@ async handleReaction(rowIndex, reaction) {
   // Enhanced cache methods with timestamp tracking
 }
 // ===== 共通ドメイン情報処理関数 =====
-// AdminPanel.html と Registration.html で共通使用
+// AdminPanel.html と Login.html で共通使用
 
 /**
  * ドメイン情報を取得して表示する共通関数

--- a/src/UnifiedStyles.html
+++ b/src/UnifiedStyles.html
@@ -351,7 +351,7 @@ body {
   transform: translateY(-1px);
 }
 
-/* Step Indicator System (from Registration.html) */
+/* Step Indicator System (from Login.html) */
 .step-indicator {
   display: flex;
   align-items: center;

--- a/src/config.gs
+++ b/src/config.gs
@@ -1184,7 +1184,7 @@ function createBoardFromAdmin(requestUserId) {
 
 /**
  * 既存ボード情報を取得 (マルチテナント対応版)
- * Registration.htmlから呼び出される
+ * Login.htmlから呼び出される
  * @param {string} requestUserId - リクエスト元のユーザーID
  */
 function getExistingBoard(requestUserId) {
@@ -1222,7 +1222,7 @@ function getExistingBoard(requestUserId) {
 
 /**
  * ユーザー認証を検証 (マルチテナント対応版)
- * Registration.htmlから呼び出される
+ * Login.htmlから呼び出される
  * @param {string} requestUserId - リクエスト元のユーザーID
  */
 function verifyUserAuthentication(requestUserId) {

--- a/src/main.gs
+++ b/src/main.gs
@@ -187,7 +187,7 @@ function debugLog() {
 
 /**
  * デプロイされたWebアプリのドメイン情報と現在のユーザーのドメイン情報を取得
- * AdminPanel.html と Registration.html から共通で呼び出される
+ * AdminPanel.html と Login.html から共通で呼び出される
  */
 function getDeployUserDomainInfo() {
   try {
@@ -262,10 +262,10 @@ function isSystemSetup() {
  * 登録ページを表示する関数
  */
 function showRegistrationPage() {
-  var template = HtmlService.createTemplateFromFile('Registration');
+  var template = HtmlService.createTemplateFromFile('Login');
   template.include = include;
   var output = template.evaluate()
-    .setTitle('新規ユーザー登録 - StudyQuest');
+    .setTitle('ログイン - StudyQuest');
   return safeSetXFrameOptionsDeny(output);
 }
 
@@ -378,27 +378,8 @@ function handleDirectExecAccess(userEmail) {
       return safeSetXFrameOptionsDeny(t.evaluate().setTitle('初回セットアップ - StudyQuest'));
     }
     
-    if (!userEmail) {
-      return showRegistrationPage();
-    }
-    
-    // サービスアカウント経由でユーザーがデータベースに登録されているかチェック
-    const userInfo = findUserByEmail(userEmail);
-    console.log('handleDirectExecAccess - userInfo:', userInfo);
-    console.log('handleDirectExecAccess - userEmail:', userEmail);
-    
-    if (userInfo && userInfo.userId) {
-      // 登録済みユーザー: 管理パネルに自動遷移（リダイレクトではなく直接遷移）
-      console.log('handleDirectExecAccess - Found user, transitioning to admin panel for userId:', userInfo.userId);
-      
-      // ここで直接管理パネルを表示する（リダイレクトしない）
-      return renderAdminPanel(userInfo, 'admin');
-    } else {
-      // 未登録ユーザー: 新規登録画面表示
-      console.log('handleDirectExecAccess - Unregistered user, showing registration page');
-      debugLog('Unregistered user, showing registration page');
-      return showRegistrationPage();
-    }
+    // /execアクセス時は常にログインページを表示し、ページ側でリダイレクト処理を行う
+    return showRegistrationPage();
   } catch (error) {
     console.error('handleDirectExecAccess error:', error);
     return showRegistrationPage();


### PR DESCRIPTION
## Summary
- rename registration page to `Login.html`
- update docs with login flow
- adjust server logic to always show login page when accessing `/exec`
- clean up references to new login page

## Testing
- `npm test` *(fails: getDeployUserDomainInfo is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687876a852a0832b863c92ed6d4fda92