### PR TITLE
Fix cache miss log level

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -639,7 +639,9 @@ function getOrFetchUserInfo(identifier, type = null, options = {}) {
   
   try {
     userInfo = cacheManager.get(cacheKey, () => {
-      console.error('cache miss - fetching from database');
+      // キャッシュに存在しない場合はデータベースから取得する
+      // 通常フローのためエラーレベルでは記録しない
+      console.log('cache miss - fetching from database');
 
       const props = PropertiesService.getScriptProperties();
       if (!props.getProperty(SCRIPT_PROPS_KEYS.DATABASE_SPREADSHEET_ID)) {


### PR DESCRIPTION
## Summary
- log cache misses as info instead of error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68856996f408832b9add794220c67853