### PR TITLE
Add config sync API and update repair logic

### DIFF
--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -476,8 +476,8 @@ function repairSetupStateInconsistencies() {
       
       // 修正された設定を保存
       console.log('💾 修正された設定を保存中...', config);
-      
-        runGasWithUserId('saveSheetConfig', '設定修復中...', currentStatus.userInfo.spreadsheetId, selectedSheet, config)
+
+        runGasWithUserId('syncConfigurationState', '設定修復中...', config, 'repair')
         .then(saveResult => {
           if (saveResult && saveResult.success) {
             console.log('✅ セットアップ状態の修復完了');


### PR DESCRIPTION
## Summary
- implement `syncConfigurationState` server function
- call the new API from setup repair logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b43ac5f8c832b9d8581b5b0a28f80