### PR TITLE
Fix viewer access for published boards

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -255,8 +255,13 @@ function verifyUserAccess(requestUserId) {
     throw new Error(`認証エラー: 指定されたユーザーID (${requestUserId}) が見つかりません。`);
   }
 
-  // リクエストユーザーのメールアドレスと、要求されたユーザーIDのadminEmailが一致するか検証
+  // 管理者かどうかを確認
   if (activeUserEmail !== requestedUserInfo.adminEmail) {
+    const config = JSON.parse(requestedUserInfo.configJson || '{}');
+    if (config.appPublished === true) {
+      debugLog(`✅ 公開ボード閲覧許可: ${activeUserEmail} -> ${requestUserId}`);
+      return;
+    }
     throw new Error(`権限エラー: ${activeUserEmail} はユーザーID ${requestUserId} のデータにアクセスする権限がありません。`);
   }
   debugLog(`✅ ユーザーアクセス検証成功: ${activeUserEmail} は ${requestUserId} のデータにアクセスできます。`);

--- a/src/Page.html
+++ b/src/Page.html
@@ -2000,8 +2000,10 @@ setupEventDelegation() {
       this.startPolling();
     });
     
-    // Load sheets in background
-    this.loadAvailableSheets();
+    // Load sheets in background only for administrators
+    if (this.state.isAdminUser) {
+      this.loadAvailableSheets();
+    }
   }
   
   showMinimalSkeleton() {


### PR DESCRIPTION
## Summary
- relax server-side user verification to allow access when a board is published
- skip `getAvailableSheets` call for non-admin users

## Testing
- `npm test` *(fails: generateAppUrls.test.js, getWebAppUrlCached.test.js, coreFunctions.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_687c03c5adec832b839d528e3d604dc7