### PR TITLE
fix: replace dev URL segments with production

### DIFF
--- a/src/adminPanel-ui.js.html
+++ b/src/adminPanel-ui.js.html
@@ -402,12 +402,18 @@ function generateUrlCacheKey(status, userId) {
  * @returns {string} 本番環境URL
  */
 function convertDevUrlToProductionUrl(devUrl) {
-  // Simplistic conversion: replace 'userCodeAppPanel' with 'exec' if present
-  if (devUrl.includes('userCodeAppPanel')) {
-    return devUrl.replace('userCodeAppPanel', 'exec');
+  // Replace known development path segments with production equivalent
+  let prodUrl = devUrl;
+
+  if (prodUrl.includes('userCodeAppPanel')) {
+    prodUrl = prodUrl.replace('userCodeAppPanel', 'exec');
   }
-  // Otherwise, return the original URL
-  return devUrl;
+
+  if (prodUrl.includes('/dev')) {
+    prodUrl = prodUrl.replace('/dev', '/exec');
+  }
+
+  return prodUrl;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- ensure dev URLs are converted to production by replacing userCodeAppPanel or /dev with /exec

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d6bf0d79c832ba3c6b1f75ef2a347