### PR TITLE
Fix fallback fetch to restore new card rendering

### DIFF
--- a/src/page.js.html
+++ b/src/page.js.html
@@ -2164,12 +2164,12 @@ class StudyQuestApp {
                       google.script.run
                         .withSuccessHandler(resolve)
                         .withFailureHandler(reject)
-                        .getStudentData(
-                          this.state.userId, 
-                          classFilter, 
+                        .getPublishedSheetData(
+                          this.state.userId,
+                          classFilter,
                           this.elements.sortOrder ? this.elements.sortOrder.value : 'newest',
                           this.state.showAdminFeatures,
-                          requestedSheetName
+                          true
                         );
                     });
                     


### PR DESCRIPTION
## Summary
- correct the fallback data retrieval function used when initial board load fails
- run npm install and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688467cbcb88832b9587c07a6935ebda