### PR TITLE
Remove Tailwind remnants from HTML pages

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -26,12 +26,12 @@
       const originalInfo = console.info;
       const originalLog = console.log;
       const originalError = console.error;
-      
+
       // Patterns to suppress
       const suppressPatterns = [
         '-ms-high-contrast is in the process of being deprecated',
         'Feature Policy',
-        'Permissions Policy', 
+        'Permissions Policy',
         'Unrecognized feature',
         'deprecated',
         'iframe.*sandbox.*allow-scripts.*allow-same-origin',
@@ -50,7 +50,7 @@
         'Learn more',
         'Don\'t show again'
       ];
-      
+
       // Helper function to check if message should be suppressed
       function shouldSuppress(args) {
         const message = args[0] ? String(args[0]).toLowerCase() : '';
@@ -59,28 +59,28 @@
           return regex.test(message);
         });
       }
-      
+
       // Override console.warn
       console.warn = function(...args) {
         if (!shouldSuppress(args)) {
           originalWarn.apply(console, args);
         }
       };
-      
+
       // Override console.info
       console.info = function(...args) {
         if (!shouldSuppress(args)) {
           originalInfo.apply(console, args);
         }
       };
-      
+
       // Override console.log for specific patterns
       console.log = function(...args) {
         if (!shouldSuppress(args)) {
           originalLog.apply(console, args);
         }
       };
-      
+
       // Enhanced error filtering but keep important errors
       console.error = function(...args) {
         if (!shouldSuppress(args)) {
@@ -94,23 +94,23 @@
   <?!= include('UnifiedStyles'); ?>
   <?!= include('BootstrapFormComponents'); ?>
   <?!= include('SharedUtilities'); ?>
-  
+
   <!-- Admin Panel Specific Styles -->
   <?!= include('adminPanel-layout.css'); ?>
   <?!= include('adminPanel.css'); ?>
-  
-  
+
+
   <!-- Core JavaScript Libraries (must be loaded first) -->
   <?!= include('ClientOptimizer'); ?>
   <?!= include('UnifiedCache.js'); ?>
-  
+
   <script>
   // GASOptimizer and UnifiedCache are now guaranteed to be defined
   // Enhanced Global Error Handling
   window.addEventListener('error', function(event) {
     const errorMessage = event.error?.message || '';
     const errorStack = event.error?.stack || '';
-    
+
     // Suppress specific Google Apps Script internal errors
     const suppressedErrors = [
       'document.write',
@@ -126,68 +126,68 @@
       'vibrate',
       'vr'
     ];
-    
-    const shouldSuppress = suppressedErrors.some(pattern => 
+
+    const shouldSuppress = suppressedErrors.some(pattern =>
       errorMessage.includes(pattern) || errorStack.includes(pattern)
     );
-    
+
     if (shouldSuppress) {
       // Log suppressed error for debugging (optional)
       console.debug('Suppressed Google Apps Script internal error:', errorMessage);
       event.preventDefault();
       return;
     }
-    
+
     // Log important errors
     console.error('Global error caught:', event.error);
   });
-  
+
   // Enhanced Promise rejection handling
   window.addEventListener('unhandledrejection', function(event) {
     const reason = event.reason?.toString() || '';
-    
+
     // Suppress Google Apps Script internal promise rejections
-    if (reason.includes('document.write') || 
+    if (reason.includes('document.write') ||
         reason.includes('mae_html_user') ||
         reason.includes('warden_bin')) {
       console.debug('Suppressed internal promise rejection:', reason);
       event.preventDefault();
       return;
     }
-    
+
     console.error('Unhandled promise rejection:', event.reason);
     event.preventDefault();
   });
 
   // GASOptimizer インスタンスの初期化
   var gasOptimizer = new GASOptimizer();
-  
+
   // UnifiedCache インスタンスの初期化
   var unifiedCache = (typeof UnifiedCache !== 'undefined')
     ? new UnifiedCache()
     : { getOrSet: function(_, fn) { return fn(); } };
-  
+
   // runGas ラッパー関数 - キャッシュ対応
   function runGas(functionName, ...args) {
     return gasOptimizer.call(functionName, ...args);
   }
-  
+
   // runGasWithUserId function is defined in adminPanel-api.js.html to avoid duplication
-  
+
   // callWithCache 関数 - 読み取り専用操作用
   function callWithCache(functionName, cacheKey, ttl, ...args) {
     return unifiedCache.getOrSet(cacheKey, function() {
       return gasOptimizer.call(functionName, ...args);
     }, ttl);
   }
-  
+
   // マルチテナント対応: callWithCacheWithUserId関数
   function callWithCacheWithUserId(functionName, cacheKey, ttl, ...args) {
     if (!userId) {
       console.error('❌  - No userId available for cached call:', functionName);
       throw new Error('ユーザーIDが設定されていません。ページを再読み込みしてください。');
     }
-    
+
     return unifiedCache.getOrSet(cacheKey, function() {
       console.log('✅  - callWithCacheWithUserId:', functionName, 'userId:', userId);
       return gasOptimizer.call(functionName, userId, ...args);
@@ -203,16 +203,16 @@
   console.log('- Raw template type:', typeof __IS_SYSTEM_ADMIN_RAW__);
   console.log('- Processed value:', __IS_SYSTEM_ADMIN__);
   console.log('- window.isSystemAdmin final:', window.isSystemAdmin);
-  
+
   </script>
-  
+
   <!-- Bootstrap JavaScript will be added at the end of body -->
 </head>
 <body class="bg-[#1a1b26] text-gray-200 font-sans">
   <div id="loading-overlay" class="loading-overlay hidden">
     <div class="text-center">
       <div class="spinner"></div>
-      <p id="loading-message" class="mt-4 text-gray-300">処理中...</p>
+      <p id="loading-message" class="mt-4 text-light">処理中...</p>
     </div>
   </div>
   <header id="admin-header" class="glass-panel border-b border-gray-700 fixed top-1 sm:top-2 left-2 right-2 sm:left-4 sm:right-4 z-50 rounded-lg sm:rounded-xl shadow-lg">
@@ -227,21 +227,21 @@
           <div class="min-w-0">
             <div class="hidden sm:block">
               <h1 class="h5 h4-sm fw-bold text-white lh-sm text-truncate">みんなの回答ボード	管理パネル</h1>
-              <p class="text-xs text-gray-400">StudyQuest</p>
+              <p class="text-xs text-secondary">StudyQuest</p>
             </div>
             <div class="sm:hidden">
               <h1 class="h6 fw-bold text-white text-truncate">みんなの回答ボード</h1>
             </div>
           </div>
         </div>
-        
+
         <!-- ドメイン・ステータス情報 -->
         <div class="flex items-center gap-2 flex-shrink-0">
           <!-- ドメイン情報（Login.htmlスタイル） -->
           <div id="header-domain-info">
             <!-- ドメイン一致表示（緑色パネル） -->
             <!-- ドメイン一致表示（Login.htmlスタイル） -->
-            <div id="header-domain-match" class="glass-panel bg-gradient-to-r from-green-500/10 to-emerald-500/10 rounded-lg p-3 border border-green-400/30 hidden">
+            <div id="header-domain-match" class="glass-panel bg-gradient-to-r from-green-500/10 to-emerald-500/10 rounded-lg p-3 border border-green-400 hidden">
               <div class="flex items-center gap-2">
                 <svg class="icon-size-md text-success flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
@@ -252,7 +252,7 @@
                 </div>
               </div>
             </div>
-            
+
             <!-- ドメイン不一致表示（Login.htmlスタイル） -->
             <div id="header-domain-mismatch" class="glass-panel bg-warning bg-opacity-10 rounded-3 p-3 border border-warning d-none">
               <div class="flex items-center gap-2">
@@ -265,13 +265,13 @@
                 </div>
               </div>
             </div>
-            
+
             <!-- 初期状態表示 -->
-            <div id="header-domain-initial" class="glass-panel bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-lg p-3 border border-blue-400/30">
+            <div id="header-domain-initial" class="glass-panel bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-lg p-3 border border-blue-400">
               <div class="flex items-center gap-2">
                 <div id="header-status-dot" class="status-dot status-dot-pulse bg-primary flex-shrink-0"></div>
                 <div>
-                  <div class="text-blue-400 font-semibold text-sm" id="header-domain-name-initial">ドメイン確認中</div>
+                  <div class="text-primary font-semibold text-sm" id="header-domain-name-initial">ドメイン確認中</div>
                   <div class="text-blue-200 text-xs" id="header-status-text-initial">セットアップ中</div>
                 </div>
               </div>
@@ -300,22 +300,22 @@
             </div>
             <div>
               <span class="text-sm font-medium text-white" id="guidance-text">セットアップを開始してください</span>
-              <div class="text-xs text-gray-400 mt-1">3ステップで簡単セットアップ</div>
+              <div class="text-xs text-secondary mt-1">3ステップで簡単セットアップ</div>
             </div>
           </div>
-          
+
           <!-- 右側: コンパクトステップナビゲーション -->
           <div class="flex items-center gap-2">
             <div class="d-flex align-items-center gap-1" id="step-1-indicator">
               <div class="d-flex align-items-center justify-content-center fw-bold rounded-circle text-white transition-all" style="width: 1.5rem; height: 1.5rem; font-size: 0.75rem; background-color: var(--bs-primary); ">1</div>
               <span class="small text-light d-none d-sm-inline">データ準備</span>
             </div>
-            <div class="w-4 h-px bg-gray-600"></div>
+            <div class="w-4 h-px bg-secondary"></div>
             <div class="d-flex align-items-center gap-1" id="step-2-indicator">
               <div class="d-flex align-items-center justify-content-center fw-bold rounded-circle text-white transition-all" style="width: 1.5rem; height: 1.5rem; font-size: 0.75rem; background-color: var(--bs-secondary); ">2</div>
               <span class="small text-light d-none d-sm-inline">シート設定</span>
             </div>
-            <div class="w-4 h-px bg-gray-600"></div>
+            <div class="w-4 h-px bg-secondary"></div>
             <div class="d-flex align-items-center gap-1" id="step-3-indicator">
               <div class="d-flex align-items-center justify-content-center fw-bold rounded-circle text-white transition-all" style="width: 1.5rem; height: 1.5rem; font-size: 0.75rem; background-color: var(--bs-secondary); ">3</div>
               <span class="small text-light d-none d-sm-inline">表示設定</span>
@@ -327,7 +327,7 @@
 
     <!-- 左右パネル -->
       <div class="left-panel col-span-2 space-y-2">
-        
+
         <!-- ステップ1: データソース設定 -->
         <div class="glass-panel p-4 lg:p-6" id="data-setup-section">
           <div class="flex items-center justify-between mb-4">
@@ -337,16 +337,16 @@
               </div>
               <div>
                 <h2 class="text-lg font-semibold text-white">データ準備</h2>
-                <p class="text-xs text-gray-400">フォームやスプレッドシートを設定</p>
+                <p class="text-xs text-secondary">フォームやスプレッドシートを設定</p>
               </div>
             </div>
             <button type="button" class="toggle-section" onclick="toggleSection('step1-content')" aria-expanded="true" aria-label="セクションを展開/折りたたみ">
-              <svg class="w-5 h-5 text-gray-400 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-secondary transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
               </svg>
             </button>
           </div>
-          
+
           <div id="step1-content" class="progressive-section expanded">
             <!-- 統合されたデータ準備セクション -->
             <div class="google-integration p-4 rounded-xl text-white mb-4">
@@ -365,7 +365,7 @@
               <p class="text-sm mb-4 opacity-90">
                 Google Workspaceと連携して、回答収集用のフォームとデータ管理用のスプレッドシートを作成します。お好みの方法を選択してください。
               </p>
-              
+
               <!-- 水平配置のボタン -->
               <div class="flex gap-3">
                 <button type="button" id="quickstart-btn" class="btn btn-google flex-1">
@@ -384,101 +384,101 @@
             </div>
 
             <!-- QuickStart Progress (共通プログレス表示) -->
-            <div id="quickstart-progress" class="hidden bg-gray-800/30 border border-emerald-400/30 rounded-lg p-4 mb-4">
+            <div id="quickstart-progress" class="hidden bg-secondary bg-opacity-25 border border-emerald-400 rounded-lg p-4 mb-4">
               <div class="flex items-center gap-2 mb-3">
                 <svg class="w-5 h-5 text-emerald-400 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                 </svg>
                 <h4 class="text-sm font-semibold text-emerald-300">セットアップ進行中</h4>
               </div>
-              
+
               <!-- Progress Steps -->
               <div class="space-y-3">
                 <div class="flex items-center gap-3" id="progress-step-1">
-                  <div class="w-6 h-6 rounded-full bg-gray-600 flex items-center justify-center">
-                    <div class="w-2 h-2 rounded-full bg-gray-400" id="progress-step-1-dot"></div>
+                  <div class="w-6 h-6 rounded-full bg-secondary flex items-center justify-center">
+                    <div class="w-2 h-2 rounded-full bg-secondary" id="progress-step-1-dot"></div>
                   </div>
                   <div class="flex-1">
-                    <div class="text-sm text-gray-300" id="progress-step-1-text">ユーザー専用フォルダの作成</div>
-                    <div class="text-xs text-gray-500" id="progress-step-1-detail">待機中...</div>
+                    <div class="text-sm text-light" id="progress-step-1-text">ユーザー専用フォルダの作成</div>
+                    <div class="text-xs text-muted" id="progress-step-1-detail">待機中...</div>
                   </div>
                 </div>
-                
+
                 <div class="flex items-center gap-3" id="progress-step-2">
-                  <div class="w-6 h-6 rounded-full bg-gray-600 flex items-center justify-center">
-                    <div class="w-2 h-2 rounded-full bg-gray-400" id="progress-step-2-dot"></div>
+                  <div class="w-6 h-6 rounded-full bg-secondary flex items-center justify-center">
+                    <div class="w-2 h-2 rounded-full bg-secondary" id="progress-step-2-dot"></div>
                   </div>
                   <div class="flex-1">
-                    <div class="text-sm text-gray-300" id="progress-step-2-text">Googleフォームとスプレッドシートの作成</div>
-                    <div class="text-xs text-gray-500" id="progress-step-2-detail">待機中...</div>
+                    <div class="text-sm text-light" id="progress-step-2-text">Googleフォームとスプレッドシートの作成</div>
+                    <div class="text-xs text-muted" id="progress-step-2-detail">待機中...</div>
                   </div>
                 </div>
-                
+
                 <div class="flex items-center gap-3" id="progress-step-3">
-                  <div class="w-6 h-6 rounded-full bg-gray-600 flex items-center justify-center">
-                    <div class="w-2 h-2 rounded-full bg-gray-400" id="progress-step-3-dot"></div>
+                  <div class="w-6 h-6 rounded-full bg-secondary flex items-center justify-center">
+                    <div class="w-2 h-2 rounded-full bg-secondary" id="progress-step-3-dot"></div>
                   </div>
                   <div class="flex-1">
-                    <div class="text-sm text-gray-300" id="progress-step-3-text">回答ボードの設定と公開</div>
-                    <div class="text-xs text-gray-500" id="progress-step-3-detail">待機中...</div>
+                    <div class="text-sm text-light" id="progress-step-3-text">回答ボードの設定と公開</div>
+                    <div class="text-xs text-muted" id="progress-step-3-detail">待機中...</div>
                   </div>
                 </div>
-                
+
                 <div class="flex items-center gap-3" id="progress-step-4">
-                  <div class="w-6 h-6 rounded-full bg-gray-600 flex items-center justify-center">
-                    <div class="w-2 h-2 rounded-full bg-gray-400" id="progress-step-4-dot"></div>
+                  <div class="w-6 h-6 rounded-full bg-secondary flex items-center justify-center">
+                    <div class="w-2 h-2 rounded-full bg-secondary" id="progress-step-4-dot"></div>
                   </div>
                   <div class="flex-1">
-                    <div class="text-sm text-gray-300" id="progress-step-4-text">セットアップ完了</div>
-                    <div class="text-xs text-gray-500" id="progress-step-4-detail">待機中...</div>
+                    <div class="text-sm text-light" id="progress-step-4-text">セットアップ完了</div>
+                    <div class="text-xs text-muted" id="progress-step-4-detail">待機中...</div>
                   </div>
                 </div>
               </div>
-              
+
               <!-- Overall Progress Bar -->
               <div class="mt-4">
                 <div class="flex items-center justify-between mb-2">
-                  <span class="text-xs text-gray-400">全体の進捗</span>
+                  <span class="text-xs text-secondary">全体の進捗</span>
                   <span class="text-xs text-emerald-400" id="progress-percentage">0%</span>
                 </div>
-                <div class="w-full bg-gray-700 rounded-full h-2">
+                <div class="w-full bg-secondary rounded-full h-2">
                   <div class="bg-gradient-to-r from-emerald-500 to-blue-500 h-2 rounded-full transition-all duration-500" style="width: 0%" id="progress-bar"></div>
                 </div>
               </div>
-              
+
               <div class="mt-3 text-center">
                 <p class="text-sm text-emerald-300" id="progress-status">初期化中...</p>
               </div>
             </div>
 
             <!-- 既存ユーザー向けの追加オプション -->
-            <div id="existing-user-section" class="hidden bg-gray-800/30 border border-gray-600/30 rounded-xl p-4 mb-4">
-              <h4 class="text-sm font-semibold text-gray-300 mb-3">追加オプション</h4>
+            <div id="existing-user-section" class="hidden bg-secondary bg-opacity-25 border border-secondary rounded-xl p-4 mb-4">
+              <h4 class="text-sm font-semibold text-light mb-3">追加オプション</h4>
               <button type="button" id="create-additional-form-btn" class="btn btn-secondary w-full text-sm">
                 <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
                 </svg>
                 <span id="create-additional-form-text" class="text-gray-200">新規のフォームを作成</span>
               </button>
-              <p class="text-xs text-gray-400 mt-2">現在のボードに連携する新しいフォームを作成</p>
+              <p class="text-xs text-secondary mt-2">現在のボードに連携する新しいフォームを作成</p>
             </div>
-            
+
             <!-- 外部リソースの連携 (上級者向け) -->
-            <details class="bg-gray-800/30 border border-gray-600/30 rounded-xl">
-              <summary class="p-4 cursor-pointer text-sm font-medium text-gray-300 hover:text-white flex items-center gap-2">
+            <details class="bg-secondary bg-opacity-25 border border-secondary rounded-xl">
+              <summary class="p-4 cursor-pointer text-sm font-medium text-light hover:text-white flex items-center gap-2">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path>
                 </svg>
                 外部リソースの連携 (上級者向け)
               </summary>
               <div class="p-4 pt-0 space-y-4">
-                <div class="bg-purple-900/20 border border-purple-500/30 rounded-lg p-4">
+                <div class="bg-purple-900 bg-opacity-25 border border-purple-500 rounded-lg p-4">
                   <label class="block text-sm font-medium text-purple-200 mb-2">
                     GoogleフォームまたはスプレッドシートのURL
                   </label>
                   <div class="space-y-3">
-                    <input type="url" 
-                           id="resource-url-input" 
+                    <input type="url"
+                           id="resource-url-input"
                            placeholder="https://docs.google.com/forms/d/... または https://docs.google.com/spreadsheets/d/..."
                            class="form-control"
                            aria-describedby="resource-url-help">
@@ -500,7 +500,7 @@
                 </div>
               </div>
             </details>
-            
+
             <!-- 作成されたリソース表示 -->
             <div class="space-y-3 hidden" id="form-url-section">
               <div class="success-state">
@@ -525,7 +525,7 @@
                 </div>
               </div>
             </div>
-            
+
             <!-- カスタムフォーム情報表示エリア -->
             <div id="custom-form-info-section" class="hidden mt-4">
               <!-- updateCustomFormInfo()で動的に内容が設定される -->
@@ -542,20 +542,20 @@
               </div>
               <div>
                 <h2 class="text-lg font-semibold text-white">シート設定</h2>
-                <p class="text-xs text-gray-400">表示するデータシートを選択</p>
+                <p class="text-xs text-secondary">表示するデータシートを選択</p>
               </div>
             </div>
             <button type="button" class="toggle-section" onclick="toggleSection('step2-content')" aria-expanded="true" aria-label="セクションを展開/折りたたみ">
-              <svg class="w-5 h-5 text-gray-400 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-secondary transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
               </svg>
             </button>
           </div>
-          
+
           <div id="step2-content" class="progressive-section expanded">
             <div class="space-y-4">
               <!-- シート選択の説明 -->
-              <div class="bg-green-900/20 border border-green-500/30 rounded-lg p-3">
+              <div class="bg-green-900 bg-opacity-25 border border-success rounded-lg p-3">
                 <div class="flex items-center gap-2 mb-2">
                   <svg class="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
@@ -564,7 +564,7 @@
                 </div>
                 <p class="text-xs text-green-300">スプレッドシートの中から回答ボードとして表示するシートを選択します</p>
               </div>
-              
+
               <!-- シート選択コントロール -->
               <div class="space-y-3">
                 <label for="sheet-select" class="block text-sm font-medium text-white">
@@ -585,25 +585,25 @@
                     </svg>
                   </button>
                 </div>
-                <p id="sheet-help" class="text-xs text-gray-400">
+                <p id="sheet-help" class="text-xs text-secondary">
                   フォームの回答や表示したいデータが含まれるシートを選択してください
                 </p>
               </div>
 
               <!-- データプレビュー -->
               <div id="data-preview-section" class="hidden">
-                <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
+                <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
                   <h4 class="text-sm font-medium text-white mb-3 flex items-center gap-2">
-                    <svg class="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
                     </svg>
                     データプレビュー
                   </h4>
-                  <div id="data-preview-content" class="text-sm text-gray-300">
+                  <div id="data-preview-content" class="text-sm text-light">
                     <div class="animate-pulse">
-                      <div class="h-4 bg-gray-700 rounded w-3/4 mb-2"></div>
-                      <div class="h-4 bg-gray-700 rounded w-1/2"></div>
+                      <div class="h-4 bg-secondary rounded w-3/4 mb-2"></div>
+                      <div class="h-4 bg-secondary rounded w-1/2"></div>
                     </div>
                   </div>
                 </div>
@@ -621,19 +621,19 @@
               </div>
               <div>
                 <h2 class="text-lg font-semibold text-white">表示設定・公開</h2>
-                <p class="text-xs text-gray-400">列設定と表示オプションを設定</p>
+                <p class="text-xs text-secondary">列設定と表示オプションを設定</p>
               </div>
             </div>
             <button type="button" class="toggle-section" onclick="toggleSection('step3-content')" aria-expanded="true" aria-label="セクションを展開/折りたたみ">
-              <svg class="w-5 h-5 text-gray-400 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-secondary transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
               </svg>
             </button>
           </div>
-          
+
           <div id="step3-content" class="progressive-section expanded">
             <div id="config-area" class="space-y-4 hidden">
-              <div class="bg-purple-900/20 border border-purple-500/30 rounded-lg p-4">
+              <div class="bg-purple-900 bg-opacity-25 border border-purple-500 rounded-lg p-4">
                 <div class="flex items-center gap-2 mb-2">
                   <svg class="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
@@ -643,10 +643,10 @@
                 </div>
                 <p class="text-xs text-purple-300">スプレッドシートの列を回答ボードの項目に割り当てます</p>
               </div>
-              
+
               <!-- 必須設定 -->
               <div class="space-y-4">
-                <div class="bg-red-900/20 border border-red-500/30 rounded-lg p-4">
+                <div class="bg-danger bg-opacity-25 border border-danger rounded-lg p-4">
                   <label class="block">
                     <div class="d-flex align-items-center gap-2 mb-2">
                       <span class="text-sm font-medium text-white">回答データ列</span>
@@ -664,15 +664,15 @@
                         <div class="absolute inset-0 bg-gradient-to-r from-cyan-400/20 to-purple-400/20 transform translate-x-full group-hover:translate-x-0 transition-transform duration-300"></div>
                       </button>
                     </div>
-                    <p id="main-help" class="text-xs text-red-300 mt-1">
+                    <p id="main-help" class="text-xs text-danger mt-1">
                       回答内容が含まれる列を選択してください
                     </p>
                   </label>
                 </div>
-                
+
                 <!-- オプション設定 -->
-                <details class="bg-gray-800/30 border border-gray-600/30 rounded-xl">
-                  <summary class="p-4 cursor-pointer text-sm font-medium text-gray-300 hover:text-white flex items-center gap-2">
+                <details class="bg-secondary bg-opacity-25 border border-secondary rounded-xl">
+                  <summary class="p-4 cursor-pointer text-sm font-medium text-light hover:text-white flex items-center gap-2">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4"></path>
                     </svg>
@@ -680,30 +680,30 @@
                   </summary>
                   <div class="p-4 pt-0 space-y-4" id="detail-options">
                     <label class="block">
-                      <span class="text-sm text-gray-300 mb-2 block">回答データ列（必須）</span>
+                      <span class="text-sm text-light mb-2 block">回答データ列（必須）</span>
                       <select id="opinion-column" class="form-control"></select>
                     </label>
                     <label class="block">
-                      <span class="text-sm text-gray-300 mb-2 block">名前列</span>
+                      <span class="text-sm text-light mb-2 block">名前列</span>
                       <select id="name-column" class="form-control"></select>
                     </label>
                     <label class="block">
-                      <span class="text-sm text-gray-300 mb-2 block">クラス列</span>
+                      <span class="text-sm text-light mb-2 block">クラス列</span>
                       <select id="class-column" class="form-control"></select>
                     </label>
-                    
+
                     <div class="flex items-center mt-4">
                       <input type="checkbox" id="show-names" name="show-names" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
-                      <label for="show-names" class="ml-2 block text-sm text-gray-300">名前を表示する</label>
+                      <label for="show-names" class="ml-2 block text-sm text-light">名前を表示する</label>
                     </div>
                     <div class="flex items-center mt-2">
                       <input type="checkbox" id="show-counts" name="show-counts" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" checked>
-                      <label for="show-counts" class="ml-2 block text-sm text-gray-300">リアクション数を表示する</label>
+                      <label for="show-counts" class="ml-2 block text-sm text-light">リアクション数を表示する</label>
                     </div>
                   </div>
                 </details>
               </div>
-              
+
               <!-- 統合アクションボタン -->
               <div class="space-y-3 pt-4">
                 <button type="button" id="save-publish-btn" disabled class="btn btn-primary w-full btn-lg">
@@ -728,52 +728,52 @@
                 </button>
               </div>
             </div>
-            
+
             <div id="config-placeholder" class="text-center py-8">
-              <div class="w-12 h-12 bg-gray-700 rounded-full flex items-center justify-center mx-auto mb-3">
+              <div class="w-12 h-12 bg-secondary rounded-full flex items-center justify-center mx-auto mb-3">
                 <div class="loading-skeleton w-full h-full rounded-full hidden" id="config-loading"></div>
-                <svg class="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-6 h-6 text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4"></path>
                 </svg>
               </div>
-              <p class="text-gray-400 text-sm">シートを選択すると列設定が表示されます</p>
+              <p class="text-secondary text-sm">シートを選択すると列設定が表示されます</p>
             </div>
           </div>
         </div>
       </div>
-      
+
       <!-- 右側：情報・ヘルプパネル -->
       <div class="right-panel space-y-4">
-        
+
         <!-- システム状況 -->
         <div id="system-info-panel" class="glass-panel p-4 lg:p-6">
     <div class="flex items-center gap-3 mb-4">
       <div class="w-8 h-8 bg-gradient-to-br from-gray-500 to-gray-600 rounded-xl flex items-center justify-center">
         <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M12 5l7 7-7 7"></path></svg>
       </div>
-      <h3 class="font-semibold text-gray-300">システム状況</h3>
+      <h3 class="font-semibold text-light">システム状況</h3>
     </div>
 
     <div class="space-y-4">
       <!-- アカウント情報 -->
-      <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
+      <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
         <h4 class="text-sm font-medium text-gray-200 mb-3 flex items-center gap-2">
-          <svg class="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
           </svg>
           アカウント
         </h4>
         <div class="space-y-2 text-xs">
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">メールアドレス:</span>
+            <span class="text-secondary">メールアドレス:</span>
             <span class="text-white font-medium" id="info-admin-email">-</span>
           </div>
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">ユーザーID:</span>
-            <span class="text-white font-mono text-xs bg-gray-700 px-1.5 py-0.5 rounded" id="info-user-id">-</span>
+            <span class="text-secondary">ユーザーID:</span>
+            <span class="text-white font-mono text-xs bg-secondary px-1.5 py-0.5 rounded" id="info-user-id">-</span>
           </div>
           <div class="text-right pt-2">
-          <a href="<?= getWebAppUrl(); ?>" class="text-cyan-400 hover:text-cyan-300 hover:underline text-xs">
+          <a href="<?= getWebAppUrl(); ?>" class="text-info hover:text-info hover:underline text-xs">
             ログイン画面に戻る
           </a>
           </div>
@@ -781,7 +781,7 @@
       </div>
 
       <!-- 公開設定 -->
-      <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
+      <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
         <h4 class="text-sm font-medium text-gray-200 mb-3 flex items-center gap-2">
           <svg class="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
@@ -791,7 +791,7 @@
         </h4>
         <div class="space-y-2 text-xs">
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">公開状態:</span>
+            <span class="text-secondary">公開状態:</span>
             <span class="px-2 py-1 rounded text-xs font-medium" id="info-publish-status">
               <span class="inline-d-flex align-items-center gap-1">
                 <div class="w-2 h-2 rounded-full" id="info-publish-indicator"></div>
@@ -800,22 +800,22 @@
             </span>
           </div>
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">公開シート:</span>
+            <span class="text-secondary">公開シート:</span>
             <span class="text-white font-semibold" id="info-published-sheet">-</span>
           </div>
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">表示モード:</span>
+            <span class="text-secondary">表示モード:</span>
             <span class="text-white" id="info-display-mode">-</span>
           </div>
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">カウント表示:</span>
+            <span class="text-secondary">カウント表示:</span>
             <span class="text-white" id="info-show-counts">-</span>
           </div>
         </div>
       </div>
 
       <!-- データ状況 -->
-      <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
+      <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
         <h4 class="text-sm font-medium text-gray-200 mb-3 flex items-center gap-2">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
@@ -824,18 +824,18 @@
         </h4>
         <div class="space-y-2 text-xs">
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">総回答数:</span>
+            <span class="text-secondary">総回答数:</span>
             <span class="text-white font-bold text-lg" id="info-answer-count">-</span>
           </div>
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">総リアクション数:</span>
+            <span class="text-secondary">総リアクション数:</span>
             <span class="text-white font-bold text-lg" id="info-reaction-count">-</span>
           </div>
         </div>
       </div>
 
       <!-- リソース -->
-      <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
+      <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
         <h4 class="text-sm font-medium text-gray-200 mb-3 flex items-center gap-2">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path>
@@ -844,13 +844,13 @@
         </h4>
         <div class="space-y-3 text-xs">
           <div class="flex gap-2">
-            <button type="button" id="open-spreadsheet-btn" class="flex-1 bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all" disabled>
+            <button type="button" id="open-spreadsheet-btn" class="flex-1 bg-success hover:bg-green-700 text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all" disabled>
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
               </svg>
               スプレッドシート
             </button>
-            <button type="button" id="open-form-btn" class="flex-1 bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all" disabled>
+            <button type="button" id="open-form-btn" class="flex-1 bg-primary hover:bg-primary text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all" disabled>
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
               </svg>
@@ -859,10 +859,10 @@
           </div>
         </div>
       </div>
-      
+
       <!-- アプリ設定リンク -->
 <? if (isDeployUser) { ?>
-      <div id="app-setup-link" class="bg-blue-900/10 border border-blue-500/30 rounded-lg p-3 transition-all hover:border-blue-500/50">
+      <div id="app-setup-link" class="bg-blue-900 bg-opacity-10 border border-primary rounded-lg p-3 transition-all hover:border-primary">
         <button type="button" onclick="openAppSetupPage()" class="w-full flex items-center justify-between text-sm font-medium text-blue-300 hover:text-blue-200 transition-colors">
           <div class="flex items-center">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -880,36 +880,36 @@
         </p>
       </div>
 <? } ?>
-      
+
       <!-- セキュリティと統合情報 -->
-      <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
+      <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
         <h4 class="text-sm font-medium text-gray-200 mb-3 flex items-center gap-2">
-          <svg class="w-4 h-4 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4 text-info" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>
           </svg>
           セキュリティと統合
         </h4>
         <div class="space-y-2 text-xs">
           <div class="flex items-center justify-between">
-            <a href="#" onclick="showSecurityInfo(); return false;" class="text-cyan-400 hover:text-cyan-300 hover:underline">
+            <a href="#" onclick="showSecurityInfo(); return false;" class="text-info hover:text-info hover:underline">
               セキュリティ仕様について
             </a>
           </div>
           <div class="flex items-center justify-between">
-            <a href="#" onclick="showGoogleIntegrationInfo(); return false;" class="text-cyan-400 hover:text-cyan-300 hover:underline">
+            <a href="#" onclick="showGoogleIntegrationInfo(); return false;" class="text-info hover:text-info hover:underline">
               Google連携の利点
             </a>
           </div>
         </div>
       </div>
-      
-      <details id="account-deletion-section" class="bg-red-900/10 border border-red-500/30 rounded-lg transition-all hover:border-red-500/50">
-        <summary class="p-3 cursor-pointer text-sm font-medium text-red-300 hover:text-red-200 flex items-center justify-between">
+
+      <details id="account-deletion-section" class="bg-red-900 bg-opacity-10 border border-danger rounded-lg transition-all hover:border-danger">
+        <summary class="p-3 cursor-pointer text-sm font-medium text-danger hover:text-danger flex items-center justify-between">
           <span>アカウントの管理</span>
           <svg class="w-4 h-4 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </summary>
         <div class="p-3 pt-0">
-          <p class="text-xs text-red-200/80 mb-3">
+          <p class="text-xs text-danger mb-3">
             この操作は元に戻せません。アカウントを削除すると、作成したすべてのボードと設定が完全に消去されます。
           </p>
           <button type="button" id="delete-account-btn" class="btn btn-danger w-full text-sm py-2" onclick="handleDeleteRequest()">
@@ -921,7 +921,7 @@
       </div>
     </div>
   </main>
-  
+
   <!-- 統合フッター -->
   <footer id="admin-footer" class="fixed bottom-0 left-0 right-0 glass-panel border-t border-gray-700 h-16 sm:h-20 hidden">
     <div class="max-w-6xl mx-auto px-6 py-4">
@@ -936,11 +936,11 @@
           </div>
           <p class="text-blue-300 font-medium text-lg" id="current-topic-text">読み込み中...</p>
         </div>
-        
+
         <!-- 右側: ボードURL操作 -->
         <div class="flex items-center gap-3">
           <input type="text" id="board-url" readonly
-                 class="px-4 py-2 bg-gray-800 border border-gray-600 rounded-lg text-sm cursor-pointer hover:bg-gray-700 focus:ring-2 focus:ring-green-400 min-w-[300px]"
+                 class="px-4 py-2 bg-secondary border border-secondary rounded-lg text-sm cursor-pointer hover:bg-secondary focus:ring-2 focus:ring-green-400 min-w-[300px]"
                  onclick="this.select()" placeholder="URLが生成されます">
           <button type="button" onclick="copyBoardUrl()" class="btn btn-secondary px-3 py-2 flex items-center" title="URLをコピー" aria-label="生徒用URLをコピー">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -957,7 +957,7 @@
     </div>
   </footer>
   <div id="message-area" class="fixed top-24 right-6 z-50" aria-live="polite" role="status"></div>
-  
+
   <!-- 共通モーダルコンポーネントを読み込み -->
   <?!= include('SharedModals'); ?>
   <!-- Admin Panel JavaScript Components -->
@@ -970,7 +970,7 @@
   <!-- フォーム設定モーダル用JavaScript -->
   <!-- Form Controls and Modal Management -->
   <?!= include('adminPanel-forms.js'); ?>
-  
+
   <!-- Admin Panel Specific JavaScript -->
   <?!= include('adminPanel.js'); ?>
 

--- a/src/AppSetupPage.html
+++ b/src/AppSetupPage.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>StudyQuest - アプリ設定</title>
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), serial=(), bluetooth=(), screen-wake-lock=(), accelerometer=(), gyroscope=(), magnetometer=(), ambient-light-sensor=(), speaker=(), vibrate=(), vr=()" />
-    <script src="https://cdn.tailwindcss.com"></script>
     <?!= include('UnifiedStyles'); ?>
     <?!= include('SharedUtilities'); ?>
     <script>
@@ -30,25 +29,25 @@
         <div class="glass-panel rounded-4 p-4 mb-4">
             <h2 class="text-xl font-semibold text-white mb-4">📊 現在のステータス</h2>
             <div id="status-display" class="space-y-3">
-                <div class="flex items-center justify-between p-3 bg-gray-800 rounded-lg">
+                <div class="flex items-center justify-between p-3 bg-secondary rounded-lg">
                     <div class="flex items-center">
-                        <span class="text-gray-300 mr-3">アプリ状態:</span>
+                        <span class="text-light mr-3">アプリ状態:</span>
                         <span id="current-status" class="px-3 py-1 rounded-full text-sm font-medium">
                             <span class="loading-spinner w-4 h-4 border-2 border-white border-t-transparent rounded-full inline-block mr-2"></span>
                             読み込み中...
                         </span>
                     </div>
                 </div>
-                <div class="flex items-center justify-between p-3 bg-gray-800 rounded-lg">
+                <div class="flex items-center justify-between p-3 bg-secondary rounded-lg">
                     <div class="flex items-center">
-                        <span class="text-gray-300 mr-3">管理者:</span>
-                        <span id="current-admin" class="text-cyan-400">読み込み中...</span>
+                        <span class="text-light mr-3">管理者:</span>
+                        <span id="current-admin" class="text-info">読み込み中...</span>
                     </div>
                 </div>
-                <div class="flex items-center justify-between p-3 bg-gray-800 rounded-lg">
+                <div class="flex items-center justify-between p-3 bg-secondary rounded-lg">
                     <div class="flex items-center">
-                        <span class="text-gray-300 mr-3">最終更新:</span>
-                        <span id="last-updated" class="text-gray-400">読み込み中...</span>
+                        <span class="text-light mr-3">最終更新:</span>
+                        <span id="last-updated" class="text-secondary">読み込み中...</span>
                     </div>
                 </div>
             </div>
@@ -57,31 +56,31 @@
         <!-- アプリ状態切り替えパネル -->
         <div class="glass-panel rounded-4 p-4 mb-4">
             <h2 class="h4 fw-semibold text-white mb-3">🔧 アプリ状態の管理</h2>
-            
+
             <div class="d-flex flex-column gap-4">
                 <!-- isActive トグル -->
-                <div class="p-4 bg-gray-800 rounded-lg">
+                <div class="p-4 bg-secondary rounded-lg">
                     <div class="flex items-center justify-between mb-3">
                         <div>
                             <h3 class="text-lg font-medium text-white">アプリケーション有効化</h3>
-                            <p class="text-sm text-gray-400">アプリの利用可能状態を制御します</p>
+                            <p class="text-sm text-secondary">アプリの利用可能状態を制御します</p>
                         </div>
                         <div class="flex items-center">
                             <label class="relative inline-flex items-center cursor-pointer">
                                 <input type="checkbox" id="isActiveToggle" class="sr-only peer" disabled>
-                                <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
+                                <div class="w-11 h-6 bg-light peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-secondary peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-secondary peer-checked:bg-primary"></div>
                             </label>
                         </div>
                     </div>
-                    
+
                     <!-- 詳細説明 -->
-                    <div class="text-sm text-gray-400 mb-4">
+                    <div class="text-sm text-secondary mb-4">
                         <p><strong>有効 (ON):</strong> ユーザーがアプリにアクセスできます</p>
                         <p><strong>無効 (OFF):</strong> アプリへのアクセスが制限されます</p>
                     </div>
 
                     <!-- 変更ボタン -->
-                    <button 
+                    <button
                         id="updateStatusBtn"
                         class="btn btn-primary w-100 fw-bold"
                         disabled>
@@ -91,9 +90,9 @@
                 </div>
 
                 <!-- 使用シナリオの説明 -->
-                <div class="p-4 bg-gray-900 rounded-lg">
-                    <h4 class="text-md font-medium text-cyan-400 mb-3">🎯 使用シナリオ</h4>
-                    <div class="grid md:grid-cols-2 gap-4 text-sm text-gray-300">
+                <div class="p-4 bg-dark rounded-lg">
+                    <h4 class="text-md font-medium text-info mb-3">🎯 使用シナリオ</h4>
+                    <div class="grid md:grid-cols-2 gap-4 text-sm text-light">
                         <div>
                             <h5 class="font-medium text-white mb-2">一時的な停止・メンテナンス</h5>
                             <p>アプリケーションのメンテナンス、アップデート、または一時的な問題解決のために使用します。</p>
@@ -118,20 +117,20 @@
         <!-- ユーザー管理セクション -->
         <div class="glass-panel rounded-4 p-4 mb-4">
             <h2 class="text-xl font-semibold text-white mb-4">👥 ユーザー管理</h2>
-            
+
             <div class="space-y-4">
                 <!-- ユーザー一覧表示エリア -->
                 <div id="user-list-container" class="hidden">
                     <div class="flex justify-between items-center mb-4">
                         <h3 class="text-lg font-medium text-white">登録ユーザー一覧</h3>
                         <div class="flex gap-2">
-                            <button 
+                            <button
                                 id="refresh-users-btn"
                                 onclick="loadUserList()"
-                                class="btn bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm">
+                                class="btn bg-primary hover:bg-primary text-white px-4 py-2 rounded-lg text-sm">
                                 🔄 更新
                             </button>
-                            <button 
+                            <button
                                 id="view-logs-btn"
                                 onclick="viewDeletionLogs()"
                                 class="btn bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg text-sm">
@@ -139,21 +138,21 @@
                             </button>
                         </div>
                     </div>
-                    
-                    <div id="user-table-wrapper" class="bg-gray-800 rounded-lg overflow-hidden">
-                        <div id="user-loading" class="p-8 text-center text-gray-400">
-                            <div class="loading-spinner w-8 h-8 border-2 border-gray-400 border-t-transparent rounded-full mx-auto mb-2"></div>
+
+                    <div id="user-table-wrapper" class="bg-secondary rounded-lg overflow-hidden">
+                        <div id="user-loading" class="p-8 text-center text-secondary">
+                            <div class="loading-spinner w-8 h-8 border-2 border-secondary border-t-transparent rounded-full mx-auto mb-2"></div>
                             ユーザー一覧を読み込み中...
                         </div>
                         <div id="user-table-content" class="hidden">
                             <table class="table table-dark table-striped w-100">
-                                <thead class="bg-gray-900">
+                                <thead class="bg-dark">
                                     <tr>
-                                        <th class="px-4 py-3 text-left text-sm font-medium text-gray-300">メールアドレス</th>
-                                        <th class="px-4 py-3 text-left text-sm font-medium text-gray-300">登録日</th>
-                                        <th class="px-4 py-3 text-left text-sm font-medium text-gray-300">状態</th>
-                                        <th class="px-4 py-3 text-left text-sm font-medium text-gray-300">最終アクセス</th>
-                                        <th class="px-4 py-3 text-center text-sm font-medium text-gray-300">操作</th>
+                                        <th class="px-4 py-3 text-left text-sm font-medium text-light">メールアドレス</th>
+                                        <th class="px-4 py-3 text-left text-sm font-medium text-light">登録日</th>
+                                        <th class="px-4 py-3 text-left text-sm font-medium text-light">状態</th>
+                                        <th class="px-4 py-3 text-left text-sm font-medium text-light">最終アクセス</th>
+                                        <th class="px-4 py-3 text-center text-sm font-medium text-light">操作</th>
                                     </tr>
                                 </thead>
                                 <tbody id="user-table-body" class="divide-y divide-gray-700">
@@ -162,10 +161,10 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <!-- ユーザー管理ボタン -->
                 <div class="text-center">
-                    <button 
+                    <button
                         id="manage-users-btn"
                         onclick="toggleUserManagement()"
                         class="btn bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-bold py-3 px-6 rounded-lg">
@@ -177,7 +176,7 @@
 
         <!-- 戻るボタン -->
         <div class="text-center">
-            <button 
+            <button
                 onclick="goBackToAdminPanel()"
                 class="btn bg-gradient-to-r from-gray-600 to-gray-700 hover:from-gray-700 hover:to-gray-800 text-white font-bold py-2 px-6 rounded-lg">
                 ← 管理パネルに戻る
@@ -189,39 +188,39 @@
     <div id="delete-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50">
         <div class="glass-panel rounded-xl p-6 max-w-md w-full mx-4">
             <h3 class="text-xl font-semibold text-white mb-4">⚠️ ユーザーアカウント削除</h3>
-            
+
             <div class="mb-4">
-                <p class="text-gray-300 mb-2">以下のユーザーを削除しますか？</p>
-                <div class="bg-gray-800 p-3 rounded-lg">
-                    <p class="text-cyan-400 font-medium" id="delete-user-email"></p>
-                    <p class="text-sm text-gray-400" id="delete-user-id"></p>
+                <p class="text-light mb-2">以下のユーザーを削除しますか？</p>
+                <div class="bg-secondary p-3 rounded-lg">
+                    <p class="text-info font-medium" id="delete-user-email"></p>
+                    <p class="text-sm text-secondary" id="delete-user-id"></p>
                 </div>
             </div>
-            
+
             <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-300 mb-2">削除理由 <span class="text-red-400">*</span></label>
-                <textarea 
+                <label class="block text-sm font-medium text-light mb-2">削除理由 <span class="text-danger">*</span></label>
+                <textarea
                     id="deletion-reason"
-                    class="w-full p-3 bg-gray-800 border border-gray-600 rounded-lg text-white resize-none"
+                    class="w-full p-3 bg-secondary border border-secondary rounded-lg text-white resize-none"
                     rows="3"
                     placeholder="削除理由を入力してください（必須）"
                     required></textarea>
-                <p class="text-xs text-gray-400 mt-1">この情報は監査ログに記録されます</p>
+                <p class="text-xs text-secondary mt-1">この情報は監査ログに記録されます</p>
             </div>
-            
-            <div class="bg-red-900/20 border border-red-500/50 p-3 rounded-lg mb-4">
-                <p class="text-red-200 text-sm">
+
+            <div class="bg-danger bg-opacity-25 border border-danger p-3 rounded-lg mb-4">
+                <p class="text-danger text-sm">
                     ⚠️ この操作は取り消せません。ユーザーのデータが完全に削除されます。
                 </p>
             </div>
-            
+
             <div class="flex gap-3">
-                <button 
+                <button
                     onclick="cancelDeletion()"
                     class="btn btn-secondary flex-grow-1 py-2 px-3">
                     キャンセル
                 </button>
-                <button 
+                <button
                     id="confirm-delete-btn"
                     onclick="confirmDeletion()"
                     class="btn btn-danger flex-grow-1 py-2 px-3">
@@ -236,26 +235,26 @@
         <div class="glass-panel rounded-xl p-6 max-w-4xl w-full mx-4 max-h-[80vh] overflow-y-auto">
             <div class="flex justify-between items-center mb-4">
                 <h3 class="text-xl font-semibold text-white">📋 削除ログ</h3>
-                <button 
+                <button
                     onclick="closeDeletionLogs()"
-                    class="text-gray-400 hover:text-white text-2xl">✕</button>
+                    class="text-secondary hover:text-white text-2xl">✕</button>
             </div>
-            
+
             <div id="logs-content">
-                <div id="logs-loading" class="p-8 text-center text-gray-400">
-                    <div class="loading-spinner w-8 h-8 border-2 border-gray-400 border-t-transparent rounded-full mx-auto mb-2"></div>
+                <div id="logs-loading" class="p-8 text-center text-secondary">
+                    <div class="loading-spinner w-8 h-8 border-2 border-secondary border-t-transparent rounded-full mx-auto mb-2"></div>
                     削除ログを読み込み中...
                 </div>
                 <div id="logs-table-content" class="hidden">
-                    <div class="bg-gray-800 rounded-lg overflow-hidden">
+                    <div class="bg-secondary rounded-lg overflow-hidden">
                         <table class="w-full">
-                            <thead class="bg-gray-900">
+                            <thead class="bg-dark">
                                 <tr>
-                                    <th class="px-4 py-3 text-left text-sm font-medium text-gray-300">削除日時</th>
-                                    <th class="px-4 py-3 text-left text-sm font-medium text-gray-300">実行者</th>
-                                    <th class="px-4 py-3 text-left text-sm font-medium text-gray-300">対象ユーザー</th>
-                                    <th class="px-4 py-3 text-left text-sm font-medium text-gray-300">削除理由</th>
-                                    <th class="px-4 py-3 text-left text-sm font-medium text-gray-300">タイプ</th>
+                                    <th class="px-4 py-3 text-left text-sm font-medium text-light">削除日時</th>
+                                    <th class="px-4 py-3 text-left text-sm font-medium text-light">実行者</th>
+                                    <th class="px-4 py-3 text-left text-sm font-medium text-light">対象ユーザー</th>
+                                    <th class="px-4 py-3 text-left text-sm font-medium text-light">削除理由</th>
+                                    <th class="px-4 py-3 text-left text-sm font-medium text-light">タイプ</th>
                                 </tr>
                             </thead>
                             <tbody id="logs-table-body" class="divide-y divide-gray-700">
@@ -275,12 +274,12 @@
         function showMessage(message, type = 'info') {
             const messageArea = document.getElementById('message-area');
             const colors = {
-                success: 'bg-green-600/20 border-green-500/50 text-green-100',
-                error: 'bg-red-600/20 border-red-500/50 text-red-100',
-                warning: 'bg-yellow-600/20 border-yellow-500/50 text-yellow-100',
-                info: 'bg-blue-600/20 border-blue-500/50 text-blue-100'
+                success: 'bg-success bg-opacity-25 border-success text-green-100',
+                error: 'bg-danger bg-opacity-25 border-danger text-danger',
+                warning: 'bg-warning bg-opacity-25 border-warning text-warning',
+                info: 'bg-primary bg-opacity-25 border-primary text-primary'
             };
-            
+
             messageArea.innerHTML = `
                 <div class="message show glass-panel rounded-lg p-4 border ${colors[type]}">
                     <div class="flex items-center">
@@ -288,7 +287,7 @@
                             ${type === 'success' ? '✅' : type === 'error' ? '❌' : type === 'warning' ? '⚠️' : 'ℹ️'}
                         </div>
                         <div class="flex-grow-1">${message}</div>
-                        <button onclick="this.closest('.message').style.display='none'" class="ml-4 text-gray-400 hover:text-white">✕</button>
+                        <button onclick="this.closest('.message').style.display='none'" class="ml-4 text-secondary hover:text-white">✕</button>
                     </div>
                 </div>
             `;
@@ -321,12 +320,12 @@
             const toggleElement = document.getElementById('isActiveToggle');
 
             // 現在の状態を表示
-            statusElement.innerHTML = isActive 
-                ? '<span class="bg-green-600 text-green-100 px-3 py-1 rounded-full">🟢 アクティブ</span>'
-                : '<span class="bg-red-600 text-red-100 px-3 py-1 rounded-full">🔴 非アクティブ</span>';
+            statusElement.innerHTML = isActive
+                ? '<span class="bg-success text-green-100 px-3 py-1 rounded-full">🟢 アクティブ</span>'
+                : '<span class="bg-danger text-danger px-3 py-1 rounded-full">🔴 非アクティブ</span>';
 
             adminElement.textContent = userInfo.adminEmail || '不明';
-            lastUpdatedElement.textContent = userInfo.lastAccessedAt 
+            lastUpdatedElement.textContent = userInfo.lastAccessedAt
                 ? new Date(userInfo.lastAccessedAt).toLocaleString('ja-JP')
                 : '不明';
 
@@ -338,17 +337,17 @@
         function enableControls() {
             const toggleElement = document.getElementById('isActiveToggle');
             const updateBtn = document.getElementById('updateStatusBtn');
-            
+
             toggleElement.disabled = false;
             updateBtn.disabled = false;
 
             // トグル変更時のイベント
             toggleElement.addEventListener('change', function() {
                 const newStatus = this.checked;
-                const confirmMessage = newStatus 
+                const confirmMessage = newStatus
                     ? 'アプリを有効化しますか？ユーザーがアクセスできるようになります。'
                     : 'アプリを無効化しますか？ユーザーのアクセスが制限されます。';
-                
+
                 if (confirm(confirmMessage)) {
                     updateIsActiveStatus(newStatus);
                 } else {
@@ -366,15 +365,15 @@
             const updateBtn = document.getElementById('updateStatusBtn');
             const updateText = document.getElementById('update-text');
             const updateSpinner = document.getElementById('update-spinner');
-            
+
             try {
                 // ボタン状態を変更
                 updateBtn.disabled = true;
                 updateText.style.display = 'none';
                 updateSpinner.classList.remove('hidden');
-                
+
                 showMessage(isActive ? 'アプリを有効化中...' : 'アプリを無効化中...', 'info');
-                
+
                 google.script.run
                     .withSuccessHandler((result) => {
                         if (result.status === 'success') {
@@ -390,7 +389,7 @@
                         showMessage(`❌ 更新に失敗しました: ${error.message || error}`, 'error');
                     })
                     .updateIsActiveStatus(__USER_ID__, isActive);
-                    
+
             } catch (error) {
                 showMessage(`❌ ${error.message}`, 'error');
             } finally {
@@ -464,7 +463,7 @@
         function toggleUserManagement() {
             const container = document.getElementById('user-list-container');
             const btn = document.getElementById('manage-users-btn');
-            
+
             if (userManagementVisible) {
                 container.classList.add('hidden');
                 btn.textContent = '👥 ユーザー管理を開く';
@@ -481,10 +480,10 @@
         function loadUserList() {
             const loadingDiv = document.getElementById('user-loading');
             const contentDiv = document.getElementById('user-table-content');
-            
+
             loadingDiv.classList.remove('hidden');
             contentDiv.classList.add('hidden');
-            
+
             google.script.run
                 .withSuccessHandler((result) => {
                     if (result.status === 'success') {
@@ -506,11 +505,11 @@
         function displayUserList(users) {
             const tableBody = document.getElementById('user-table-body');
             const contentDiv = document.getElementById('user-table-content');
-            
+
             if (users.length === 0) {
                 tableBody.innerHTML = `
                     <tr>
-                        <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+                        <td colspan="5" class="px-4 py-8 text-center text-secondary">
                             登録ユーザーが見つかりません
                         </td>
                     </tr>
@@ -518,30 +517,30 @@
             } else {
                 tableBody.innerHTML = users.map(user => {
                     const isActive = user.isActive === true || String(user.isActive).toLowerCase() === 'true';
-                    const statusBadge = isActive 
-                        ? '<span class="px-2 py-1 bg-green-600 text-green-100 rounded-full text-xs">アクティブ</span>'
-                        : '<span class="px-2 py-1 bg-red-600 text-red-100 rounded-full text-xs">非アクティブ</span>';
-                    
-                    const lastAccess = user.lastAccessedAt 
+                    const statusBadge = isActive
+                        ? '<span class="px-2 py-1 bg-success text-green-100 rounded-full text-xs">アクティブ</span>'
+                        : '<span class="px-2 py-1 bg-danger text-danger rounded-full text-xs">非アクティブ</span>';
+
+                    const lastAccess = user.lastAccessedAt
                         ? new Date(user.lastAccessedAt).toLocaleDateString('ja-JP')
                         : '不明';
-                    
-                    const registrationDate = user.registrationDate 
+
+                    const registrationDate = user.registrationDate
                         ? new Date(user.registrationDate).toLocaleDateString('ja-JP')
                         : '不明';
-                    
+
                     return `
-                        <tr class="hover:bg-gray-700/50">
+                        <tr class="hover:bg-secondary bg-opacity-50">
                             <td class="px-4 py-3 text-sm text-white">${user.adminEmail}</td>
-                            <td class="px-4 py-3 text-sm text-gray-300">${registrationDate}</td>
+                            <td class="px-4 py-3 text-sm text-light">${registrationDate}</td>
                             <td class="px-4 py-3">${statusBadge}</td>
-                            <td class="px-4 py-3 text-sm text-gray-300">${lastAccess}</td>
+                            <td class="px-4 py-3 text-sm text-light">${lastAccess}</td>
                             <td class="px-4 py-3 text-center">
-                                <button 
+                                <button
                                     data-user-id="${user.userId}"
                                     data-user-email="${user.adminEmail}"
                                     onclick="showDeleteConfirmation(this.dataset.userId, this.dataset.userEmail)"
-                                    class="btn bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-xs">
+                                    class="btn bg-danger hover:bg-danger text-white px-3 py-1 rounded text-xs">
                                     削除
                                 </button>
                             </td>
@@ -549,14 +548,14 @@
                     `;
                 }).join('');
             }
-            
+
             contentDiv.classList.remove('hidden');
         }
 
         // 削除確認モーダルを表示
         function showDeleteConfirmation(userId, userEmail) {
             userToDelete = { userId, userEmail };
-            
+
             document.getElementById('delete-user-email').textContent = userEmail;
             document.getElementById('delete-user-id').textContent = `ID: ${userId}`;
             document.getElementById('deletion-reason').value = '';
@@ -572,17 +571,17 @@
         // 削除を実行
         function confirmDeletion() {
             if (!userToDelete) return;
-            
+
             const reason = document.getElementById('deletion-reason').value.trim();
             if (!reason) {
                 showMessage('削除理由を入力してください', 'warning');
                 return;
             }
-            
+
             const confirmBtn = document.getElementById('confirm-delete-btn');
             confirmBtn.disabled = true;
             confirmBtn.textContent = '削除中...';
-            
+
             google.script.run
                 .withSuccessHandler((result) => {
                     if (result.status === 'success') {
@@ -608,11 +607,11 @@
             const modal = document.getElementById('logs-modal');
             const loadingDiv = document.getElementById('logs-loading');
             const contentDiv = document.getElementById('logs-table-content');
-            
+
             modal.classList.remove('hidden');
             loadingDiv.classList.remove('hidden');
             contentDiv.classList.add('hidden');
-            
+
             google.script.run
                 .withSuccessHandler((result) => {
                     if (result.status === 'success') {
@@ -633,11 +632,11 @@
         function displayDeletionLogs(logs) {
             const tableBody = document.getElementById('logs-table-body');
             const contentDiv = document.getElementById('logs-table-content');
-            
+
             if (logs.length === 0) {
                 tableBody.innerHTML = `
                     <tr>
-                        <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+                        <td colspan="5" class="px-4 py-8 text-center text-secondary">
                             削除ログが見つかりません
                         </td>
                     </tr>
@@ -645,21 +644,21 @@
             } else {
                 tableBody.innerHTML = logs.map(log => {
                     const deleteDate = new Date(log.timestamp).toLocaleString('ja-JP');
-                    const typeColor = log.deleteType === 'admin' ? 'text-red-400' : 'text-blue-400';
+                    const typeColor = log.deleteType === 'admin' ? 'text-danger' : 'text-primary';
                     const typeText = log.deleteType === 'admin' ? '管理者削除' : '自己削除';
-                    
+
                     return `
-                        <tr class="hover:bg-gray-700/50">
-                            <td class="px-4 py-3 text-sm text-gray-300">${deleteDate}</td>
+                        <tr class="hover:bg-secondary bg-opacity-50">
+                            <td class="px-4 py-3 text-sm text-light">${deleteDate}</td>
                             <td class="px-4 py-3 text-sm text-white">${log.executorEmail}</td>
-                            <td class="px-4 py-3 text-sm text-cyan-400">${log.targetEmail}</td>
-                            <td class="px-4 py-3 text-sm text-gray-300">${log.reason || '理由なし'}</td>
+                            <td class="px-4 py-3 text-sm text-info">${log.targetEmail}</td>
+                            <td class="px-4 py-3 text-sm text-light">${log.reason || '理由なし'}</td>
                             <td class="px-4 py-3 text-sm ${typeColor}">${typeText}</td>
                         </tr>
                     `;
                 }).join('');
             }
-            
+
             contentDiv.classList.remove('hidden');
         }
 

--- a/src/SetupPage.html
+++ b/src/SetupPage.html
@@ -17,7 +17,7 @@
             <div class="col-md-8 col-lg-6">
                 <!-- ヘッダー -->
                 <div class="text-center mb-5">
-                    <h1 class="display-4 fw-bold text-cyan-400 mb-2">📚 StudyQuest</h1>
+                    <h1 class="display-4 fw-bold text-info mb-2">📚 StudyQuest</h1>
                     <p class="fs-4 text-light">初回セットアップ</p>
                     <p class="text-muted">システムを使用開始するための設定を行います</p>
                 </div>
@@ -28,17 +28,17 @@
                 <!-- セットアップフォーム -->
                 <div class="glass-panel rounded-3 p-4 mb-4">
                     <h2 class="h4 fw-semibold text-white mb-4">🔧 システム設定</h2>
-                    
+
                     <form id="setup-form">
                         <!-- サービスアカウントJSON -->
                         <div class="mb-3">
                             <label for="service-account-json" class="form-label text-light">
                                 🔑 サービスアカウントJSONキー
                             </label>
-                            <textarea 
-                                id="service-account-json" 
+                            <textarea
+                                id="service-account-json"
                                 name="serviceAccountJson"
-                                rows="8" 
+                                rows="8"
                                 class="form-control bg-dark text-light font-monospace"
                                 style="font-size: 0.75rem; resize: vertical;"
                                 placeholder='{"type": "service_account", "project_id": "...", "private_key_id": "...", ...}'
@@ -51,9 +51,9 @@
                             <label for="database-id" class="form-label text-light">
                                 📊 データベーススプレッドシートID
                             </label>
-                            <input 
-                                type="text" 
-                                id="database-id" 
+                            <input
+                                type="text"
+                                id="database-id"
                                 name="databaseId"
                                 class="form-control bg-dark text-light font-monospace"
                                 placeholder="1BcD3fGhIjKlMnOpQrStUvWxYz0123456789ABCDEFGH"
@@ -65,8 +65,8 @@
 
                         <!-- セットアップボタン -->
                         <div class="d-grid">
-                            <button 
-                                type="submit" 
+                            <button
+                                type="submit"
                                 id="setup-btn"
                                 class="btn btn-primary btn-lg fw-bold"
                                 style="background: linear-gradient(to right, #0891b2, #2563eb); border: none;">
@@ -81,7 +81,7 @@
                 <div id="test-section" class="glass-panel rounded-3 p-4 d-none">
                     <h3 class="h5 fw-semibold text-white mb-3">✅ セットアップ完了</h3>
                     <p class="text-light mb-3">セットアップが正常に完了しました。システムの動作確認を行えます。</p>
-                    <button 
+                    <button
                         id="test-btn"
                         class="btn btn-success fw-bold me-2 mb-2"
                         style="background: linear-gradient(to right, #059669, #10b981); border: none;">
@@ -132,12 +132,12 @@
         function showMessage(message, type = 'info') {
             const messageArea = document.getElementById('message-area');
             const colors = {
-                success: 'bg-green-600/20 border-green-500/50 text-green-100',
-                error: 'bg-red-600/20 border-red-500/50 text-red-100',
-                warning: 'bg-yellow-600/20 border-yellow-500/50 text-yellow-100',
-                info: 'bg-blue-600/20 border-blue-500/50 text-blue-100'
+                success: 'bg-success bg-opacity-25 border-success text-green-100',
+                error: 'bg-danger bg-opacity-25 border-danger text-danger',
+                warning: 'bg-warning bg-opacity-25 border-warning text-warning',
+                info: 'bg-primary bg-opacity-25 border-primary text-primary'
             };
-            
+
             messageArea.innerHTML = `
                 <div class="message show glass-panel rounded-lg p-4 border ${colors[type]}">
                     <div class="flex items-center">
@@ -183,30 +183,30 @@
         // セットアップフォーム送信処理
         document.getElementById('setup-form').addEventListener('submit', async function(e) {
             e.preventDefault();
-            
+
             if (setupInProgress) return;
             setupInProgress = true;
 
             const setupBtn = document.getElementById('setup-btn');
             const setupText = document.getElementById('setup-text');
             const setupSpinner = document.getElementById('setup-spinner');
-            
+
             try {
                 // ボタン状態を変更
                 setupBtn.disabled = true;
                 setupText.style.display = 'none';
                 setupSpinner.classList.remove('hidden');
-                
+
                 // 入力値取得
                 const serviceAccountJson = document.getElementById('service-account-json').value.trim();
                 const databaseId = document.getElementById('database-id').value.trim();
-                
+
                 // バリデーション
                 validateJSON(serviceAccountJson);
                 validateSpreadsheetId(databaseId);
-                
+
                 showMessage('セットアップを実行中...', 'info');
-                
+
                 // セットアップ実行
                 await new Promise((resolve, reject) => {
                     google.script.run
@@ -230,7 +230,7 @@
                         })
                         .setupApplication(serviceAccountJson, databaseId);
                 });
-                
+
             } catch (error) {
                 showMessage(`❌ ${error.message}`, 'error');
             } finally {
@@ -246,7 +246,7 @@
         document.getElementById('test-btn').addEventListener('click', function() {
             this.disabled = true;
             this.innerHTML = '<div class="loading-spinner w-4 h-4 border-2 border-white border-t-transparent rounded-full mx-auto"></div>';
-            
+
             google.script.run
                 .withSuccessHandler((result) => {
                     showMessage(`${result.message}`, result.status === 'success' ? 'success' : 'warning');

--- a/src/SharedModals.html
+++ b/src/SharedModals.html
@@ -49,7 +49,7 @@
 </div>
 
 <!-- プライバシーモーダル -->
-<div id="privacy-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
+<div id="privacy-modal" class="fixed inset-0 bg-black bg-opacity-75 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-lg w-full">
       <div class="flex items-center gap-3 mb-4">
@@ -58,9 +58,9 @@
         </svg>
         <h3 class="text-xl font-bold text-yellow-400">プライバシーとデータ保護</h3>
       </div>
-      <div class="space-y-4 text-gray-300">
+      <div class="space-y-4 text-light">
         <p>このシステムは教育目的でのみ使用されます。</p>
-        <div class="glass-panel bg-yellow-500/10 rounded-lg p-4 border border-yellow-400/30">
+        <div class="glass-panel bg-yellow-500 bg-opacity-10 rounded-lg p-4 border border-yellow-400">
           <h4 class="font-semibold text-yellow-400 mb-2">重要な注意事項</h4>
           <ul class="text-sm space-y-1">
             <li>• 個人情報は適切に保護されます</li>
@@ -79,50 +79,50 @@
 </div>
 
 <!-- デジタルシティズンシップモーダル -->
-<div id="digital-citizenship-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
+<div id="digital-citizenship-modal" class="fixed inset-0 bg-black bg-opacity-75 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-6">
-        <h3 class="text-2xl font-bold text-cyan-400">デジタル・シティズンシップに基づく回答ボード指導</h3>
-        <button type="button" id="digital-citizenship-modal-close" class="p-2 text-gray-400 transition-colors rounded-full hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
+        <h3 class="text-2xl font-bold text-info">デジタル・シティズンシップに基づく回答ボード指導</h3>
+        <button type="button" id="digital-citizenship-modal-close" class="p-2 text-secondary transition-colors rounded-full hover:bg-secondary hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
           </svg>
         </button>
       </div>
-      
-      <div class="space-y-6 text-gray-300">
-        <div class="glass-panel bg-cyan-500/10 rounded-lg p-4 border border-cyan-400/30 mb-4">
-          <h4 class="font-semibold text-cyan-400 mb-2">🌐 デジタル・シティズンシップとは</h4>
+
+      <div class="space-y-6 text-light">
+        <div class="glass-panel bg-cyan-500 bg-opacity-10 rounded-lg p-4 border border-cyan-400 mb-4">
+          <h4 class="font-semibold text-info mb-2">🌐 デジタル・シティズンシップとは</h4>
           <p class="text-sm">デジタル社会における責任ある市民として、技術を適切かつ効果的に使用する能力です。回答ボードを通じて、この重要な概念を実践的に指導しましょう。</p>
         </div>
-        
-        <div class="glass-panel bg-blue-500/10 rounded-lg p-4 border border-blue-400/30">
-          <h4 class="font-semibold text-blue-400 mb-2">📝 デジタル・リテラシーの育成</h4>
+
+        <div class="glass-panel bg-blue-500 bg-opacity-10 rounded-lg p-4 border border-blue-400">
+          <h4 class="font-semibold text-primary mb-2">📝 デジタル・リテラシーの育成</h4>
           <p class="text-sm">適切な質問設計を通じて、学習者がデジタル環境で建設的な議論ができるよう導きましょう。情報を批判的に評価し、根拠に基づいた意見を表現する力を育成します。</p>
         </div>
-        
-        <div class="glass-panel bg-green-500/10 rounded-lg p-4 border border-green-400/30">
+
+        <div class="glass-panel bg-green-500 bg-opacity-10 rounded-lg p-4 border border-green-400">
           <h4 class="font-semibold text-green-400 mb-2">🤝 デジタル・コミュニケーション</h4>
           <p class="text-sm">多様な意見を尊重し、相手の立場を理解する姿勢を重視しましょう。リアクション機能の適切な使い方を指導し、建設的なフィードバック文化を形成します。</p>
         </div>
-        
-        <div class="glass-panel bg-purple-500/10 rounded-lg p-4 border border-purple-400/30">
+
+        <div class="glass-panel bg-purple-500 bg-opacity-10 rounded-lg p-4 border border-purple-400">
           <h4 class="font-semibold text-purple-400 mb-2">🛡️ デジタル・セキュリティと倫理</h4>
           <p class="text-sm">個人情報保護の重要性を学習者に伝え、デジタル環境でのプライバシー意識を高めましょう。名前表示設定を通じて、適切な情報開示について考える機会を提供します。</p>
         </div>
-        
-        <div class="glass-panel bg-red-500/10 rounded-lg p-4 border border-red-400/30">
-          <h4 class="font-semibold text-red-400 mb-2">⚖️ デジタル・責任と法的理解</h4>
+
+        <div class="glass-panel bg-red-500 bg-opacity-10 rounded-lg p-4 border border-red-400">
+          <h4 class="font-semibold text-danger mb-2">⚖️ デジタル・責任と法的理解</h4>
           <p class="text-sm">デジタル空間での行動にも実世界と同様の責任が伴うことを指導しましょう。不適切な投稿への対応を通じて、デジタル環境でのルールとマナーを学ばせます。</p>
         </div>
-        
-        <div class="glass-panel bg-yellow-500/10 rounded-lg p-4 border border-yellow-400/30">
+
+        <div class="glass-panel bg-yellow-500 bg-opacity-10 rounded-lg p-4 border border-yellow-400">
           <h4 class="font-semibold text-yellow-400 mb-2">📊 デジタル・フットプリントと振り返り</h4>
           <p class="text-sm">デジタル活動の記録が残ることを意識させ、学習データを活用した振り返りの価値を伝えましょう。自らの学習過程を客観視する力を育成します。</p>
         </div>
       </div>
-      
+
       <div class="flex justify-end mt-6">
         <button type="button" id="digital-citizenship-modal-close-btn" class="btn btn-primary">理解しました</button>
       </div>
@@ -131,35 +131,35 @@
 </div>
 
 <!-- 教師ガイドモーダル -->
-<div id="teacherGuideModal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
+<div id="teacherGuideModal" class="fixed inset-0 bg-black bg-opacity-75 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-4xl w-full max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-6">
-        <h2 class="text-2xl font-bold text-cyan-400">教師向けガイド</h2>
-        <button type="button" id="teacherGuideModal-close" class="p-2 text-gray-400 transition-colors rounded-full hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
+        <h2 class="text-2xl font-bold text-info">教師向けガイド</h2>
+        <button type="button" id="teacherGuideModal-close" class="p-2 text-secondary transition-colors rounded-full hover:bg-secondary hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
           </svg>
         </button>
       </div>
-      
-      <div class="space-y-6 text-gray-300">
-        <div class="glass-panel bg-blue-500/10 rounded-lg p-4 border border-blue-400/30">
-          <h3 class="font-semibold text-blue-400 mb-2">📚 学習目標の設定</h3>
+
+      <div class="space-y-6 text-light">
+        <div class="glass-panel bg-blue-500 bg-opacity-10 rounded-lg p-4 border border-blue-400">
+          <h3 class="font-semibold text-primary mb-2">📚 学習目標の設定</h3>
           <p class="text-sm">明確な学習目標を設定し、学習者がアクティブに参加できる環境を作りましょう。</p>
         </div>
-        
-        <div class="glass-panel bg-green-500/10 rounded-lg p-4 border border-green-400/30">
+
+        <div class="glass-panel bg-green-500 bg-opacity-10 rounded-lg p-4 border border-green-400">
           <h3 class="font-semibold text-green-400 mb-2">🎯 効果的な質問設計</h3>
           <p class="text-sm">学習者の思考を促進する質問を設計し、多様な回答を引き出しましょう。</p>
         </div>
-        
-        <div class="glass-panel bg-purple-500/10 rounded-lg p-4 border border-purple-400/30">
+
+        <div class="glass-panel bg-purple-500 bg-opacity-10 rounded-lg p-4 border border-purple-400">
           <h3 class="font-semibold text-purple-400 mb-2">📊 データ活用</h3>
           <p class="text-sm">収集したデータを分析し、学習指導の改善に活用しましょう。</p>
         </div>
       </div>
-      
+
       <div class="flex justify-end mt-6">
         <button type="button" id="teacherGuideModal-close-btn" class="btn btn-primary">理解しました</button>
       </div>
@@ -168,7 +168,7 @@
 </div>
 
 <!-- 汎用アラートモーダル -->
-<div id="alert-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
+<div id="alert-modal" class="fixed inset-0 bg-black bg-opacity-75 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-md w-full">
       <div class="flex items-center gap-3 mb-4">
@@ -177,7 +177,7 @@
         </svg>
         <h3 id="alert-modal-title" class="text-xl font-bold"></h3>
       </div>
-      <p id="alert-modal-message" class="text-gray-300 mb-6"></p>
+      <p id="alert-modal-message" class="text-light mb-6"></p>
       <div class="flex justify-end">
         <button type="button" id="alert-modal-close-btn" class="btn btn-primary">OK</button>
       </div>
@@ -186,59 +186,59 @@
 </div>
 
 <!-- ローディングモーダル -->
-<div id="loading-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
+<div id="loading-modal" class="fixed inset-0 bg-black bg-opacity-75 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-md w-full text-center">
       <div class="spinner mx-auto mb-4"></div>
-      <h3 id="loading-modal-title" class="text-xl font-bold text-cyan-400 mb-2">処理中...</h3>
-      <p id="loading-modal-message" class="text-gray-300">しばらくお待ちください</p>
+      <h3 id="loading-modal-title" class="text-xl font-bold text-info mb-2">処理中...</h3>
+      <p id="loading-modal-message" class="text-light">しばらくお待ちください</p>
     </div>
   </div>
 </div>
-        
+
       </div>
 </div>
 
 <!-- セキュリティモーダル -->
-<div id="security-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
+<div id="security-modal" class="fixed inset-0 bg-black bg-opacity-75 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
       <div class="flex items-center justify-between mb-6">
-        <h3 class="text-2xl font-bold text-cyan-400">セキュリティとデータ保護</h3>
-        <button type="button" id="security-modal-close" class="p-2 text-gray-400 transition-colors rounded-full hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
+        <h3 class="text-2xl font-bold text-info">セキュリティとデータ保護</h3>
+        <button type="button" id="security-modal-close" class="p-2 text-secondary transition-colors rounded-full hover:bg-secondary hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
           </svg>
         </button>
       </div>
-      
-      <div class="space-y-6 text-gray-300">
-        <div class="glass-panel bg-blue-500/10 rounded-lg p-4 border border-blue-400/30">
-          <h4 class="font-semibold text-blue-400 mb-2">🔒 データの暗号化と保護</h4>
+
+      <div class="space-y-6 text-light">
+        <div class="glass-panel bg-blue-500 bg-opacity-10 rounded-lg p-4 border border-blue-400">
+          <h4 class="font-semibold text-primary mb-2">🔒 データの暗号化と保護</h4>
           <p class="text-sm">すべてのデータ通信はHTTPS暗号化により保護されており、Google Workspace のセキュリティ基準に準拠しています。学習者の個人情報は適切に保護されます。</p>
         </div>
-        
-        <div class="glass-panel bg-green-500/10 rounded-lg p-4 border border-green-400/30">
+
+        <div class="glass-panel bg-green-500 bg-opacity-10 rounded-lg p-4 border border-green-400">
           <h4 class="font-semibold text-green-400 mb-2">👥 アクセス制御</h4>
           <p class="text-sm">管理者権限により、教師のみがシート設定や公開・非公開の切り替えを行えます。学習者は閲覧と回答のみ可能で、他の学習者のデータを変更することはできません。</p>
         </div>
-        
-        <div class="glass-panel bg-purple-500/10 rounded-lg p-4 border border-purple-400/30">
+
+        <div class="glass-panel bg-purple-500 bg-opacity-10 rounded-lg p-4 border border-purple-400">
           <h4 class="font-semibold text-purple-400 mb-2">📊 データの管理と保存</h4>
           <p class="text-sm">回答データはGoogle スプレッドシートに保存され、学校のGoogle Workspace 管理ポリシーに従って管理されます。データは教育目的でのみ使用されます。</p>
         </div>
-        
-        <div class="glass-panel bg-yellow-500/10 rounded-lg p-4 border border-yellow-400/30">
+
+        <div class="glass-panel bg-yellow-500 bg-opacity-10 rounded-lg p-4 border border-yellow-400">
           <h4 class="font-semibold text-yellow-400 mb-2">🛡️ プライバシー設定</h4>
           <p class="text-sm">名前の表示・非表示、リアクション数の表示設定により、学習環境に応じて適切なプライバシーレベルを設定できます。匿名での議論も可能です。</p>
         </div>
-        
-        <div class="glass-panel bg-red-500/10 rounded-lg p-4 border border-red-400/30">
-          <h4 class="font-semibold text-red-400 mb-2">⚠️ 注意事項</h4>
+
+        <div class="glass-panel bg-red-500 bg-opacity-10 rounded-lg p-4 border border-red-400">
+          <h4 class="font-semibold text-danger mb-2">⚠️ 注意事項</h4>
           <p class="text-sm">機密性の高い個人情報や学外秘の内容は投稿しないよう、学習者に事前に指導してください。適切な利用ガイドラインを設定することが重要です。</p>
         </div>
       </div>
-      
+
       <div class="flex justify-end mt-6">
         <button type="button" id="security-modal-confirm" class="btn btn-primary">理解しました</button>
       </div>
@@ -249,22 +249,22 @@
 <!-- 管理者用モーダル (AdminPanel専用) -->
 
 <!-- フォーム設定モーダル -->
-<div id="form-config-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
+<div id="form-config-modal" class="fixed inset-0 bg-black bg-opacity-75 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto">
       <div class="p-8">
         <div class="flex justify-between items-center mb-6">
-          <h3 class="text-2xl font-bold text-cyan-400">新しいフォームを作成</h3>
-          <button type="button" id="form-config-close" class="p-2 text-gray-400 transition-colors rounded-full hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
+          <h3 class="text-2xl font-bold text-info">新しいフォームを作成</h3>
+          <button type="button" id="form-config-close" class="p-2 text-secondary transition-colors rounded-full hover:bg-secondary hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
             </svg>
           </button>
         </div>
-        
+
         <div class="space-y-6">
           <!-- ステップ0: フォームタイトルの設定 -->
-          <div class="glass-panel bg-cyan-500/5 border border-cyan-400/20 rounded-lg p-4">
+          <div class="glass-panel bg-cyan-500 bg-opacity-10 border border-cyan-400 rounded-lg p-4">
             <div class="flex items-center gap-2 mb-3">
               <div class="w-6 h-6 bg-cyan-500 text-white rounded-full flex items-center justify-center text-sm font-bold">
                 <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
@@ -272,96 +272,96 @@
                   <path d="M6 8h8v2H6V8zm0 4h6v2H6v-2z"/>
                 </svg>
               </div>
-              <h4 class="text-lg font-semibold text-cyan-400">フォームタイトル</h4>
-              <span class="text-xs text-gray-400 bg-gray-700/50 px-2 py-1 rounded">必須</span>
+              <h4 class="text-lg font-semibold text-info">フォームタイトル</h4>
+              <span class="text-xs text-secondary bg-secondary bg-opacity-50 px-2 py-1 rounded">必須</span>
             </div>
-            <input 
-              type="text" 
-              id="custom-form-title" 
-              class="w-full p-3 bg-gray-800/50 border border-gray-600/50 rounded-lg text-white text-sm placeholder-gray-400 focus:border-cyan-400 focus:ring-1 focus:ring-cyan-400 transition-colors" 
+            <input
+              type="text"
+              id="custom-form-title"
+              class="w-full p-3 bg-secondary bg-opacity-50 border border-secondary rounded-lg text-white text-sm placeholder-gray-400 focus:border-cyan-400 focus:ring-1 focus:ring-cyan-400 transition-colors"
               placeholder="例：国語の授業振り返り、理科実験レポート、今日の学習まとめ"
               maxlength="100"
             >
             <div class="flex justify-between items-center mt-2">
-              <p class="text-xs text-gray-400">📝 作成されるフォームのタイトルに使用されます（自動で日時が追加されます）</p>
-              <span class="text-xs text-gray-500" id="title-counter">0/100</span>
+              <p class="text-xs text-secondary">📝 作成されるフォームのタイトルに使用されます（自動で日時が追加されます）</p>
+              <span class="text-xs text-muted" id="title-counter">0/100</span>
             </div>
           </div>
 
           <!-- ステップ1: 問題文の入力 -->
-          <div class="glass-panel bg-blue-500/5 border border-blue-400/20 rounded-lg p-4">
+          <div class="glass-panel bg-blue-500 bg-opacity-10 border border-blue-400 rounded-lg p-4">
             <div class="flex items-center gap-2 mb-3">
               <div class="w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold">1</div>
-              <h4 class="text-lg font-semibold text-blue-400">質問内容を入力</h4>
-              <span class="text-xs text-gray-400 bg-gray-700/50 px-2 py-1 rounded">必須</span>
+              <h4 class="text-lg font-semibold text-primary">質問内容を入力</h4>
+              <span class="text-xs text-secondary bg-secondary bg-opacity-50 px-2 py-1 rounded">必須</span>
             </div>
-            <textarea 
-              id="custom-main-question" 
-              rows="3" 
-              class="w-full p-3 bg-gray-800/50 border border-gray-600/50 rounded-lg text-white text-sm placeholder-gray-400 focus:border-blue-400 focus:ring-1 focus:ring-blue-400 transition-colors" 
+            <textarea
+              id="custom-main-question"
+              rows="3"
+              class="w-full p-3 bg-secondary bg-opacity-50 border border-secondary rounded-lg text-white text-sm placeholder-gray-400 focus:border-blue-400 focus:ring-1 focus:ring-blue-400 transition-colors"
               placeholder="例：今日の授業で学んだことの中で、最も印象に残ったことは何ですか？"
               maxlength="500"
             ></textarea>
             <div class="flex justify-between items-center mt-2">
-              <p class="text-xs text-gray-400">💡 学習者に表示される質問文を入力してください</p>
-              <span class="text-xs text-gray-500" id="question-counter">0/500</span>
+              <p class="text-xs text-secondary">💡 学習者に表示される質問文を入力してください</p>
+              <span class="text-xs text-muted" id="question-counter">0/500</span>
             </div>
           </div>
 
           <!-- ステップ2: 回答方法の選択 -->
-          <div class="glass-panel bg-green-500/5 border border-green-400/20 rounded-lg p-4">
+          <div class="glass-panel bg-green-500 bg-opacity-10 border border-green-400 rounded-lg p-4">
             <div class="flex items-center gap-2 mb-3">
               <div class="w-6 h-6 bg-green-500 text-white rounded-full flex items-center justify-center text-sm font-bold">2</div>
               <h4 class="text-lg font-semibold text-green-400">回答方法を選択</h4>
             </div>
-            <select id="main-question-type" class="w-full p-3 bg-gray-800/50 border border-gray-600/50 rounded-lg text-white text-sm focus:border-green-400 focus:ring-1 focus:ring-green-400 transition-colors" title="回答方法を選択してください">
+            <select id="main-question-type" class="w-full p-3 bg-secondary bg-opacity-50 border border-secondary rounded-lg text-white text-sm focus:border-green-400 focus:ring-1 focus:ring-green-400 transition-colors" title="回答方法を選択してください">
               <option value="choice" selected>選択肢（単一選択）</option>
               <option value="multiple">選択肢（複数選択可）</option>
               <option value="text">短文テキスト（1行回答）</option>
             </select>
-            <p class="text-xs text-gray-400 mt-2">💡 すべての回答方法で、回答の理由を入力する欄が自動的に追加されます</p>
+            <p class="text-xs text-secondary mt-2">💡 すべての回答方法で、回答の理由を入力する欄が自動的に追加されます</p>
           </div>
 
           <!-- 選択肢設定（選択肢タイプの場合） -->
-          <div id="main-question-choices-div" class="glass-panel bg-yellow-500/5 border border-yellow-400/20 rounded-lg p-4">
+          <div id="main-question-choices-div" class="glass-panel bg-yellow-500 bg-opacity-10 border border-yellow-400 rounded-lg p-4">
             <div class="flex items-center gap-2 mb-3">
               <div class="w-6 h-6 bg-yellow-500 text-white rounded-full flex items-center justify-center text-sm font-bold">3</div>
               <h4 class="text-lg font-semibold text-yellow-400">選択肢を設定</h4>
             </div>
-            <textarea id="main-question-choices" rows="4" class="w-full p-3 bg-gray-800/50 border border-gray-600/50 rounded-lg text-white text-sm placeholder-gray-400 focus:border-yellow-400 focus:ring-1 focus:ring-yellow-400 transition-colors" placeholder="例：&#10;気づいたことがある。&#10;疑問に思うことがある。&#10;もっと知りたいことがある。"></textarea>
-            <p class="text-xs text-gray-400 mt-2">💡 学習者が選択できる選択肢を1行に1つずつ入力してください。例のような評価軸や、具体的な選択肢を設定できます。</p>
-            
+            <textarea id="main-question-choices" rows="4" class="w-full p-3 bg-secondary bg-opacity-50 border border-secondary rounded-lg text-white text-sm placeholder-gray-400 focus:border-yellow-400 focus:ring-1 focus:ring-yellow-400 transition-colors" placeholder="例：&#10;気づいたことがある。&#10;疑問に思うことがある。&#10;もっと知りたいことがある。"></textarea>
+            <p class="text-xs text-secondary mt-2">💡 学習者が選択できる選択肢を1行に1つずつ入力してください。例のような評価軸や、具体的な選択肢を設定できます。</p>
+
             <div class="mt-4">
               <label class="flex items-center">
-                <input type="checkbox" id="include-others-option" class="mr-2 rounded bg-gray-700 border-gray-600 text-yellow-500 focus:ring-yellow-400" checked>
-                <span class="text-sm text-gray-300">「その他...」選択肢を追加する</span>
+                <input type="checkbox" id="include-others-option" class="mr-2 rounded bg-secondary border-secondary text-yellow-500 focus:ring-yellow-400" checked>
+                <span class="text-sm text-light">「その他...」選択肢を追加する</span>
               </label>
-              <p class="text-xs text-gray-400 mt-1 ml-6">チェックすると、学習者が自由に回答を入力できる「その他...」オプションが自動的に追加されます</p>
+              <p class="text-xs text-secondary mt-1 ml-6">チェックすると、学習者が自由に回答を入力できる「その他...」オプションが自動的に追加されます</p>
             </div>
           </div>
 
           <!-- ステップ4: クラス設定（オプション） -->
-          <div class="glass-panel bg-purple-500/5 border border-purple-400/20 rounded-lg p-4">
+          <div class="glass-panel bg-purple-500 bg-opacity-10 border border-purple-400 rounded-lg p-4">
             <div class="flex items-center gap-2 mb-3">
               <div class="w-6 h-6 bg-purple-500 text-white rounded-full flex items-center justify-center text-sm font-bold">4</div>
               <h4 class="text-lg font-semibold text-purple-400">クラス設定</h4>
-              <span class="text-xs text-gray-400 bg-gray-700/50 px-2 py-1 rounded">オプション</span>
+              <span class="text-xs text-secondary bg-secondary bg-opacity-50 px-2 py-1 rounded">オプション</span>
             </div>
             <div class="mb-3">
               <label class="flex items-center">
-                <input type="checkbox" id="enable-class-selection" class="mr-2 rounded bg-gray-700 border-gray-600 text-purple-500 focus:ring-purple-400" checked>
-                <span class="text-sm text-gray-300">クラス選択を有効にする</span>
+                <input type="checkbox" id="enable-class-selection" class="mr-2 rounded bg-secondary border-secondary text-purple-500 focus:ring-purple-400" checked>
+                <span class="text-sm text-light">クラス選択を有効にする</span>
               </label>
             </div>
             <div id="class-choices-container">
-              <textarea id="class-choices" rows="3" class="w-full p-3 bg-gray-800/50 border border-gray-600/50 rounded-lg text-white text-sm placeholder-gray-400 focus:border-purple-400 focus:ring-1 focus:ring-purple-400 transition-colors" placeholder="例：&#10;クラス1&#10;クラス2&#10;クラス3&#10;クラス4"></textarea>
-              <p class="text-xs text-gray-400 mt-2">1行に1つずつクラス名を入力してください</p>
+              <textarea id="class-choices" rows="3" class="w-full p-3 bg-secondary bg-opacity-50 border border-secondary rounded-lg text-white text-sm placeholder-gray-400 focus:border-purple-400 focus:ring-1 focus:ring-purple-400 transition-colors" placeholder="例：&#10;クラス1&#10;クラス2&#10;クラス3&#10;クラス4"></textarea>
+              <p class="text-xs text-secondary mt-2">1行に1つずつクラス名を入力してください</p>
             </div>
           </div>
         </div>
 
         <div class="flex gap-3 mt-8">
-          <button type="button" id="form-config-cancel" class="flex-1 px-6 py-3 bg-gray-600/80 text-gray-200 rounded-lg hover:bg-gray-600 transition-colors font-medium">
+          <button type="button" id="form-config-cancel" class="flex-1 px-6 py-3 bg-secondary bg-opacity-75 text-gray-200 rounded-lg hover:bg-secondary transition-colors font-medium">
             キャンセル
           </button>
           <button type="button" id="form-config-create" class="flex-1 px-6 py-3 bg-gradient-to-r from-cyan-500 to-blue-500 text-white rounded-lg hover:from-cyan-600 hover:to-blue-600 transition-colors font-medium shadow-lg">
@@ -374,45 +374,45 @@
 </div>
 
 <!-- セキュリティ詳細モーダル -->
-<div id="security-details-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
+<div id="security-details-modal" class="fixed inset-0 bg-black bg-opacity-75 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
-      <div class="flex justify-between items-center p-6 border-b border-gray-600/30">
+      <div class="flex justify-between items-center p-6 border-b border-secondary">
         <h2 class="text-xl font-semibold text-white">🔒 セキュリティについて</h2>
-        <button type="button" id="security-details-modal-close" class="p-2 text-gray-400 transition-colors rounded-full hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
+        <button type="button" id="security-details-modal-close" class="p-2 text-secondary transition-colors rounded-full hover:bg-secondary hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
           </svg>
         </button>
       </div>
-      
+
       <div class="p-6 space-y-6">
         <!-- データベースアクセス制御 -->
-        <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
-          <h3 class="text-lg font-medium text-cyan-400 mb-4 flex items-center gap-2">
+        <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
+          <h3 class="text-lg font-medium text-info mb-4 flex items-center gap-2">
             🔒 データベースアクセス制御
           </h3>
-          <ul class="space-y-2 text-sm text-gray-300">
+          <ul class="space-y-2 text-sm text-light">
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>限定アクセス：</strong>データベースにアクセスできるのはウェブアプリをデプロイしたユーザーとサービスアカウントのみ
               </div>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>完全非公開設定：</strong>システム上、データベースは非公開設定が必須となっており、外部からのアクセスは一切不可能
               </div>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>個別データ分離：</strong>各ユーザーのデータは専用スプレッドシートで完全分離
               </div>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>自動権限管理：</strong>サービスアカウントへの編集権限付与を自動実行
               </div>
@@ -421,31 +421,31 @@
         </div>
 
         <!-- 多層セキュリティ対策 -->
-        <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
-          <h3 class="text-lg font-medium text-cyan-400 mb-4 flex items-center gap-2">
+        <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
+          <h3 class="text-lg font-medium text-info mb-4 flex items-center gap-2">
             🛡️ 多層セキュリティ対策
           </h3>
-          <ul class="space-y-2 text-sm text-gray-300">
+          <ul class="space-y-2 text-sm text-light">
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>暗号化認証：</strong>JWT ベースのサービスアカウント認証とトークン自動更新
               </div>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>ドメイン制限：</strong>組織展開時のドメインベースアクセス制御
               </div>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>入力検証：</strong>全入力データの包括的検証とサニタイゼーション
               </div>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>監査ログ：</strong>システム活動の完全追跡とログ記録
               </div>
@@ -454,25 +454,25 @@
         </div>
 
         <!-- ユーザー保護 -->
-        <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
-          <h3 class="text-lg font-medium text-cyan-400 mb-4 flex items-center gap-2">
+        <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
+          <h3 class="text-lg font-medium text-info mb-4 flex items-center gap-2">
             👥 ユーザー保護
           </h3>
-          <ul class="space-y-2 text-sm text-gray-300">
+          <ul class="space-y-2 text-sm text-light">
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>学習者データ保護：</strong>一般ユーザーは他の回答者データや基盤データベースにアクセス不可
               </div>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>管理者権限分離：</strong>階層的アクセスレベルによる適切な権限管理
               </div>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-cyan-400">•</span>
+              <span class="text-info">•</span>
               <div>
                 <strong>セッションセキュリティ：</strong>自動クリーンアップ機能付きセキュアセッション管理
               </div>
@@ -481,7 +481,7 @@
         </div>
 
         <!-- 重要事項 -->
-        <div class="bg-blue-900/20 border border-blue-500/30 rounded-lg p-4">
+        <div class="bg-blue-900 bg-opacity-25 border border-primary rounded-lg p-4">
           <h3 class="text-lg font-medium text-blue-300 mb-3 flex items-center gap-2">
             📋 重要
           </h3>
@@ -490,8 +490,8 @@
           </p>
         </div>
       </div>
-      
-      <div class="p-6 border-t border-gray-600/30 text-center">
+
+      <div class="p-6 border-t border-secondary text-center">
         <button type="button" id="security-details-modal-confirm" class="btn btn-primary">閉じる</button>
       </div>
     </div>
@@ -499,21 +499,21 @@
 </div>
 
 <!-- Google連携の利点モーダル -->
-<div id="google-integration-modal" class="fixed inset-0 bg-black/80 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
+<div id="google-integration-modal" class="fixed inset-0 bg-black bg-opacity-75 z-50 hidden flex items-center justify-center" role="dialog" aria-modal="true">
   <div class="flex items-center justify-center min-h-full p-4">
     <div class="glass-panel rounded-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
-      <div class="flex justify-between items-center p-6 border-b border-gray-600/30">
+      <div class="flex justify-between items-center p-6 border-b border-secondary">
         <h2 class="text-xl font-semibold text-white">📊 Google連携の利点</h2>
-        <button type="button" id="google-integration-modal-close" class="p-2 text-gray-400 transition-colors rounded-full hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
+        <button type="button" id="google-integration-modal-close" class="p-2 text-secondary transition-colors rounded-full hover:bg-secondary hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500" aria-label="閉じる">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
           </svg>
         </button>
       </div>
-      
+
       <div class="p-6 space-y-4">
-        <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
-          <ul class="space-y-3 text-sm text-gray-300">
+        <div class="bg-secondary bg-opacity-25 border border-secondary rounded-lg p-4">
+          <ul class="space-y-3 text-sm text-light">
             <li class="flex items-start gap-2">
               <span class="text-green-400">•</span>
               <div>
@@ -547,8 +547,8 @@
           </ul>
         </div>
       </div>
-      
-      <div class="p-6 border-t border-gray-600/30 text-center">
+
+      <div class="p-6 border-t border-secondary text-center">
         <button type="button" id="google-integration-modal-confirm" class="btn btn-primary">閉じる</button>
       </div>
     </div>
@@ -594,7 +594,7 @@ class SharedModals {
 
     titleEl.textContent = title;
     messageEl.textContent = message;
-    
+
     modal.classList.remove('hidden');
     modal.classList.add('flex');
 
@@ -603,7 +603,7 @@ class SharedModals {
       this.hideModal('confirmation-modal');
       if (onConfirm) onConfirm();
     };
-    
+
     cancelBtn.onclick = () => {
       this.hideModal('confirmation-modal');
       if (onCancel) onCancel();
@@ -626,22 +626,22 @@ class SharedModals {
 
     titleEl.textContent = title;
     messageEl.textContent = message;
-    
+
     // アイコンとカラーを設定
     const typeConfig = {
-      info: { color: 'text-blue-400', icon: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' },
+      info: { color: 'text-primary', icon: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' },
       success: { color: 'text-green-400', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
       warning: { color: 'text-yellow-400', icon: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z' },
-      error: { color: 'text-red-400', icon: 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' }
+      error: { color: 'text-danger', icon: 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z' }
     };
-    
+
     const config = typeConfig[type] || typeConfig.info;
     titleEl.className = `text-xl font-bold ${config.color}`;
     iconEl.className = `w-8 h-8 ${config.color}`;
     iconEl.querySelector('path').setAttribute('d', config.icon);
-    
+
     modal.classList.remove('hidden');
-    
+
     closeBtn.onclick = () => this.hideModal('alert-modal');
   }
 
@@ -650,10 +650,10 @@ class SharedModals {
     const modal = document.getElementById('loading-modal');
     const titleEl = document.getElementById('loading-modal-title');
     const messageEl = document.getElementById('loading-modal-message');
-    
+
     if (titleEl) titleEl.textContent = title;
     if (messageEl) messageEl.textContent = message;
-    
+
     if (modal) modal.classList.remove('hidden');
   }
 
@@ -684,7 +684,7 @@ class SharedModals {
           'security-details-modal',
           'google-integration-modal'
         ];
-        
+
         modals.forEach(modalId => {
           const modal = document.getElementById(modalId);
           if (modal && !modal.classList.contains('hidden')) {
@@ -709,7 +709,7 @@ class SharedModals {
       'google-integration-modal-close',
       'google-integration-modal-confirm'
     ];
-    
+
     closeButtons.forEach(buttonId => {
       const button = document.getElementById(buttonId);
       if (button) {
@@ -739,19 +739,19 @@ class SharedModals {
       console.error('プライバシーモーダルが見つかりません');
       return;
     }
-    
+
     modal.classList.remove('hidden');
-    
+
     const continueBtn = document.getElementById('privacy-modal-continue');
     const cancelBtn = document.getElementById('privacy-modal-cancel');
-    
+
     if (continueBtn) {
       continueBtn.onclick = () => {
         this.hideModal('privacy-modal');
         if (onContinue) onContinue();
       };
     }
-    
+
     if (cancelBtn) {
       cancelBtn.onclick = () => {
         this.hideModal('privacy-modal');
@@ -766,7 +766,7 @@ class SharedModals {
       console.error('デジタル・シティズンシップモーダルが見つかりません');
       return;
     }
-    
+
     modal.classList.remove('hidden');
   }
 
@@ -778,7 +778,7 @@ class SharedModals {
       console.error('フォーム設定モーダルが見つかりません');
       return;
     }
-    
+
     modal.classList.remove('hidden');
     modal.classList.add('flex');
   }
@@ -791,7 +791,7 @@ class SharedModals {
       console.error('セキュリティ詳細モーダルが見つかりません');
       return;
     }
-    
+
     modal.classList.remove('hidden');
     modal.classList.add('flex');
   }
@@ -804,7 +804,7 @@ class SharedModals {
       console.error('Google連携モーダルが見つかりません');
       return;
     }
-    
+
     modal.classList.remove('hidden');
     modal.classList.add('flex');
   }

--- a/src/Unpublished.html
+++ b/src/Unpublished.html
@@ -6,7 +6,6 @@
     <title>StudyQuest -みんなの回答ボード- - 準備中</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- TailwindCSS CDN -->
-    <script src="https://cdn.tailwindcss.com"></script>
     <?= include('UnifiedStyles'); ?>
     <?= include('SharedUtilities'); ?>
     <style>
@@ -35,53 +34,53 @@
                 <!-- メインステータス -->
                 <div class="glass-panel rounded-2xl p-8 shadow-2xl mb-8">
                     <div class="mb-6">
-                        <div class="w-24 h-24 mx-auto mb-4 rounded-full bg-gradient-to-r from-yellow-500/20 to-orange-500/20 flex items-center justify-center border-2 border-yellow-400/30 pulse-slow">
+                        <div class="w-24 h-24 mx-auto mb-4 rounded-full bg-gradient-to-r from-yellow-500/20 to-orange-500/20 flex items-center justify-center border-2 border-yellow-400 pulse-slow">
                             <svg class="w-12 h-12 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
                             </svg>
                         </div>
                         <h1 class="text-3xl font-bold mb-2 text-yellow-300">回答ボード準備中</h1>
-                        <p class="text-gray-400 text-lg">現在、回答ボードは非公開になっています</p>
+                        <p class="text-secondary text-lg">現在、回答ボードは非公開になっています</p>
                     </div>
-                    
+
                     <? if (typeof ownerName !== 'undefined' && ownerName) { ?>
-                    <div class="mb-6 p-3 bg-gray-700/50 rounded-lg">
-                        <p class="text-sm text-gray-300">管理者: <span class="text-cyan-400 font-medium"><?= ownerName ?></span></p>
+                    <div class="mb-6 p-3 bg-secondary bg-opacity-50 rounded-lg">
+                        <p class="text-sm text-light">管理者: <span class="text-info font-medium"><?= ownerName ?></span></p>
                     </div>
                     <? } ?>
-                    
+
                     <!-- ステータス情報 -->
                     <div class="grid md:grid-cols-2 gap-4 mb-8">
-                        <div class="bg-gray-700/30 rounded-lg p-4">
+                        <div class="bg-secondary bg-opacity-25 rounded-lg p-4">
                             <div class="flex items-center gap-2 mb-2">
                                 <div class="w-3 h-3 rounded-full bg-red-500"></div>
                                 <span class="text-sm font-medium">公開状態</span>
                             </div>
-                            <p class="text-gray-400 text-sm">非公開（学習者はアクセスできません）</p>
+                            <p class="text-secondary text-sm">非公開（学習者はアクセスできません）</p>
                         </div>
-                        <div class="bg-gray-700/30 rounded-lg p-4">
+                        <div class="bg-secondary bg-opacity-25 rounded-lg p-4">
                             <div class="flex items-center gap-2 mb-2">
                                 <div class="w-3 h-3 rounded-full bg-blue-500"></div>
                                 <span class="text-sm font-medium">システム状態</span>
                             </div>
-                            <p class="text-gray-400 text-sm">待機中（いつでも再公開可能）</p>
+                            <p class="text-secondary text-sm">待機中（いつでも再公開可能）</p>
                         </div>
                     </div>
                 </div>
 
                 <!-- 管理者向けコントロール -->
                 <div class="admin-controls rounded-2xl p-6 mb-6">
-                    <h2 class="text-xl font-bold mb-4 text-cyan-300 flex items-center justify-center gap-2">
+                    <h2 class="text-xl font-bold mb-4 text-info flex items-center justify-center gap-2">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
                         </svg>
                         管理者コントロール
                     </h2>
-                    
+
                     <div class="grid md:grid-cols-2 gap-4">
                         <!-- 再公開ボタン -->
-                        <button type="button" id="republish-btn" 
+                        <button type="button" id="republish-btn"
                                 class="group btn btn-success px-4 py-3 rounded-3 fw-semibold hover-scale-105 btn-gradient-hover shadow-lg" style="background: linear-gradient(135deg, #10b981, #059669);">
                             <div class="flex items-center justify-center gap-2">
                                 <svg class="w-5 h-5 group-hover:rotate-12 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -91,9 +90,9 @@
                             </div>
                             <p class="text-xs mt-1 opacity-80">既存の設定で即座に公開</p>
                         </button>
-                        
+
                         <!-- 管理パネルボタン -->
-                        <button type="button" id="admin-panel-btn" 
+                        <button type="button" id="admin-panel-btn"
                                 class="group btn btn-info px-4 py-3 rounded-3 fw-semibold hover-scale-105 btn-gradient-hover shadow-lg" style="background: linear-gradient(135deg, #0891b2, #0e7490);">
                             <div class="flex items-center justify-center gap-2">
                                 <svg class="w-5 h-5 group-hover:rotate-12 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -114,19 +113,19 @@
                         </svg>
                         学習者用URL
                     </h3>
-                    <div class="bg-gray-700/50 rounded-lg p-4">
+                    <div class="bg-secondary bg-opacity-50 rounded-lg p-4">
                         <div class="flex gap-2 mb-2">
                             <input type="text" id="board-url" readonly value="<?= typeof boardUrl !== 'undefined' ? boardUrl : '' ?>"
-                                   class="flex-1 p-3 bg-gray-600 border border-gray-500 rounded-lg text-sm cursor-pointer hover:bg-gray-500 transition-colors"
+                                   class="flex-1 p-3 bg-secondary border border-secondary rounded-lg text-sm cursor-pointer hover:bg-secondary transition-colors"
                                    onclick="this.select()">
-                            <button type="button" onclick="copyBoardUrl()" 
-                                    class="px-4 py-3 bg-cyan-600 hover:bg-cyan-700 rounded-lg text-sm font-medium transition-colors">
+                            <button type="button" onclick="copyBoardUrl()"
+                                    class="px-4 py-3 bg-info hover:bg-info rounded-lg text-sm font-medium transition-colors">
                               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                               </svg>
                             </button>
                         </div>
-                        <p class="text-xs text-gray-400">このURLは固定です。再公開後、学習者は同じURLでアクセスできます。</p>
+                        <p class="text-xs text-secondary">このURLは固定です。再公開後、学習者は同じURLでアクセスできます。</p>
                     </div>
                 </div>
             </div>
@@ -134,29 +133,29 @@
             <!-- 一般ユーザー用画面 -->
             <div class="text-center fade-in">
                 <div class="glass-panel rounded-2xl p-8 shadow-2xl">
-                    <div class="w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-r from-yellow-500/20 to-orange-500/20 flex items-center justify-center border-2 border-yellow-400/30 pulse-slow">
+                    <div class="w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-r from-yellow-500/20 to-orange-500/20 flex items-center justify-center border-2 border-yellow-400 pulse-slow">
                         <svg class="w-10 h-10 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                         </svg>
                     </div>
                     <h1 class="text-4xl font-bold mb-4 text-yellow-300">準備中です</h1>
-                    <p class="text-gray-400 mb-6 text-lg">先生が回答ボードを準備中です。<br>しばらくお待ちください。</p>
-                    
+                    <p class="text-secondary mb-6 text-lg">先生が回答ボードを準備中です。<br>しばらくお待ちください。</p>
+
                     <? if (typeof ownerName !== 'undefined' && ownerName) { ?>
-                    <div class="mb-6 p-3 bg-gray-700/50 rounded-lg">
-                        <p class="text-sm text-gray-300">担当: <span class="text-cyan-400"><?= ownerName ?></span></p>
+                    <div class="mb-6 p-3 bg-secondary bg-opacity-50 rounded-lg">
+                        <p class="text-sm text-light">担当: <span class="text-info"><?= ownerName ?></span></p>
                     </div>
                     <? } ?>
-                    
+
                     <div class="space-y-4">
-                        <button type="button" onclick="location.reload()" 
-                                class="px-6 py-3 bg-cyan-600 hover:bg-cyan-700 rounded-lg font-semibold transition-colors flex items-center gap-2 mx-auto">
+                        <button type="button" onclick="location.reload()"
+                                class="px-6 py-3 bg-info hover:bg-info rounded-lg font-semibold transition-colors flex items-center gap-2 mx-auto">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                             </svg>
                             更新して確認
                         </button>
-                        <p class="text-xs text-gray-500">準備ができたらこのページに回答ボードが表示されます</p>
+                        <p class="text-xs text-muted">準備ができたらこのページに回答ボードが表示されます</p>
                     </div>
                 </div>
             </div>
@@ -192,27 +191,27 @@
             const messageArea = document.getElementById('message-area');
             if (messageArea) {
                 const colors = {
-                    success: 'bg-green-600 border-green-500',
-                    error: 'bg-red-600 border-red-500', 
-                    info: 'bg-blue-600 border-blue-500',
-                    warning: 'bg-yellow-600 border-yellow-500'
+                    success: 'bg-success border-success',
+                    error: 'bg-danger border-danger',
+                    info: 'bg-primary border-primary',
+                    warning: 'bg-yellow-600 border-warning'
                 };
-                
+
                 const messageDiv = document.createElement('div');
                 messageDiv.className = `${colors[type] || colors.info} text-white px-4 py-3 rounded-lg shadow-lg border-l-4 mb-2 transform transition-all duration-300 translate-x-0`;
                 messageDiv.innerHTML = `
                     <div class="flex items-center gap-2">
                         <span class="font-medium">${message}</span>
-                        <button onclick="this.parentElement.parentElement.remove()" class="ml-auto hover:bg-white/20 rounded p-1">
+                        <button onclick="this.parentElement.parentElement.remove()" class="ml-auto hover:bg-white bg-opacity-25 rounded p-1">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                             </svg>
                         </button>
                     </div>
                 `;
-                
+
                 messageArea.appendChild(messageDiv);
-                
+
                 // Auto remove after 4 seconds
                 setTimeout(() => {
                     if (messageDiv.parentElement) {
@@ -230,7 +229,7 @@
         document.getElementById('republish-btn')?.addEventListener('click', function() {
             const button = this;
             const originalHTML = button.innerHTML;
-            
+
             // ローディング状態に変更
             button.disabled = true;
             button.classList.remove('hover-scale-105');
@@ -242,9 +241,9 @@
                     <span>再公開中...</span>
                 </div>
             `;
-            
+
             showMessage('回答ボードを再公開しています...', 'info');
-            
+
             // サーバーに再公開リクエスト
             google.script.run
                 .withSuccessHandler((result) => {
@@ -261,11 +260,11 @@
                 })
                 .republishBoard();
         });
-        
+
         // 管理パネルボタン
         document.getElementById('admin-panel-btn')?.addEventListener('click', function() {
             showMessage('管理パネルに移動しています...', 'info');
-            
+
             // 管理パネルURLに移動
             <? if (typeof adminPanelUrl !== 'undefined' && adminPanelUrl) { ?>
             window.location.href = '<?= adminPanelUrl ?>';


### PR DESCRIPTION
## Summary
- drop Tailwind CDN scripts
- convert leftover Tailwind classes to Bootstrap utilities
- update message color helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d88ec02c8832b8f6cd2e8eb38e08c