### PR TITLE
Fix admin header height

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -226,7 +226,7 @@
       <p id="loading-message" class="mt-4 text-gray-300">処理中...</p>
     </div>
   </div>
-  <header class="glass-panel border-b border-gray-700 fixed top-1 sm:top-2 left-2 right-2 sm:left-4 sm:right-4 z-50 rounded-lg sm:rounded-xl shadow-lg h-16 sm:h-20">
+  <header id="admin-header" class="glass-panel border-b border-gray-700 fixed top-1 sm:top-2 left-2 right-2 sm:left-4 sm:right-4 z-50 rounded-lg sm:rounded-xl shadow-lg">
   <div class="relative -top-1 sm:-top-2 max-w-6xl mx-auto px-4 sm:px-6 py-4 sm:py-5 flex items-center justify-between gap-4">
         <!-- ロゴとタイトル -->
         <div class="flex items-center gap-3 flex-shrink-0">
@@ -291,7 +291,7 @@
         </div>
     </div>
   </header>
-  <main class="flex-1 max-w-6xl mx-auto px-4 sm:px-6
+  <main id="admin-main" class="flex-1 max-w-6xl mx-auto px-4 sm:px-6
               pt-16 sm:pt-20
               pb-16 sm:pb-20
               h-screen overflow-y-auto">

--- a/src/adminPanel-layout.css.html
+++ b/src/adminPanel-layout.css.html
@@ -65,4 +65,20 @@ main.flex-1 {
   flex: 1;
   min-height: 0;
 }
+
+/* Adjust fixed header and main padding for extra height */
+#admin-header {
+  height: calc(4rem + 1mm);
+}
+#admin-main {
+  padding-top: calc(4rem + 1mm);
+}
+@media (min-width: 640px) {
+  #admin-header {
+    height: calc(5rem + 1mm);
+  }
+  #admin-main {
+    padding-top: calc(5rem + 1mm);
+  }
+}
 </style>


### PR DESCRIPTION
## Summary
- add `admin-header` and `admin-main` elements
- enlarge fixed header by 1mm
- keep content padding aligned

## Testing
- `npm test` *(fails: getWebAppUrlCached and coreFunctions tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c1f155638832b81c5e826a1c0345a