### PR TITLE
Fix step indicator for pending database

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -75,7 +75,12 @@ if (typeof infoLog === 'undefined') {
  */
 function getSetupStep(userInfo, configJson) {
   // Step 1: データソース未設定
-  if (!userInfo || !userInfo.spreadsheetId || userInfo.spreadsheetId.trim() === '') {
+  if (
+    !userInfo ||
+    !userInfo.spreadsheetId ||
+    userInfo.spreadsheetId.trim() === '' ||
+    userInfo.spreadsheetId === 'pending'
+  ) {
     return 1;
   }
   
@@ -185,7 +190,11 @@ function determineSetupStepUnified(userInfo, configJson, options = {}) {
   const debugMode = options.debugMode || false;
 
   // Step 1: データソース未設定
-  if (!userInfo || !userInfo.spreadsheetId || userInfo.spreadsheetId.trim() === '') {
+  const spreadsheetId =
+    userInfo && typeof userInfo.spreadsheetId === 'string'
+      ? userInfo.spreadsheetId.trim()
+      : '';
+  if (!spreadsheetId || spreadsheetId === 'pending') {
     if (debugMode) debugLog('🔧 setupStep統一判定: Step 1 - データソース未設定');
     return 1;
   }

--- a/src/adminPanel-ui.js.html
+++ b/src/adminPanel-ui.js.html
@@ -1118,7 +1118,10 @@ function getStepCompletionFromConfig(status) {
 
     // 通常のステップ完了判定
     // Step 1: スプレッドシートIDの存在確認
-    const step1Complete = !!(status.userInfo.spreadsheetId);
+    const spreadsheetId = (status.userInfo && typeof status.userInfo.spreadsheetId === 'string')
+      ? status.userInfo.spreadsheetId.trim()
+      : '';
+    const step1Complete = spreadsheetId !== '' && spreadsheetId !== 'pending';
     
     // Step 2: セットアップ完了状態の確認
     const step2Complete = config.setupStatus === 'completed' && 


### PR DESCRIPTION
## Summary
- treat placeholder spreadsheet IDs as unset so setup remains on step 1
- ensure UI step completion logic handles `pending` spreadsheet IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dd32b20c0832bb911cca5589c40b4