### PR TITLE
Fix account switch redirect

### DIFF
--- a/src/login.js.html
+++ b/src/login.js.html
@@ -244,13 +244,23 @@
       google.script.run
         .withSuccessHandler(result => {
           console.log('Session cleanup result:', result);
-          // Google認証のログアウトURLにリダイレクト
-          window.location.href = 'https://accounts.google.com/logout';
+          google.script.run
+            .withSuccessHandler(res => {
+              if (res && res.url) {
+                window.location.href = res.url;
+              } else {
+                window.location.href = 'https://accounts.google.com/logout';
+              }
+            })
+            .withFailureHandler(err => {
+              console.error('Get sign-in URL failed:', err);
+              window.location.href = 'https://accounts.google.com/logout';
+            })
+            .getGoogleSignInUrl();
         })
         .withFailureHandler(error => {
           console.error('Session cleanup failed:', error);
           alert('セッションクリアに失敗しました。手動でGoogleアカウントからログアウトしてください。');
-          // 失敗時もGoogleログアウトページへ
           window.location.href = 'https://accounts.google.com/logout';
         })
         .resetUserAuthentication();

--- a/src/url.gs
+++ b/src/url.gs
@@ -289,3 +289,36 @@ function generateAppUrls(userId) {
   }
 }
 
+/**
+ * Generate Google account chooser URL dynamically.
+ * @returns {{url: string}}
+ */
+function getGoogleSignInUrl() {
+  try {
+    var continueUrl = getWebAppUrlCached();
+    var domainInfo = getSystemDomainInfo();
+
+    var params = {
+      continue: continueUrl,
+      followup: continueUrl,
+      flowName: 'GlifWebSignIn',
+      flowEntry: 'AccountChooser'
+    };
+
+    if (domainInfo && domainInfo.adminDomain) {
+      params.hd = domainInfo.adminDomain;
+    }
+
+    var query = Object.keys(params)
+      .map(function(key) {
+        return encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
+      })
+      .join('&');
+
+    return { url: 'https://accounts.google.com/v3/signin/accountchooser?' + query };
+  } catch (e) {
+    console.error('getGoogleSignInUrl error: ' + e.message);
+    return { url: 'https://accounts.google.com/' };
+  }
+}
+


### PR DESCRIPTION
## Summary
- compute Google sign-in URL server-side
- use new dynamic URL when switching accounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d3b212c80832b9e45c41e0fb527f8