### PR TITLE
Fix app setup routing and login link

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -784,9 +784,9 @@
             <span class="text-white font-mono text-xs bg-gray-700 px-1.5 py-0.5 rounded" id="info-user-id">-</span>
           </div>
           <div class="text-right pt-2">
-            <a href="/" class="text-cyan-400 hover:text-cyan-300 hover:underline text-xs">
-              ログイン画面に戻る
-            </a>
+          <a href="<?= getWebAppUrl(); ?>" class="text-cyan-400 hover:text-cyan-300 hover:underline text-xs">
+            ログイン画面に戻る
+          </a>
           </div>
         </div>
       </div>

--- a/src/main.gs
+++ b/src/main.gs
@@ -417,12 +417,17 @@ function doGet(e) {
     const params = parseRequestParams(e);
 
     // 3. ログイン状態の確認
-    const userEmail = Session.getActiveUser().getEmail();
-    if (!userEmail) {
-      return showLoginPage();
-    }
+  const userEmail = Session.getActiveUser().getEmail();
+  if (!userEmail) {
+    return showLoginPage();
+  }
 
-    // 4. パラメータ検証とデフォルト処理
+  // 4. アプリ設定ページリクエストの処理
+  if (params.setupParam === 'true') {
+    return showAppSetupPage();
+  }
+
+  // 5. パラメータ検証とデフォルト処理
     if (!params || !params.mode) {
       // パラメータなしまたは不正な場合はログインページを表示
       console.log('No mode parameter, showing login page');


### PR DESCRIPTION
## Summary
- correctly link back to the web app from the admin panel
- allow `doGet` to show the AppSetup page when `setup=true` is supplied

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c871cb1d4832baa52ae2a247d1f35