### PR TITLE
Fix duplicate quick start modal

### DIFF
--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -2400,14 +2400,8 @@ function handleQuickStart() {
     return;
   }
 
-  // 公開状態をチェックして、必要に応じて確認モーダルを表示
-  checkPublicationStatusAndProceed(() => {
-    // 確認完了後の処理
-    executeQuickStart(quickstartBtn, quickstartText);
-  }, () => {
-    // キャンセル時の処理
-    console.log('クイックスタートがキャンセルされました');
-  });
+  // 公開状態に応じたクイックスタート処理を実行
+  executeQuickStart(quickstartBtn, quickstartText);
 }
 
 // 公開状態チェックとモーダル表示


### PR DESCRIPTION
## Summary
- avoid showing two confirmation modals when launching quick start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b8c0af8c8832bb1ac79349e127402