### PR TITLE
Fix modal positioning and message offset

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -965,7 +965,7 @@
       </div>
     </div>
   </footer>
-  <div id="message-area" class="fixed top-20 right-6 z-50" aria-live="polite" role="status"></div>
+  <div id="message-area" class="fixed top-24 right-6 z-50" aria-live="polite" role="status"></div>
   
   <!-- 共通モーダルコンポーネントを読み込み -->
   <?!= include('SharedModals'); ?>

--- a/src/SharedModals.html
+++ b/src/SharedModals.html
@@ -2,7 +2,7 @@
 <!-- GAS include用のモーダルコンポーネント集 -->
 
 <!-- 確認モーダル -->
-<div id="confirmation-modal" class="fixed inset-0 bg-black/80 z-[60] hidden items-center justify-center" role="dialog" aria-modal="true">
+<div id="confirmation-modal" class="fixed inset-0 bg-black/80 z-[60] hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="glass-panel rounded-xl p-6 max-w-md w-full mx-4">
     <h3 id="modal-title" class="text-xl font-bold text-cyan-400 mb-4"></h3>
     <p id="modal-message" class="text-gray-300 mb-6"></p>
@@ -14,7 +14,7 @@
 </div>
 
 <!-- 公開モーダル -->
-<div id="publish-modal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="publish-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-md w-full">
       <h3 class="text-xl font-bold text-cyan-400 mb-4">
@@ -41,7 +41,7 @@
 </div>
 
 <!-- プライバシーモーダル -->
-<div id="privacy-modal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="privacy-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-lg w-full">
       <div class="flex items-center gap-3 mb-4">
@@ -71,7 +71,7 @@
 </div>
 
 <!-- デジタルシティズンシップモーダル -->
-<div id="digital-citizenship-modal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="digital-citizenship-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-6">
@@ -123,7 +123,7 @@
 </div>
 
 <!-- 教師ガイドモーダル -->
-<div id="teacherGuideModal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="teacherGuideModal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-4xl w-full max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-6">
@@ -160,7 +160,7 @@
 </div>
 
 <!-- 汎用アラートモーダル -->
-<div id="alert-modal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="alert-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-md w-full">
       <div class="flex items-center gap-3 mb-4">
@@ -178,7 +178,7 @@
 </div>
 
 <!-- ローディングモーダル -->
-<div id="loading-modal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="loading-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-md w-full text-center">
       <div class="spinner mx-auto mb-4"></div>
@@ -192,7 +192,7 @@
 </div>
 
 <!-- セキュリティモーダル -->
-<div id="security-modal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="security-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-6">
@@ -241,7 +241,7 @@
 <!-- 管理者用モーダル (AdminPanel専用) -->
 
 <!-- フォーム設定モーダル -->
-<div id="form-config-modal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="form-config-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto">
       <div class="p-8">
@@ -366,7 +366,7 @@
 </div>
 
 <!-- セキュリティ詳細モーダル -->
-<div id="security-details-modal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="security-details-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
       <div class="flex justify-between items-center p-6 border-b border-gray-600/30">
@@ -491,7 +491,7 @@
 </div>
 
 <!-- Google連携の利点モーダル -->
-<div id="google-integration-modal" class="fixed inset-0 bg-black/80 z-50 hidden" role="dialog" aria-modal="true">
+<div id="google-integration-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
       <div class="flex justify-between items-center p-6 border-b border-gray-600/30">


### PR DESCRIPTION
## Summary
- adjust the admin panel message area so notifications appear below the header
- ensure all admin panel modals are centered using flexbox

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c7d6a11c0832ba8b077ab8e42726c