### PR TITLE
Fix admin links and account deletion

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -872,6 +872,7 @@
       </div>
       
       <!-- アプリ設定リンク -->
+<? if (isDeployUser) { ?>
       <div id="app-setup-link" class="bg-blue-900/10 border border-blue-500/30 rounded-lg p-3 transition-all hover:border-blue-500/50">
         <button type="button" onclick="openAppSetupPage()" class="w-full flex items-center justify-between text-sm font-medium text-blue-300 hover:text-blue-200 transition-colors">
           <div class="flex items-center">
@@ -889,6 +890,7 @@
           アプリの有効/無効状態を管理できます
         </p>
       </div>
+<? } ?>
       
       <!-- セキュリティと統合情報 -->
       <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">

--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -497,7 +497,8 @@ function openForm() {
 function openAppSetupPage() {
   runGasWithUserId('getWebAppUrl')
     .then(function(webAppUrl) {
-      const setupUrl = webAppUrl + '?setup=true&mode=appsetup';
+      const setupUrl =
+        webAppUrl + '?setup=true&mode=appsetup&userId=' + encodeURIComponent(userId);
       window.location.href = setupUrl;
     })
     .catch(function(error) {

--- a/src/adminPanel-events.js.html
+++ b/src/adminPanel-events.js.html
@@ -364,11 +364,13 @@ function handleDeleteRequest() {
             window.localStorage.clear();
           }
           setTimeout(function() {
-            runGasWithUserId('getWebAppUrl').then(function(webAppUrl) {
-              window.location.href = '/login';
-            }).catch(function() {
-              window.location.href = '/login';
-            });
+            runGasWithUserId('getWebAppUrl')
+              .then(function(webAppUrl) {
+                window.location.href = webAppUrl;
+              })
+              .catch(function() {
+                window.location.reload();
+              });
           }, 2000);
         })
         .catch(function(error) {

--- a/src/adminPanel.js.html
+++ b/src/adminPanel.js.html
@@ -364,12 +364,14 @@
               window.localStorage.clear();
             }
             setTimeout(() => {
-              runGasWithUserId('getWebAppUrl').then(webAppUrl => {
-                window.location.href = '/login';
-              }).catch(error => {
-                console.error('Failed to get web app URL:', error);
-                window.location.href = '/login';
-              });
+              runGasWithUserId('getWebAppUrl')
+                .then(webAppUrl => {
+                  window.location.href = webAppUrl;
+                })
+                .catch(error => {
+                  console.error('Failed to get web app URL:', error);
+                  window.location.reload();
+                });
             }, 2000);
           } else {
             showMessage(result.message || '削除に失敗しました', 'error');


### PR DESCRIPTION
## Summary
- restrict App Setup link to system admins using script property
- add userId query param when opening AppSetupPage
- redirect to web app after account deletion for reliability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c9a94298c832ba66564a34498fa4d