### PR TITLE
Add error handler fallbacks and wrap stop/create flow

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -10,9 +10,48 @@ if (typeof debugLog === 'undefined') {
   }
 }
 
-// Import standardized error handling functions
+// Import standardized error handling functions with safe fallbacks
+// The Apps Script runtime does not guarantee file load order, so Core.gs
+// must operate even if errorHandler.gs has not executed yet.
+if (typeof ERROR_SEVERITY === 'undefined') {
+  const ERROR_SEVERITY = {
+    LOW: 'low',
+    MEDIUM: 'medium',
+    HIGH: 'high',
+    CRITICAL: 'critical'
+  };
+}
+
+if (typeof ERROR_CATEGORIES === 'undefined') {
+  const ERROR_CATEGORIES = {
+    AUTHENTICATION: 'authentication',
+    AUTHORIZATION: 'authorization',
+    DATABASE: 'database',
+    CACHE: 'cache',
+    NETWORK: 'network',
+    VALIDATION: 'validation',
+    SYSTEM: 'system',
+    USER_INPUT: 'user_input'
+  };
+}
+
 if (typeof logError === 'undefined') {
-  throw new Error('errorHandler.gs must be loaded before Core.gs');
+  /**
+   * Basic fallback error logger used when UnifiedErrorHandler is not yet loaded.
+   * This prevents initialization failures while still recording minimal details.
+   */
+  function logError(error, context, severity = ERROR_SEVERITY.MEDIUM, category = ERROR_CATEGORIES.SYSTEM, metadata = {}) {
+    const message = error && error.message ? error.message : String(error);
+    console.error(`[FallbackError][${context}]`, message, metadata);
+    return {
+      message,
+      context,
+      severity,
+      category,
+      metadata,
+      timestamp: new Date().toISOString()
+    };
+  }
 }
 
 if (typeof warnLog === 'undefined') {

--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -2884,40 +2884,34 @@ function showSimpleQuickStartModal(quickstartBtn, quickstartText) {
 }
 
 // 公開停止とクイックスタートの統合処理
-function handleStopAndCreateNew(quickstartBtn, quickstartText) {
+async function handleStopAndCreateNew(quickstartBtn, quickstartText) {
   console.log('🛑📋 公開停止→クイックスタートの統合処理を開始します');
 
-  // ボタン状態を更新
-  quickstartBtn.disabled = true;
-  quickstartText.textContent = '公開停止中...';
+  try {
+    // ボタン状態を更新
+    quickstartBtn.disabled = true;
+    quickstartText.textContent = '公開停止中...';
 
-  // 1. まず公開停止処理を実行
-  if (typeof unpublishBoard === 'function') {
+    if (typeof unpublishBoard !== 'function') {
+      throw new Error('unpublishBoard function not found');
+    }
+
     showMessage('現在の回答ボードを停止しています...', 'info');
+    const stopResult = await unpublishBoard();
+    console.log('✅ 公開停止が完了しました:', stopResult);
+    showMessage('✅ 公開停止が完了しました。新しいフォームを作成します...', 'success');
 
-    unpublishBoard()
-      .then(function(stopResult) {
-        console.log('✅ 公開停止が完了しました:', stopResult);
-        showMessage('✅ 公開停止が完了しました。新しいフォームを作成します...', 'success');
+    // 公開停止が完了したら、少し遅延してからクイックスタートを実行
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    quickstartText.textContent = 'セットアップ中...';
+    console.log('🚀 クイックスタート処理を開始します（自動公開モード）');
 
-        // 公開停止が完了したら、少し遅延してからクイックスタートを実行
-        setTimeout(() => {
-          quickstartText.textContent = 'セットアップ中...';
-          console.log('🚀 クイックスタート処理を開始します（自動公開モード）');
-
-          // 2. クイックスタート実行（自動公開フラグ付き）
-          executeQuickStartProcess(quickstartBtn, quickstartText, true)
-            .then(() => loadStatus(true));
-        }, 1000);
-      })
-      .catch(function(stopError) {
-        console.error('❌ 公開停止に失敗しました:', stopError);
-        showMessage('❌ 公開停止に失敗しました。再度お試しください。', 'error');
-        resetQuickStartButton(quickstartBtn, quickstartText);
-      });
-  } else {
-    console.error('❌ unpublishBoard function not found');
-    showMessage('❌ 公開停止機能が見つかりません。ページを再読み込みしてください。', 'error');
+    // クイックスタート実行（自動公開フラグ付き）
+    await executeQuickStartProcess(quickstartBtn, quickstartText, true);
+    await loadStatus(true);
+  } catch (error) {
+    console.error('❌ 公開停止→クイックスタート処理に失敗しました:', error);
+    showMessage('❌ 公開停止またはセットアップに失敗しました。再度お試しください。', 'error');
     resetQuickStartButton(quickstartBtn, quickstartText);
   }
 }


### PR DESCRIPTION
## Summary
- prevent server startup crash by supplying fallback error handler and constants when `errorHandler.gs` isn't loaded
- wrap "stop and create new" flow in async try/catch to reset UI on failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dcfee8660832bb0f5a1fefc58a218