### PR TITLE
Fix footer question text for published boards

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -4280,7 +4280,7 @@ function getInitialData(requestUserId, targetSheetName) {
       // カスタムフォーム情報
       customFormInfo: configJson.formUrl ? {
         title: configJson.formTitle || 'カスタムフォーム',
-        mainQuestion: configJson.publishedSheetName || '質問',
+        mainQuestion: opinionHeader || configJson.publishedSheetName || '質問',
         formUrl: configJson.formUrl
       } : null,
       // メタ情報


### PR DESCRIPTION
## Summary
- ensure `getInitialData` returns the opinion header as the main question for custom forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c834d9ebc832ba6a8cfd7f1efebc4