### PR TITLE
Fix caching issues with Quick Start form creation

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -1734,7 +1734,7 @@ function createQuickStartFiles(setupContext) {
   
   // ステップ2: Googleフォームとスプレッドシートを作成
   debugLog('📝 ステップ2: フォーム作成中...');
-  var formAndSsInfo = createStudyQuestForm(userEmail, requestUserId);
+  var formAndSsInfo = createUnifiedForm('study', userEmail, requestUserId);
   
   // 作成したファイルをフォルダに移動（改善版：冗長処理除去と安全な移動処理）
   if (folder) {

--- a/src/config.gs
+++ b/src/config.gs
@@ -1617,7 +1617,7 @@ function createBoardFromAdmin(requestUserId) {
     var userId = requestUserId; // requestUserId を使用
 
     // フォームとスプレッドシートを作成
-    var formAndSsInfo = createStudyQuestForm(activeUserEmail, userId);
+    var formAndSsInfo = createUnifiedForm('study', activeUserEmail, userId);
 
     // 中央データベースにユーザー情報を登録
     var initialConfig = {

--- a/src/database.gs
+++ b/src/database.gs
@@ -495,13 +495,15 @@ function findUserByIdFresh(userId) {
   // 既存キャッシュを強制削除
   var cacheKey = 'user_' + userId;
   cacheManager.remove(cacheKey);
-  
-  // データベースから直接取得（キャッシュなし）
-  var freshUserInfo = fetchUserFromDatabase('userId', userId);
-  
+
+  // データベースから直接取得（範囲キャッシュも無効化）
+  var freshUserInfo = fetchUserFromDatabase('userId', userId, {
+    clearCache: true
+  });
+
   // 次回の通常アクセス時にキャッシュされるため、ここでは手動設定不要
   console.log('✅ Fresh user data retrieved for:', userId);
-  
+
   return freshUserInfo;
 }
 


### PR DESCRIPTION
## Summary
- ensure `findUserByIdFresh` bypasses range caches
- use `createUnifiedForm('study', ...)` instead of deprecated `createStudyQuestForm`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68856b42c568832b9f4fc107f04c0b1b