### PR TITLE
Fix reason field missing in diff cards

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -2176,7 +2176,18 @@ function processHighlightToggle(spreadsheetId, sheetName, rowIndex) {
 
 function getHeaderIndices(spreadsheetId, sheetName) {
   debugLog('getHeaderIndices received in core.gs: spreadsheetId=%s, sheetName=%s', spreadsheetId, sheetName);
-  return getHeadersCached(spreadsheetId, sheetName);
+
+  var cacheKey = 'hdr_' + spreadsheetId + '_' + sheetName;
+  var indices = getHeadersCached(spreadsheetId, sheetName);
+
+  // 理由列が取得できていない場合はキャッシュを無効化して再取得
+  if (!indices || indices[COLUMN_HEADERS.REASON] === undefined) {
+    debugLog('getHeaderIndices: Reason header missing, refreshing cache for key=%s', cacheKey);
+    cacheManager.remove(cacheKey);
+    indices = getHeadersCached(spreadsheetId, sheetName);
+  }
+
+  return indices;
 }
 
 function getSheetColumns(userId, sheetId) {


### PR DESCRIPTION
## Summary
- refresh header cache when reason column is absent to keep incremental updates consistent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886ab0eaa1c832b9db16d3541290cc5