### PR TITLE
Fix missing service error in getSheetsList

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -2715,7 +2715,20 @@ function getSheetsList(userId) {
       spreadsheetUrl: userInfo.spreadsheetUrl
     });
     
-    if (!userInfo.spreadsheetId) {      console.warn('getSheetsList: No spreadsheet ID for user:', userId);      return [];    }    debugLog('getSheetsList: User\'s spreadsheetId:', userInfo.spreadsheetId); // Added debug log    var service = getSheetsService();    debugLog('getSheetsList: SheetsService obtained, attempting to fetch spreadsheet data...');
+    if (!userInfo.spreadsheetId) {
+      console.warn('getSheetsList: No spreadsheet ID for user:', userId);
+      return [];
+    }
+
+    debugLog('getSheetsList: User\'s spreadsheetId:', userInfo.spreadsheetId);
+
+    var service = getSheetsService();
+    if (!service) {
+      console.error('getSheetsList: Sheets service not initialized');
+      return { error: true, message: 'Sheets service initialization failed' };
+    }
+
+    debugLog('getSheetsList: SheetsService obtained, attempting to fetch spreadsheet data...');
     
     var spreadsheet;
     try {


### PR DESCRIPTION
## Summary
- handle missing service object in `getSheetsList`

## Testing
- `npm test` *(fails: getOpinionHeaderSafely, getWebAppUrlCached, generateAppUrls)*

------
https://chatgpt.com/codex/tasks/task_e_687b6bc86924832b83cca78c06bdfca4