### PR TITLE
Fix tests for errorHandler.js.html rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Googleスプレッドシートをデータベースとして活用し、Google�
 
 #### 【適正サイズファイル】
 6. **auth.gs** (15,249文字) - 認証とアクセス制御
-7. **errorHandler.gs** (9,634文字) - 統一エラーハンドリング
+7. **errorHandler.js.html** (9,634文字) - 統一エラーハンドリング
 8. **unifiedUtilities.gs** (14,094文字) - 統一ユーティリティ
 9. **url.gs** (14,056文字) - URL管理とルーティング
 10. **session-utils.gs** (12,710文字) - セッション管理
@@ -275,7 +275,7 @@ https://www.googleapis.com/auth/userinfo.email
 ### 新規関数作成時の注意点
 1. **重複チェック**: 既存の類似関数がないか確認
 2. **統一クラス優先**: UnifiedUserManager, CacheManager等を優先使用
-3. **エラーハンドリング**: errorHandler.gsの関数を使用
+3. **エラーハンドリング**: errorHandler.js.htmlの関数を使用
 4. **機密情報保護**: ログ出力で機密情報をマスク
 
 ### パフォーマンス考慮事項

--- a/src/Core.gs
+++ b/src/Core.gs
@@ -10,7 +10,7 @@ if (typeof debugLog === 'undefined') {
 
 // Import standardized error handling functions
 if (typeof logError === 'undefined') {
-  throw new Error('errorHandler.gs must be loaded before Core.gs');
+  throw new Error('errorHandler.js.html must be loaded before Core.gs');
 }
 
 if (typeof warnLog === 'undefined') {

--- a/tests/addUnifiedQuestions.test.js
+++ b/tests/addUnifiedQuestions.test.js
@@ -11,10 +11,14 @@ function createMockItem() {
 }
 
 describe('addUnifiedQuestions other option', () => {
-  const errorHandlerCode = fs.readFileSync('src/errorHandler.gs', 'utf8');
+  const errorHandlerCode = fs
+    .readFileSync('src/errorHandler.js.html', 'utf8')
+    .split('\n')
+    .slice(1, -1)
+    .join('\n');
   const code = fs.readFileSync('src/Core.gs', 'utf8');
-  const context = { 
-    console, 
+  const context = {
+    console,
     debugLog: () => {},
     Utilities: { getUuid: () => 'test-uuid-' + Math.random() }
   };

--- a/tests/coreFunctions.test.js
+++ b/tests/coreFunctions.test.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const vm = require('vm');
 
 describe('Core.gs utilities', () => {
-  const errorHandlerCode = fs.readFileSync('src/errorHandler.gs', 'utf8');
+  const errorHandlerCode = fs
+    .readFileSync('src/errorHandler.js.html', 'utf8')
+    .split('\n')
+    .slice(1, -1)
+    .join('\n');
   const urlCode = fs.readFileSync('src/url.gs', 'utf8');
   const mainCode = fs.readFileSync('src/main.gs', 'utf8');
   const coreCode = fs.readFileSync('src/Core.gs', 'utf8');

--- a/tests/createFormFactory.test.js
+++ b/tests/createFormFactory.test.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const vm = require('vm');
 
 describe('createFormFactory returns URLs', () => {
-  const errorHandlerCode = fs.readFileSync('src/errorHandler.gs', 'utf8');
+  const errorHandlerCode = fs
+    .readFileSync('src/errorHandler.js.html', 'utf8')
+    .split('\n')
+    .slice(1, -1)
+    .join('\n');
   const code = fs.readFileSync('src/Core.gs', 'utf8');
   let context;
 

--- a/tests/getDataCount.test.js
+++ b/tests/getDataCount.test.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const vm = require('vm');
 
 describe('getDataCount reflects new rows', () => {
-  const errorHandlerCode = fs.readFileSync('src/errorHandler.gs', 'utf8');
+  const errorHandlerCode = fs
+    .readFileSync('src/errorHandler.js.html', 'utf8')
+    .split('\n')
+    .slice(1, -1)
+    .join('\n');
   const coreCode = fs.readFileSync('src/Core.gs', 'utf8');
   const mainCode = fs.readFileSync('src/main.gs', 'utf8');
   const spreadsheetCacheCode = fs.readFileSync('src/spreadsheetCache.gs', 'utf8');

--- a/tests/getInitialDataHeaders.test.js
+++ b/tests/getInitialDataHeaders.test.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const vm = require('vm');
 
 describe('getInitialData header extraction', () => {
-  const errorHandlerCode = fs.readFileSync('src/errorHandler.gs', 'utf8');
+  const errorHandlerCode = fs
+    .readFileSync('src/errorHandler.js.html', 'utf8')
+    .split('\n')
+    .slice(1, -1)
+    .join('\n');
   const urlCode = fs.readFileSync('src/url.gs', 'utf8');
   const mainCode = fs.readFileSync('src/main.gs', 'utf8');
   const coreCode = fs.readFileSync('src/Core.gs', 'utf8');

--- a/tests/isDeployUser.test.js
+++ b/tests/isDeployUser.test.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const vm = require('vm');
 
 describe('isDeployUser uses ADMIN_EMAIL property', () => {
-  const errorHandlerCode = fs.readFileSync('src/errorHandler.gs', 'utf8');
+  const errorHandlerCode = fs
+    .readFileSync('src/errorHandler.js.html', 'utf8')
+    .split('\n')
+    .slice(1, -1)
+    .join('\n');
   const code = fs.readFileSync('src/Core.gs', 'utf8');
   let context;
   beforeEach(() => {

--- a/tests/questionConfig.test.js
+++ b/tests/questionConfig.test.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const vm = require('vm');
 
 describe('getQuestionConfig simple', () => {
-  const errorHandlerCode = fs.readFileSync('src/errorHandler.gs', 'utf8');
+  const errorHandlerCode = fs
+    .readFileSync('src/errorHandler.js.html', 'utf8')
+    .split('\n')
+    .slice(1, -1)
+    .join('\n');
   const code = fs.readFileSync('src/Core.gs', 'utf8');
   const context = {
     Utilities: { getUuid: () => 'test-uuid-' + Math.random() }

--- a/tests/verifyUserAccess.test.js
+++ b/tests/verifyUserAccess.test.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const vm = require('vm');
 
 describe('verifyUserAccess security checks', () => {
-  const errorHandlerCode = fs.readFileSync('src/errorHandler.gs', 'utf8');
+  const errorHandlerCode = fs
+    .readFileSync('src/errorHandler.js.html', 'utf8')
+    .split('\n')
+    .slice(1, -1)
+    .join('\n');
   const coreCode = fs.readFileSync('src/Core.gs', 'utf8');
   let context;
 


### PR DESCRIPTION
## Summary
- update tests to load renamed errorHandler.js.html and strip script tags
- sync Core.gs and README with new error handler filename

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ea7fcc0fc832ba22c7796d7f4311a