### PR TITLE
Improve user access checks and caching

### DIFF
--- a/src/config.gs
+++ b/src/config.gs
@@ -515,7 +515,7 @@ function getConfig(requestUserId, sheetName, forceRefresh = false) {
   verifyUserAccess(requestUserId);
   const userId = requestUserId; // requestUserId を使用
   const userCache = CacheService.getUserCache();
-  const cacheKey = 'config_v3_' + userId + '_' + sheetName;
+  const cacheKey = buildUserScopedKey('config_v3', userId, sheetName);
 
   if (!forceRefresh) {
     const cached = userCache.get(cacheKey);
@@ -1183,7 +1183,7 @@ function activateSheet(requestUserId, spreadsheetId, sheetName) {
       if (userInfo) {
         // 最小限のキャッシュクリア（スプレッドシート関連のみ）
         const keysToRemove = [
-          'config_v3_' + currentUserId + '_' + sheetName,
+          buildUserScopedKey('config_v3', currentUserId, sheetName),
           'sheets_' + spreadsheetId,
           'data_' + spreadsheetId
         ];

--- a/src/keyUtils.gs
+++ b/src/keyUtils.gs
@@ -1,0 +1,14 @@
+/**
+ * ユーザーIDと識別子から一意のキャッシュキーを生成します。
+ * @param {string} prefix - キーのプレフィックス
+ * @param {string} userId - 対象ユーザーID
+ * @param {string} [suffix] - 追加識別子
+ * @return {string} 生成されたキャッシュキー
+ */
+function buildUserScopedKey(prefix, userId, suffix) {
+  if (!userId) throw new Error('userId is required for cache key');
+  let key = `${prefix}_${userId}`;
+  if (suffix) key += `_${suffix}`;
+  return key;
+}
+

--- a/src/page.js.html
+++ b/src/page.js.html
@@ -4404,10 +4404,16 @@ class StudyQuestApp {
     });
   }
 
+  // ユーザーIDとシート名に基づくローカルストレージキー生成
+  getScopedKey(base) {
+    const userId = this.state?.userId || USER_ID;
+    return `${base}_${userId}_${SHEET_NAME}`;
+  }
+
   // lastSeenCount永続化機能
   loadLastSeenCount() {
     try {
-      const key = `lastSeenCount_${this.state?.userId || USER_ID}_${SHEET_NAME}`;
+      const key = this.getScopedKey('lastSeenCount');
       const stored = localStorage.getItem(key);
       const count = stored ? parseInt(stored, 10) : 0;
       
@@ -4422,16 +4428,11 @@ class StudyQuestApp {
   // 真の初回ボードアクセス判定
   isFirstTimeBoardAccess() {
     try {
-      const userId = this.state?.userId || USER_ID;
-      const sheetName = SHEET_NAME;
-      
       // 1. lastSeenCountの存在確認
-      const lastSeenKey = `lastSeenCount_${userId}_${sheetName}`;
-      const hasLastSeen = localStorage.getItem(lastSeenKey) !== null;
-      
+      const hasLastSeen = localStorage.getItem(this.getScopedKey('lastSeenCount')) !== null;
+
       // 2. 差分カードの存在確認
-      const diffCardKey = `differentialCards_${userId}_${sheetName}`;
-      const hasDiffCards = localStorage.getItem(diffCardKey) !== null;
+      const hasDiffCards = localStorage.getItem(this.getScopedKey('differentialCards')) !== null;
       
       // 3. 初期データロード状態の確認
       const hasInitialLoad = this.initialDataLoaded === true;
@@ -4461,7 +4462,7 @@ class StudyQuestApp {
 
   saveLastSeenCount(count) {
     try {
-      const key = `lastSeenCount_${this.state?.userId || USER_ID}_${SHEET_NAME}`;
+      const key = this.getScopedKey('lastSeenCount');
       localStorage.setItem(key, count.toString());
       
       console.log('💾 lastSeenCount保存:', { key, count });
@@ -4487,7 +4488,7 @@ class StudyQuestApp {
   // 差分カード管理メソッド
   loadDifferentialCards() {
     try {
-      const key = `differentialCards_${this.state?.userId || USER_ID}_${SHEET_NAME}`;
+      const key = this.getScopedKey('differentialCards');
       const stored = localStorage.getItem(key);
       const cards = stored ? JSON.parse(stored) : [];
       
@@ -4501,7 +4502,7 @@ class StudyQuestApp {
 
   saveDifferentialCards(cardIds) {
     try {
-      const key = `differentialCards_${this.state?.userId || USER_ID}_${SHEET_NAME}`;
+      const key = this.getScopedKey('differentialCards');
       const existing = this.loadDifferentialCards();
       const merged = [...new Set([...existing, ...cardIds])];
       localStorage.setItem(key, JSON.stringify(merged));
@@ -4514,7 +4515,7 @@ class StudyQuestApp {
 
   clearDifferentialCards() {
     try {
-      const key = `differentialCards_${this.state?.userId || USER_ID}_${SHEET_NAME}`;
+      const key = this.getScopedKey('differentialCards');
       localStorage.removeItem(key);
       console.log('🗑️ 差分カードクリア:', { key });
     } catch (error) {

--- a/tests/verifyUserAccess.test.js
+++ b/tests/verifyUserAccess.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('verifyUserAccess security checks', () => {
+  const coreCode = fs.readFileSync('src/Core.gs', 'utf8');
+  let context;
+
+  beforeEach(() => {
+    context = {
+      console,
+      debugLog: () => {},
+      clearExecutionUserInfoCache: jest.fn(),
+      Session: { getActiveUser: () => ({ getEmail: () => 'admin@example.com' }) },
+      findUserById: jest.fn(() => ({
+        adminEmail: 'admin@example.com',
+        configJson: JSON.stringify({ appPublished: false }),
+      })),
+    };
+    vm.createContext(context);
+    vm.runInContext(coreCode, context);
+  });
+
+  test('allows access for matching admin email', () => {
+    expect(() => context.verifyUserAccess('U1')).not.toThrow();
+  });
+
+  test('denies access when emails differ and board not published', () => {
+    context.Session.getActiveUser = () => ({ getEmail: () => 'other@example.com' });
+    expect(() => context.verifyUserAccess('U1')).toThrow('権限エラー');
+  });
+
+  test('allows read-only access for published board', () => {
+    context.Session.getActiveUser = () => ({ getEmail: () => 'viewer@example.com' });
+    context.findUserById.mockReturnValue({
+      adminEmail: 'admin@example.com',
+      configJson: JSON.stringify({ appPublished: true }),
+    });
+    expect(() => context.verifyUserAccess('U1')).not.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `buildUserScopedKey` helper to centralize cache key generation
- use the helper inside `getConfig`
- add `getScopedKey` client helper and refactor localStorage key usage
- test `verifyUserAccess` for cross‑user access restrictions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885f25bb010832b999cbc067129b195