### PR TITLE
fix URL generation

### DIFF
--- a/src/url.gs
+++ b/src/url.gs
@@ -57,7 +57,7 @@ function normalizeUrlString(url) {
  */
 function computeWebAppUrl() {
   try {
-    const url = ScriptApp.getService().getUrl();
+    let url = ScriptApp.getService().getUrl();
     if (!url) {
       warnLog('ScriptApp.getService().getUrl()がnullを返しました');
       return getFallbackUrl();


### PR DESCRIPTION
## Summary
- use `let` for the variable in `computeWebAppUrl`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b592c0f34832bae8203e16589f70d