### PR TITLE
fix: load error handler before core

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -10,7 +10,10 @@ if (typeof debugLog === 'undefined') {
 
 // Import standardized error handling functions
 if (typeof logError === 'undefined') {
-  throw new Error('errorHandler.js.html must be loaded before Core.gs');
+  eval(HtmlService.createHtmlOutputFromFile('errorHandler.js').getContent());
+  if (typeof logError === 'undefined') {
+    throw new Error('Failed to load errorHandler.js before Core.gs');
+  }
 }
 
 if (typeof warnLog === 'undefined') {


### PR DESCRIPTION
## Summary
- dynamically load `errorHandler.js` when `Core.gs` initializes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eaa15d4f0832ba0abf82d8843b394