### PR TITLE
Fix auto-stop modal

### DIFF
--- a/src/SharedModals.html
+++ b/src/SharedModals.html
@@ -721,7 +721,12 @@ class SharedModals {
 
   // 管理者専用モーダルの読み込み
   loadAdminModals() {
-    this.loadModals(['form-config-modal', 'security-details-modal', 'google-integration-modal']);
+    this.loadModals([
+      'form-config-modal',
+      'security-details-modal',
+      'google-integration-modal',
+      'auto-stop-confirmation-modal'
+    ]);
   }
 
   // 確認モーダルの表示
@@ -918,6 +923,8 @@ class SharedModals {
 
   // 6時間自動停止確認モーダルの表示
   showAutoStopConfirmation(publishResult) {
+    this.loadModals(['auto-stop-confirmation-modal']);
+
     const modal = document.getElementById('auto-stop-confirmation-modal');
     if (!modal) {
       console.error('自動停止確認モーダルが見つかりません');
@@ -927,7 +934,8 @@ class SharedModals {
     // 公開時間と停止時間の設定
     if (publishResult && publishResult.publishedAt) {
       const publishTime = new Date(publishResult.publishedAt);
-      const stopTime = new Date(publishTime.getTime() + (360 * 60 * 1000)); // 6時間後
+      const minutes = publishResult.autoStopMinutes || 360;
+      const stopTime = new Date(publishTime.getTime() + (minutes * 60 * 1000));
       
       document.getElementById('publish-start-time').textContent = publishTime.toLocaleString('ja-JP');
       document.getElementById('auto-stop-time').textContent = stopTime.toLocaleString('ja-JP');

--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -387,10 +387,14 @@ function proceedWithSaveAndPublish(config) {
         
         // 6時間自動停止の確認モーダルを表示
         setTimeout(() => {
-          if (typeof showAutoStopConfirmationModal === 'function' && result.userInfo) {
+          if (window.sharedModals && typeof window.sharedModals.loadModals === 'function') {
+            window.sharedModals.loadModals(['auto-stop-confirmation-modal']);
+          }
+
+          if (typeof window.showAutoStopConfirmationModal === 'function' && result.userInfo) {
             const configJson = JSON.parse(result.userInfo.configJson || '{}');
             if (configJson.publishedAt && configJson.autoStopEnabled) {
-              showAutoStopConfirmationModal({
+              window.showAutoStopConfirmationModal({
                 publishedAt: configJson.publishedAt,
                 autoStopMinutes: configJson.autoStopMinutes || 360
               });


### PR DESCRIPTION
## Summary
- load auto-stop confirmation modal with other admin modals
- use configured auto-stop minutes when computing stop time
- ensure auto-stop modal is prepared before showing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688471d4fd68832b9bc54e310681d15e