### PR TITLE
fix(gas): prevent duplicate execution cache declaration

### DIFF
--- a/src/config.gs
+++ b/src/config.gs
@@ -8,7 +8,6 @@ const CONFIG_SHEET_NAME = 'Config';
 let runtimeUserInfo = null;
 
 // メモリ管理用の実行レベル変数 (main.gsと統一)
-let _executionUserInfoCache = null;
 let lastCacheUserIdKey = null;
 let executionStartTime = Date.now();
 const EXECUTION_MAX_LIFETIME = 300000; // 5分間の最大実行時間


### PR DESCRIPTION
## Summary
- remove redundant `_executionUserInfoCache` definition in `config.gs`
- run all Jest tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b3d6bbe34832b817fc84c8cb03cdf