### PR TITLE
fix: repair web app url parsing and helpers

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -701,8 +701,8 @@ function getDeployUserDomainInfo() {
     if (webAppUrl) {
       // Google WorkspaceアカウントのドメインをURLから抽出
       const domainMatch =
-        webAppUrl.match(/\/a\/([a-zA-Z0-9\-.]+)\/macros\/) ||
-        webAppUrl.match(/\/a\/macros\/([a-zA-Z0-9\-.]+)\/);
+        webAppUrl.match(/\/a\/([a-zA-Z0-9\-.]+)\/macros\//) ||
+        webAppUrl.match(/\/a\/macros\/([a-zA-Z0-9\-.]+)\//);
       if (domainMatch && domainMatch[1]) {
         deployDomain = domainMatch[1];
       }

--- a/src/url.gs
+++ b/src/url.gs
@@ -49,5 +49,27 @@ function getProductionWebAppUrl() {
   }
 }
 
+/**
+ * WebアプリのベースURLを取得します。
+ * 値はキャッシュされ、再計算を避けます。
+ * @returns {string} WebアプリのベースURL
+ */
+function getWebAppBaseUrl() {
+  return cacheManager.get('WEB_APP_URL', () => getProductionWebAppUrl());
+}
+
+/**
+ * ユーザー毎のアプリURLを生成します。
+ * @param {string} userId ユーザーID
+ * @returns {{adminUrl: string, viewUrl: string}} 生成されたURL
+ */
+function generateUserUrls(userId) {
+  const baseUrl = getWebAppBaseUrl();
+  return {
+    adminUrl: `${baseUrl}?mode=admin&userId=${userId}`,
+    viewUrl: `${baseUrl}?mode=view&userId=${userId}`
+  };
+}
+
 // 既存のgetWebAppUrlCachedやgetFallbackUrlなどは不要になるため削除
 // 必要に応じて、他のファイルでgetProductionWebAppUrlを呼び出すように変更します。


### PR DESCRIPTION
## Summary
- fix deploy domain extraction regex
- add helpers for cached web app base URL and user URL generation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688d8529ae48832b9b2a34540e906ee9