### PR TITLE
Expose nested sheet headers in getInitialData

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -4231,6 +4231,17 @@ function getInitialData(requestUserId, targetSheetName) {
     
     // === ステップ5: セットアップステップの決定 ===
     var setupStep = determineSetupStep(userInfo, configJson);
+
+    // 公開シート設定とヘッダー情報を取得
+    var publishedSheetName = configJson.publishedSheetName || '';
+    var sheetConfigKey = publishedSheetName ? 'sheet_' + publishedSheetName : '';
+    var activeSheetConfig = sheetConfigKey && configJson[sheetConfigKey]
+      ? configJson[sheetConfigKey]
+      : {};
+
+    var opinionHeader = activeSheetConfig.opinionHeader || '';
+    var nameHeader = activeSheetConfig.nameHeader || '';
+    var classHeader = activeSheetConfig.classHeader || '';
     
     // === ベース応答の構築 ===
     var response = {
@@ -4252,6 +4263,17 @@ function getInitialData(requestUserId, targetSheetName) {
       isPublished: !!configJson.appPublished,
       answerCount: answerCount,
       totalReactions: totalReactions,
+      config: {
+        publishedSheetName: publishedSheetName,
+        opinionHeader: opinionHeader,
+        nameHeader: nameHeader,
+        classHeader: classHeader,
+        showNames: configJson.showNames || false,
+        showCounts: configJson.showCounts !== undefined ? configJson.showCounts : true,
+        displayMode: configJson.displayMode || 'anonymous',
+        setupStatus: configJson.setupStatus || 'initial',
+        isPublished: !!configJson.appPublished,
+      },
       // シート情報
       allSheets: sheets,
       sheetNames: sheets,

--- a/src/url.gs
+++ b/src/url.gs
@@ -67,7 +67,9 @@ function getWebAppUrlCached() {
     
     if (cachedUrl) {
       // キャッシュされたURLが開発URLでないか検証
-      if (!cachedUrl.includes('googleusercontent.com') && !cachedUrl.includes('userCodeAppPanel')) {
+      if (!cachedUrl.includes('googleusercontent.com') &&
+          !cachedUrl.includes('userCodeAppPanel') &&
+          !cachedUrl.endsWith('/dev')) {
         console.log('Valid cached URL found: ' + cachedUrl);
         return cachedUrl;
       } else {

--- a/tests/getInitialDataHeaders.test.js
+++ b/tests/getInitialDataHeaders.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('getInitialData header extraction', () => {
+  const coreCode = fs.readFileSync('src/Core.gs', 'utf8');
+  const mainCode = fs.readFileSync('src/main.gs', 'utf8');
+  let context;
+
+  beforeEach(() => {
+    context = {
+      debugLog: () => {},
+      console,
+      PropertiesService: {
+        getScriptProperties: () => ({ getProperty: () => null }),
+      },
+      CacheService: {
+        getUserCache: () => ({ get: () => null, put: () => {} }),
+      },
+      Session: { getActiveUser: () => ({ getEmail: () => 'test@example.com' }) },
+      Utilities: { getUuid: () => 'uid', computeDigest: () => [], Charset: { UTF_8: 'UTF-8' } },
+    };
+    vm.createContext(context);
+    vm.runInContext(mainCode, context);
+    vm.runInContext(coreCode, context);
+
+    Object.assign(context, {
+      verifyUserAccess: jest.fn(),
+      getCachedUserInfo: jest.fn(() => ({
+        userId: 'U',
+        adminEmail: 'test@example.com',
+        spreadsheetId: '',
+        spreadsheetUrl: '',
+        configJson: JSON.stringify({
+          publishedSheetName: 'ClassA',
+          sheet_ClassA: {
+            opinionHeader: 'テーマ',
+            nameHeader: '氏名',
+            classHeader: 'クラス',
+          },
+        }),
+      })),
+      getSheetsList: jest.fn(() => []),
+      generateAppUrls: jest.fn(() => ({ webApp: 'web', adminUrl: 'admin', viewUrl: 'view' })),
+      getResponsesData: jest.fn(() => ({ status: 'success', data: [] })),
+      determineSetupStep: jest.fn(() => 3),
+    });
+  });
+
+  test('returns headers from nested sheet config', () => {
+    const res = context.getInitialData('U');
+    expect(res.config.opinionHeader).toBe('テーマ');
+    expect(res.config.nameHeader).toBe('氏名');
+    expect(res.config.classHeader).toBe('クラス');
+  });
+});


### PR DESCRIPTION
## Summary
- return sheet-specific header settings from `getInitialData`
- treat cached `/dev` URLs as invalid
- adjust URL helper tests to load `url.gs`
- add regression test for header extraction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c6268ea24832ba23ede75cb37c528