### PR TITLE
Fix admin panel domain info initialization

### DIFF
--- a/src/adminPanel-core.js.html
+++ b/src/adminPanel-core.js.html
@@ -390,6 +390,42 @@ function checkAndExpandAllSections() {
   }
 }
 
+// ドメイン情報を取得してヘッダーを更新
+function fetchDomainInfo() {
+  if (typeof runGasWithUserId !== 'function') {
+    logWarn('runGasWithUserId is not available.');
+    return Promise.resolve(null);
+  }
+
+  return runGasWithUserId('getSystemDomainInfo', false)
+    .then(info => {
+      if (!info || info.error) {
+        logWarn('Domain info retrieval failed:', info);
+        if (typeof updateDomainDisplay === 'function') {
+          updateDomainDisplay('initial', 'ドメイン確認中', 'セットアップ中');
+        }
+        return null;
+      }
+
+      if (typeof updateDomainDisplay === 'function') {
+        if (info.isDomainMatch) {
+          updateDomainDisplay('match', info.adminDomain, 'セキュアアクセス有効');
+        } else {
+          updateDomainDisplay('mismatch', info.adminDomain, 'アクセス制限あり');
+        }
+      }
+
+      return info;
+    })
+    .catch(error => {
+      logWarn('fetchDomainInfo error:', error);
+      if (typeof updateDomainDisplay === 'function') {
+        updateDomainDisplay('initial', 'ドメイン確認中', 'セットアップ中');
+      }
+      return null;
+    });
+}
+
 // 統合初期化システム - 単一エントリーポイント
 // システム監視用の状態管理
 window.systemStatus = {
@@ -414,6 +450,9 @@ function updateSystemStatus(component, status, error = null) {
 
 function initializeAdminPanelMaster() {
   logInfo('🚀 AdminPanel Master Initialization Started');
+  if (window.unifiedLoading) {
+    window.unifiedLoading.showSimple('初期化中...');
+  }
   updateSystemStatus('initializationStarted', true);
   
   // Phase 1: Core初期化
@@ -540,6 +579,12 @@ function initializeAdminPanelMaster() {
             
             // システム状態の最終レポート
             console.log('📊 Final System Status:', window.systemStatus);
+
+            fetchDomainInfo().finally(() => {
+              if (window.unifiedLoading) {
+                window.unifiedLoading.hide();
+              }
+            });
           } catch (error) {
             updateSystemStatus('eventsInitialized', false, error);
             console.error('❌ Events initialization failed:', error);
@@ -599,6 +644,12 @@ function initializeAdminPanelMaster() {
         
         // システム状態の最終レポート（フォールバック版）
         console.log('📊 Final System Status (Fallback):', window.systemStatus);
+
+        fetchDomainInfo().finally(() => {
+          if (window.unifiedLoading) {
+            window.unifiedLoading.hide();
+          }
+        });
       }
       
       initializeEventsWithRetry();

--- a/src/adminPanel-ui.js.html
+++ b/src/adminPanel-ui.js.html
@@ -2282,6 +2282,33 @@ function showAppropriateHeaderStatus() {
   }
 }
 
+// ドメイン表示を更新するヘルパー関数
+function updateDomainDisplay(type, domainText, statusText) {
+  const initialDiv = document.getElementById('header-domain-initial');
+  const matchDiv = document.getElementById('header-domain-match');
+  const mismatchDiv = document.getElementById('header-domain-mismatch');
+
+  if (initialDiv) initialDiv.classList.add('hidden');
+  if (matchDiv) matchDiv.classList.add('hidden');
+  if (mismatchDiv) mismatchDiv.classList.add('hidden');
+
+  if (type === 'match' && matchDiv) {
+    matchDiv.classList.remove('hidden');
+    const textEl = document.getElementById('header-domain-match-text');
+    if (textEl) textEl.textContent = domainText;
+  } else if (type === 'mismatch' && mismatchDiv) {
+    mismatchDiv.classList.remove('hidden');
+    const textEl = document.getElementById('header-domain-mismatch-text');
+    if (textEl) textEl.textContent = domainText;
+  } else if (initialDiv) {
+    initialDiv.classList.remove('hidden');
+    const domainEl = document.getElementById('header-domain-name-initial');
+    const statusEl = document.getElementById('header-status-text-initial');
+    if (domainEl) domainEl.textContent = domainText;
+    if (statusEl) statusEl.textContent = statusText;
+  }
+}
+
 /**
  * セットアップ状況に応じてボタン状態を更新
  * @param {Object} status - ステータスオブジェクト


### PR DESCRIPTION
## Summary
- ensure domain info fetching works after admin panel initialization
- keep loading overlay visible until domain info is fetched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c3e691818832b9bab6277cb13351e