### PR TITLE
Fix fresh count retrieval

### DIFF
--- a/tests/getDataCount.test.js
+++ b/tests/getDataCount.test.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('getDataCount reflects new rows', () => {
+  const coreCode = fs.readFileSync('src/Core.gs', 'utf8');
+  const mainCode = fs.readFileSync('src/main.gs', 'utf8');
+  let context;
+  let sheetData;
+
+  beforeEach(() => {
+    sheetData = [
+      ['Timestamp', 'クラス'],
+      ['2024-01-01', 'A'],
+    ];
+    const sheet = {
+      getLastRow: () => sheetData.length,
+      getRange: (row, col, numRows, numCols) => ({
+        getValues: () => sheetData
+          .slice(row - 1, row - 1 + numRows)
+          .map(r => r.slice(col - 1, col - 1 + numCols)),
+      }),
+    };
+    context = {
+      console,
+      debugLog: () => {},
+      cacheManager: {
+        store: {},
+        get(key, fn) { return this.store.hasOwnProperty(key) ? this.store[key] : (this.store[key] = fn()); },
+        remove(key) { delete this.store[key]; },
+      },
+      PropertiesService: {
+        getScriptProperties: () => ({
+          getProperty: () => null,
+        }),
+      },
+      Session: { getActiveUser: () => ({ getEmail: () => 'user@example.com' }) },
+      SpreadsheetApp: {
+        openById: () => ({ getSheetByName: () => sheet }),
+      },
+      verifyUserAccess: jest.fn(),
+      findUserById: jest.fn(() => ({
+        userId: 'U1',
+        configJson: JSON.stringify({
+          publishedSpreadsheetId: 'SID',
+          publishedSheetName: 'Sheet1',
+        }),
+      })),
+      getHeaderIndices: () => ({ クラス: 1 }),
+      COLUMN_HEADERS: { CLASS: 'クラス' },
+    };
+    vm.createContext(context);
+    vm.runInContext(mainCode, context);
+    vm.runInContext(coreCode, context);
+    context.verifyUserAccess = jest.fn();
+  });
+
+  test('returns updated count after adding row', () => {
+    const first = context.getDataCount('U1', 'すべて', 'newest', false);
+    expect(first.count).toBe(1);
+    sheetData.push(['2024-01-02', 'A']);
+    context.cacheManager.remove('rowCount_SID_Sheet1_すべて');
+    const second = context.getDataCount('U1', 'すべて', 'newest', false);
+    expect(second.count).toBe(2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add lightweight countSheetRows helper
- revise getDataCount to use the new helper and reduce caching delay
- add unit test verifying fresh counts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c929ea594832bb2c349b5ac687947