### PR TITLE
Fix header offset & grid layout

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -226,8 +226,8 @@
       <p id="loading-message" class="mt-4 text-gray-300">処理中...</p>
     </div>
   </div>
-  <header class="glass-panel border-b border-gray-700 fixed top-4 sm:top-6 left-2 right-2 sm:left-4 sm:right-4 z-50 rounded-lg sm:rounded-xl shadow-lg h-16 sm:h-20">
-  <div class="relative -top-4 sm:-top-6 max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-5 flex items-center justify-between gap-4">
+  <header class="glass-panel border-b border-gray-700 fixed top-1 sm:top-2 left-2 right-2 sm:left-4 sm:right-4 z-50 rounded-lg sm:rounded-xl shadow-lg h-16 sm:h-20">
+  <div class="relative -top-1 sm:-top-2 max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-5 flex items-center justify-between gap-4">
         <!-- ロゴとタイトル -->
         <div class="flex items-center gap-3 flex-shrink-0">
           <div class="w-8 h-8 bg-gradient-to-r from-cyan-400 to-purple-400 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -296,10 +296,10 @@
               pb-16 sm:pb-20
               h-screen overflow-y-auto">
     <!-- メインコンテンツ：ステータスバー＋左右パネル -->
-    <div class="responsive-grid space-y-4">
+    <div class="responsive-grid grid grid-cols-1 lg:grid-cols-3 gap-4">
 
     <!-- シンプル統合ステータスバー -->
-    <section class="mb-0">
+    <section class="col-span-1 lg:col-span-3">
       <div class="glass-panel p-4 rounded-lg">
         <div class="flex items-center justify-between">
           <!-- 左側: ステータス表示 -->
@@ -337,7 +337,6 @@
     </section>
 
     <!-- 左右パネル -->
-    <div class="grid grid-cols-1 lg:grid-cols-3 lg:gap-x-6">
       <div class="left-panel col-span-2 space-y-2">
         
         <!-- ステップ1: データソース設定 -->
@@ -933,7 +932,6 @@
       </details>
       </div>
     </div>
-  </div>
   </main>
   
   <!-- 統合フッター -->


### PR DESCRIPTION
## Summary
- tweak header offset
- switch admin layout to grid for proper status/side panels

## Testing
- `npm test` *(fails: getWebAppUrlCached and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c1c4090e8832bbaa6fdf4ba9355cb