### PR TITLE
Fix custom form edit URL handling

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -2071,16 +2071,18 @@ function createFormFactory(options) {
     // フォーム作成
     var form = FormApp.create(formTitle);
     form.setDescription(formDescription);
-    
+
     // 基本的な質問を追加
     addUnifiedQuestions(form, options.questions || 'default', options.customConfig || {});
-    
+
     // スプレッドシート作成
     var spreadsheetResult = createLinkedSpreadsheet(userEmail, form, dateTimeString);
-    
+
     return {
       formId: form.getId(),
       formUrl: form.getPublishedUrl(),
+      viewFormUrl: form.getPublishedUrl(),
+      editFormUrl: typeof form.getEditUrl === 'function' ? form.getEditUrl() : '',
       spreadsheetId: spreadsheetResult.spreadsheetId,
       spreadsheetUrl: spreadsheetResult.spreadsheetUrl,
       sheetName: spreadsheetResult.sheetName

--- a/tests/createFormFactory.test.js
+++ b/tests/createFormFactory.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('createFormFactory returns URLs', () => {
+  const code = fs.readFileSync('src/Core.gs', 'utf8');
+  let context;
+
+  beforeEach(() => {
+    const mockItem = {
+      setTitle: jest.fn(),
+      setRequired: jest.fn(),
+      setChoiceValues: jest.fn(),
+      showOtherOption: jest.fn(),
+      setHelpText: jest.fn()
+    };
+    const mockForm = {
+      setDescription: jest.fn(),
+      setCollectEmail: jest.fn(),
+      addTextItem: jest.fn(() => mockItem),
+      addCheckboxItem: jest.fn(() => mockItem),
+      addListItem: jest.fn(() => mockItem),
+      addMultipleChoiceItem: jest.fn(() => mockItem),
+      addParagraphTextItem: jest.fn(() => mockItem),
+      getId: jest.fn(() => 'FORM_ID'),
+      getPublishedUrl: jest.fn(() => 'https://example.com/view'),
+      getEditUrl: jest.fn(() => 'https://example.com/edit')
+    };
+
+    context = {
+      console,
+      debugLog: () => {},
+      FormApp: { create: jest.fn(() => mockForm) },
+      Utilities: { formatDate: jest.fn(() => '2025/01/01 00:00:00') }
+    };
+    vm.createContext(context);
+    vm.runInContext(code, context);
+    context.createLinkedSpreadsheet = jest.fn(() => ({
+      spreadsheetId: 'SS_ID',
+      spreadsheetUrl: 'https://example.com/ss',
+      sheetName: 'Sheet1'
+    }));
+  });
+
+  test('returns editFormUrl and viewFormUrl', () => {
+    const result = context.createFormFactory({
+      userEmail: 'u@example.com',
+      userId: 'uid',
+      formTitle: 'Title'
+    });
+    expect(result.editFormUrl).toBe('https://example.com/edit');
+    expect(result.viewFormUrl).toBe('https://example.com/view');
+    expect(result.formUrl).toBe('https://example.com/view');
+  });
+});
+


### PR DESCRIPTION
## Summary
- return edit URL from `createFormFactory`
- test that the edit and view URLs are included

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd3a25774832b87b4d399dfcbcc71