### PR TITLE
feat: clear caches on account deletion

### DIFF
--- a/src/database.gs
+++ b/src/database.gs
@@ -3070,8 +3070,23 @@ function deleteUserAccount(userId) {
         'self'
       );
 
-      // 関連するすべてのキャッシュを削除
-      invalidateUserCache(userId, userInfo.adminEmail, userInfo.spreadsheetId, false);
+        // 関連するすべてのキャッシュを削除
+        invalidateUserCache(userId, userInfo.adminEmail, userInfo.spreadsheetId, false);
+
+        // セッション関連のキャッシュも完全クリア
+        try {
+          if (typeof cleanupSessionOnAccountSwitch === 'function') {
+            cleanupSessionOnAccountSwitch(userInfo.adminEmail);
+          }
+          if (typeof cacheManager !== 'undefined') {
+            cacheManager.clearAll();
+          }
+          if (typeof clearAllExecutionCache === 'function') {
+            clearAllExecutionCache();
+          }
+        } catch (cacheError) {
+          warnLog('アカウント削除後のキャッシュクリアでエラー:', cacheError.message);
+        }
 
       // Google Drive のデータは保持するため何も操作しない
 


### PR DESCRIPTION
## Summary
- clear caches server side after `deleteUserAccount`
- keep admin panel event to wipe browser caches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b8d75c818832ba3acb933e80e8b04