### PR TITLE
fix(ui): use fallback status for unpublish history

### DIFF
--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -1247,65 +1247,90 @@ function unpublishBoard() {
     });
 }
 
-// 公開停止時に履歴を保存する関数
+/**
+ * 公開停止時に履歴を保存する。
+ * @param {Object} unpublishResponse 公開停止APIからのレスポンス。
+ */
 function saveHistoryOnUnpublish(unpublishResponse) {
   try {
-    // 信頼性の高いunpublishResponseから直接データを取得
+    const fallbackStatus = window.lastStatusCache || currentStatus;
+
     if (!unpublishResponse || !unpublishResponse.userInfo || !unpublishResponse.config) {
-      logWarn('履歴保存: unpublishResponseに必要な情報が含まれていません', unpublishResponse);
-      // 念のため、グローバルキャッシュにフォールバック
-      const currentStatus = window.lastStatusCache;
-      if (!currentStatus || !currentStatus.config) {
-        logError('履歴保存失敗: フォールバック用のステータス情報も取得できません');
+      logWarn(
+        '履歴保存: unpublishResponseに必要な情報が含まれていません',
+        UnifiedErrorHandler.ErrorCategories.DATA_VALIDATION,
+        { unpublishResponse }
+      );
+      if (!fallbackStatus || !fallbackStatus.config) {
+        logError(
+          '履歴保存失敗: フォールバック用のステータス情報も取得できません',
+          UnifiedErrorHandler.ErrorCategories.SYSTEM_INITIALIZATION,
+          { unpublishResponse }
+        );
         return;
       }
-      unpublishResponse.config = currentStatus.config;
-      unpublishResponse.userInfo = currentStatus.userInfo;
+      unpublishResponse = {
+        ...(unpublishResponse || {}),
+        config: fallbackStatus.config,
+        userInfo: fallbackStatus.userInfo
+      };
     }
 
     const config = unpublishResponse.config;
     const userInfo = unpublishResponse.userInfo;
-    
-    // 履歴アイテムを作成
+
     const historyItem = {
       questionText: config.opinionHeader || config.opinionColumn || userInfo.customFormInfo?.mainQuestion || '（問題文未設定）',
       sheetName: config.publishedSheetName || '',
       publishedAt: config.publishedAt || config.lastPublishedAt || new Date().toISOString(),
-      endTime: new Date().toISOString(), // 実際の終了日時
-      scheduledEndTime: config.scheduledEndTime || null, // 予定終了日時
-      answerCount: unpublishResponse.answerCount || currentStatus.answerCount || 0,
-      reactionCount: unpublishResponse.reactionCount || currentStatus.reactionCount || 0,
+      endTime: new Date().toISOString(),
+      scheduledEndTime: config.scheduledEndTime || null,
+      answerCount: unpublishResponse.answerCount || fallbackStatus?.answerCount || 0,
+      reactionCount: unpublishResponse.reactionCount || fallbackStatus?.reactionCount || 0,
       config: config,
       formUrl: userInfo.formUrl || '',
       spreadsheetUrl: userInfo.spreadsheetUrl || '',
       setupType: determineSetupType(config, userInfo),
-      isActive: false // 終了したのでfalse
+      isActive: false
     };
-    
-    // LocalStorage履歴保存を実行
+
     saveToHistory(historyItem);
-    
-    // サーバーサイド履歴保存も実行
+
     try {
       runGasWithUserId('saveHistoryToSheetAPI', '履歴をサーバーに保存中...', historyItem)
         .then(response => {
           if (response && response.status === 'success') {
             logDebug('✅ サーバーサイド履歴保存完了:', response);
           } else {
-            logWarn('⚠️ サーバーサイド履歴保存で警告:', response);
+            logWarn(
+              '⚠️ サーバーサイド履歴保存で警告:',
+              UnifiedErrorHandler.ErrorCategories.API_COMMUNICATION,
+              { response }
+            );
           }
         })
         .catch(error => {
-          logWarn('❌ サーバーサイド履歴保存エラー:', error);
+          logWarn(
+            '❌ サーバーサイド履歴保存エラー:',
+            UnifiedErrorHandler.ErrorCategories.API_COMMUNICATION,
+            { error }
+          );
         });
     } catch (serverError) {
-      logWarn('❌ サーバーサイド履歴保存の呼び出しに失敗:', serverError);
+      logWarn(
+        '❌ サーバーサイド履歴保存の呼び出しに失敗:',
+        UnifiedErrorHandler.ErrorCategories.API_COMMUNICATION,
+        { error: serverError }
+      );
     }
-    
+
     logDebug('履歴保存完了（公開停止時）:', historyItem);
-    
   } catch (error) {
-    logWarn('公開停止時の履歴保存に失敗:', error);
+    logWarn(
+      '公開停止時の履歴保存に失敗:',
+      UnifiedErrorHandler.ErrorCategories.SYSTEM_INITIALIZATION,
+      { error }
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure history saving falls back to cached status when unpublish response lacks data
- log warnings/errors with proper categories and context

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dccd1786c832b8b8a358f12b125a9