### PR TITLE
Add cache clear and redirect on account deletion

### DIFF
--- a/src/adminPanel-events.js.html
+++ b/src/adminPanel-events.js.html
@@ -347,11 +347,23 @@ function handleDeleteRequest() {
       runGasWithUserId('deleteCurrentUserAccount')
         .then(function(response) {
           setLoading(false);
-          showMessage(response, 'success');
-          // Redirect to login or show confirmation
+          showMessage(response.message || 'アカウントが削除されました', 'success');
+          if (window.unifiedCache && typeof window.unifiedCache.clear === 'function') {
+            window.unifiedCache.clear();
+          }
+          if (window.gasOptimizer && typeof window.gasOptimizer.clearCache === 'function') {
+            window.gasOptimizer.clearCache();
+          }
+          if (window.localStorage) {
+            window.localStorage.clear();
+          }
           setTimeout(function() {
-            window.location.reload();
-          }, 3000);
+            runGasWithUserId('getWebAppUrl').then(function(webAppUrl) {
+              window.location.href = '/login';
+            }).catch(function() {
+              window.location.href = '/login';
+            });
+          }, 2000);
         })
         .catch(function(error) {
           setLoading(false);

--- a/src/adminPanel.js.html
+++ b/src/adminPanel.js.html
@@ -508,12 +508,20 @@
     if (typeof runGasWithUserId === 'function') {
       runGasWithUserId('deleteCurrentUserAccount')
         .then(result => {
-          if (result.success) {
+          if (result.status === 'success' || result.success) {
             showMessage('アカウントが削除されました', 'success');
+            if (window.unifiedCache && typeof window.unifiedCache.clear === 'function') {
+              window.unifiedCache.clear();
+            }
+            if (window.gasOptimizer && typeof window.gasOptimizer.clearCache === 'function') {
+              window.gasOptimizer.clearCache();
+            }
+            if (window.localStorage) {
+              window.localStorage.clear();
+            }
             setTimeout(() => {
-              // Use the unified URL function from backend for redirect
               runGasWithUserId('getWebAppUrl').then(webAppUrl => {
-                window.location.href = webAppUrl;
+                window.location.href = '/login';
               }).catch(error => {
                 console.error('Failed to get web app URL:', error);
                 window.location.href = '/login';


### PR DESCRIPTION
## Summary
- clear frontend caches on account deletion
- redirect users to the login screen after deleting their account

## Testing
- `npm test` *(fails: getWebAppUrlCached upgrade, generateAppUrls)*

------
https://chatgpt.com/codex/tasks/task_e_687b157bcc1c832ba0c725da9f9290c8