### PR TITLE
Add post-create user polling

### DIFF
--- a/src/auth.gs
+++ b/src/auth.gs
@@ -276,6 +276,9 @@ function processLoginFlow(userEmail) {
       
       // 3b. データベースに作成
       createUser(newUser);
+      if (!waitForUserRecord(newUser.userId, 3000, 500)) {
+        console.warn('processLoginFlow: user not found after create:', newUser.userId);
+      }
       console.log('processLoginFlow: 新規ユーザー作成完了:', newUser.userId);
       
       // 3c. 新規ユーザーの管理パネルへリダイレクト

--- a/src/database.gs
+++ b/src/database.gs
@@ -680,6 +680,22 @@ function createUser(userData) {
 }
 
 /**
+ * Polls the database until a user record becomes available.
+ * @param {string} userId - The ID of the user to fetch.
+ * @param {number} maxWaitMs - Maximum wait time in milliseconds.
+ * @param {number} intervalMs - Poll interval in milliseconds.
+ * @returns {boolean} true if found within the wait window.
+ */
+function waitForUserRecord(userId, maxWaitMs, intervalMs) {
+  var start = Date.now();
+  while (Date.now() - start < maxWaitMs) {
+    if (fetchUserFromDatabase('userId', userId)) return true;
+    Utilities.sleep(intervalMs);
+  }
+  return false;
+}
+
+/**
  * データベースシートを初期化
  * @param {string} spreadsheetId - データベースのスプレッドシートID
  */


### PR DESCRIPTION
## Summary
- add `waitForUserRecord` helper to poll Sheets for a newly created user
- call this helper in `processLoginFlow` and warn if the user record isn't readable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cae73858c832ba1c24489feed80db