### PR TITLE
Fix stray method call causing sheet load failure

### DIFF
--- a/src/page.js.html
+++ b/src/page.js.html
@@ -2515,7 +2515,7 @@ class StudyQuestApp {
             this.hideLoadingOverlay();
           }
         })
-        .getPublishedSheetData(this.state.userId, classFilter, sortOrder, this.state.showAdminFeatures, false);
+        ;
       
       
       // Post-processing after successful data load


### PR DESCRIPTION
## Summary
- remove extraneous `getPublishedSheetData` call after promise chain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688534759edc832bb969775eb7bf9283