### PR TITLE
Fix delete account userId pass

### DIFF
--- a/src/adminPanel-events.js.html
+++ b/src/adminPanel-events.js.html
@@ -347,7 +347,7 @@ function handleDeleteRequest() {
     'アカウント削除の確認',
     '本当にこのアカウントを削除しますか？この操作は元に戻せず、すべてのデータが失われます。',
     function() {
-      sharedUtilities.gas.callWithLoading('deleteCurrentUserAccount', 'アカウントを完全に削除しています...', 'overlay')
+      runGasWithUserId('deleteCurrentUserAccount', 'アカウントを完全に削除しています...')
         .then(function(response) {
           showMessage(response.message || 'アカウントが削除されました', 'success');
           if (window.unifiedCache && typeof window.unifiedCache.clear === 'function') {


### PR DESCRIPTION
## Summary
- ensure delete account calls runGasWithUserId so userId is passed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884c55bbd34832bb7c888d3710cce9d