### PR TITLE
Fix board state residue on switch

### DIFF
--- a/src/page.js.html
+++ b/src/page.js.html
@@ -1891,7 +1891,36 @@ class StudyQuestApp {
     console.log('safeDisplayEmptyState: 条件を満たしたため空状態を表示します');
     this.displayEmptyState();
   }
-  
+
+  /**
+   * 回答ボードの状態をリセットし、表示をクリアする
+   * @param {string} reason - リセットの理由をログに出力するための文字列
+   */
+  resetBoardState(reason = 'Unknown') {
+    console.log(`🔄 ボードの状態をリセットします。理由: ${reason}`);
+
+    // 1. DOMからすべてのカードを削除
+    const container = this.elements.answersContainer;
+    if (container) {
+      container.innerHTML = '';
+      console.log('🗑️ DOMから全カードを削除しました。');
+    }
+
+    // 2. 内部の回答データをリセット
+    this.state.currentAnswers = [];
+
+    // 3. リアクション状態もクリア
+    this.state.reactionStates = {};
+
+    // 4. lastSeenCountも0にリセット (ボードごとに管理するため)
+    this.updateLastSeenCount(0);
+
+    // 5. 差分カード情報もクリア
+    this.clearDifferentialCards();
+
+    console.log('✅ ボードのリセットが完了しました。');
+  }
+
   clearAllCardsForEmptyData() {
     console.log('🗑️ clearAllCardsForEmptyData: 空データ受信のため全カードをクリアします');
     
@@ -2132,6 +2161,16 @@ class StudyQuestApp {
       requestedSheetName: options.requestedSheetName || null,
       ...options
     };
+
+    // ボード切り替え判定
+    const isSwitchingBoards =
+      config.requestedSheetName &&
+      config.requestedSheetName !== this.state.currentActiveSheet;
+    if (isSwitchingBoards) {
+      this.resetBoardState(
+        `ボード切り替え (${this.state.currentActiveSheet} -> ${config.requestedSheetName})`
+      );
+    }
     
     // Prevent concurrent loading
     if (this.state.isLoading && config.showLoading) {


### PR DESCRIPTION
## Summary
- add `resetBoardState` helper to fully clear cards and state
- call reset before loading data when switching boards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884b53064b0832ba67ba2ee6307824b