### PR TITLE
Fix config inconsistency

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -289,6 +289,13 @@ function performAutoHealing(userInfo, configJson, userId) {
       updated = true;
     }
 
+    // 修復ルール2b: setupStatusがcompletedだがformCreatedがfalseの場合
+    if (!healedConfig.formCreated && healedConfig.setupStatus === 'completed') {
+      healedConfig.setupStatus = 'pending';
+      changes.push('setupStatus: completed → pending (formCreated=false)');
+      updated = true;
+    }
+
     // 修復ルール3: publishedSheetNameが存在するがappPublishedがfalseの場合
     // Note: これは公開状態の判定なので、より慎重に処理
     if (healedConfig.publishedSheetName &&


### PR DESCRIPTION
## Summary
- ensure config healing resets `setupStatus` when no form is created

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b481becc4832b959e4dd5bc2ba65a