### PR TITLE
Fix QuickStart config sync userId parameter

### DIFF
--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -1615,8 +1615,12 @@ async function enhanceConfigSynchronization(flowType, expectedState) {
       console.log(`🔧 ${flowType}フロー: 設定不整合を検出 - 同期修正を実行`, synchronizationIssues);
       
       // バックエンドに同期修正を依頼
-      const syncResult = await runGasWithUserId('syncConfigurationState', '設定同期を実行中...', 
-        userId, updatedConfig, flowType);
+      const syncResult = await runGasWithUserId(
+        'syncConfigurationState',
+        '設定同期を実行中...',
+        updatedConfig,
+        flowType
+      );
       
       if (syncResult && syncResult.success) {
         appliedFixes.push(...synchronizationIssues);


### PR DESCRIPTION
## Summary
- fix config synchronization by removing unintended userId argument

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c54fda7e8832b95847f91f532ad6c