### PR TITLE
Fix empty state removal

### DIFF
--- a/src/page.js.html
+++ b/src/page.js.html
@@ -1662,11 +1662,13 @@ class StudyQuestApp {
   // 新しいカードを既存のカードコンテナに追加
   async appendNewCards(newData, sortOrder = 'newest') {
     if (!newData || newData.length === 0) return;
-    
+
     console.log('📌 新しいカードを追加:', newData.length + '件');
-    
+
     const container = this.elements.answersContainer;
     if (!container) return;
+
+    this.removeEmptyState();
     
     // 新しいカードを作成してコンテナに追加
     const fragment = document.createDocumentFragment();
@@ -2195,7 +2197,7 @@ class StudyQuestApp {
     if (!container) return;
     
     container.innerHTML = `
-      <div class="text-center py-16 px-6 col-span-full">
+      <div class="text-center py-16 px-6 col-span-full" data-empty-state="true">
         <svg class="mx-auto h-12 w-12 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
@@ -2222,7 +2224,7 @@ class StudyQuestApp {
     if (!container) return;
     
     container.innerHTML = `
-      <div class="text-center py-16 px-6 col-span-full">
+      <div class="text-center py-16 px-6 col-span-full" data-empty-state="true">
         <svg class="mx-auto h-12 w-12 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L5.08 16.5c-.77.833.192 2.5 1.732 2.5z" />
         </svg>
@@ -2288,7 +2290,7 @@ class StudyQuestApp {
     if (!container) return;
     
     container.innerHTML = `
-      <div class="text-center py-16 px-6 col-span-full">
+      <div class="text-center py-16 px-6 col-span-full" data-empty-state="true">
         <svg class="mx-auto h-12 w-12 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
         </svg>
@@ -2297,7 +2299,20 @@ class StudyQuestApp {
       </div>
     `;
   }
-  
+
+  /**
+   * 空状態のバナーを削除します。
+   */
+  removeEmptyState() {
+    const container = this.elements.answersContainer;
+    if (!container) return;
+
+    const banner = container.querySelector('[data-empty-state="true"]');
+    if (banner) {
+      banner.remove();
+    }
+  }
+
   safeDisplayEmptyState() {
     const container = this.elements.answersContainer;
     if (!container) return;


### PR DESCRIPTION
## Summary
- remove empty state banner when answers arrive
- mark empty state with a data attribute for easy deletion

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68861fc68e4c832bafc3e064a6e5c045