### PR TITLE
Fix updateUser to allow isActive changes

### DIFF
--- a/src/database.gs
+++ b/src/database.gs
@@ -761,7 +761,8 @@ function updateUser(userId, updateData) {
   }
   
   // 許可されたフィールドのホワイトリスト検証
-  const allowedFields = ['adminEmail', 'spreadsheetId', 'spreadsheetUrl', 'configJson', 'lastAccessedAt', 'createdAt', 'formUrl'];
+  const allowedFields = ['adminEmail', 'spreadsheetId', 'spreadsheetUrl',
+    'configJson', 'lastAccessedAt', 'createdAt', 'formUrl', 'isActive'];
   const updateFields = Object.keys(updateData);
   const invalidFields = updateFields.filter(field => !allowedFields.includes(field));
   


### PR DESCRIPTION
## Summary
- permit `isActive` updates in `updateUser`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884c848b008832b8b71a1cd31514da2