### PR TITLE
Add missing created-at info element in admin panel

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -950,6 +950,10 @@
             <span class="text-white font-semibold" id="info-system-status">-</span>
           </div>
           <div class="flex justify-between items-center">
+            <span class="text-gray-400">作成日時:</span>
+            <span class="text-white font-semibold" id="info-created-at">-</span>
+          </div>
+          <div class="flex justify-between items-center">
             <span class="text-gray-400">最終アクセス:</span>
             <span class="text-white font-semibold" id="info-last-accessed">-</span>
           </div>


### PR DESCRIPTION
## Summary
- show database creation timestamp in Data Status panel by adding `info-created-at` element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dc7790d88832baca32072aed3ac6c