### PR TITLE
Fix email column placement for new forms

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -2263,8 +2263,22 @@ function createFormFactory(options) {
     // 基本的な質問を追加
     addUnifiedQuestions(form, options.questions || 'default', options.customConfig || {});
 
+    // メールアドレス収集を有効化（スプレッドシート連携前に設定）
+    try {
+      if (typeof form.setEmailCollectionType === 'function') {
+        form.setEmailCollectionType(FormApp.EmailCollectionType.VERIFIED);
+      } else {
+        form.setCollectEmail(true);
+      }
+    } catch (emailError) {
+      console.warn('Email collection setting failed:', emailError.message);
+    }
+
     // スプレッドシート作成
     var spreadsheetResult = createLinkedSpreadsheet(userEmail, form, dateString);
+
+    // リアクション関連列を追加
+    addReactionColumnsToSpreadsheet(spreadsheetResult.spreadsheetId, spreadsheetResult.sheetName);
 
     return {
       formId: form.getId(),
@@ -2870,9 +2884,6 @@ function createStudyQuestForm(userEmail, userId, formTitle, questionType) {
       console.warn('サービスアカウント追加に失敗しましたが、処理を継続します:', serviceAccountError.message);
       // 権限エラーの場合でも、フォーム作成自体は成功とみなす
     }
-    
-    // リアクション列をスプレッドシートに追加
-    addReactionColumnsToSpreadsheet(formResult.spreadsheetId, formResult.sheetName);
     
     profiler.end('createForm');
     

--- a/tests/createFormFactory.test.js
+++ b/tests/createFormFactory.test.js
@@ -16,6 +16,7 @@ describe('createFormFactory returns URLs', () => {
     const mockForm = {
       setDescription: jest.fn(),
       setCollectEmail: jest.fn(),
+      setEmailCollectionType: jest.fn(),
       addTextItem: jest.fn(() => mockItem),
       addCheckboxItem: jest.fn(() => mockItem),
       addListItem: jest.fn(() => mockItem),
@@ -29,7 +30,10 @@ describe('createFormFactory returns URLs', () => {
     context = {
       console,
       debugLog: () => {},
-      FormApp: { create: jest.fn(() => mockForm) },
+      FormApp: {
+        create: jest.fn(() => mockForm),
+        EmailCollectionType: { VERIFIED: 'VERIFIED' }
+      },
       Utilities: { formatDate: jest.fn(() => '2025/01/01 00:00:00') }
     };
     vm.createContext(context);
@@ -39,6 +43,7 @@ describe('createFormFactory returns URLs', () => {
       spreadsheetUrl: 'https://example.com/ss',
       sheetName: 'Sheet1'
     }));
+    context.addReactionColumnsToSpreadsheet = jest.fn();
   });
 
   test('returns editFormUrl and viewFormUrl', () => {


### PR DESCRIPTION
## Summary
- ensure email collection is enabled before linking spreadsheet
- add reaction and highlight columns at the same time as linking
- adjust test mocks for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884794be078832b977424cb72da9780