### PR TITLE
fix: remove script tags when loading error handler

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -8,9 +8,15 @@ if (typeof debugLog === 'undefined') {
   var debugLog = function() {};
 }
 
-// Import standardized error handling functions
+// Import standardized error handling functions from the shared HTML file
 if (typeof logError === 'undefined') {
-  eval(HtmlService.createHtmlOutputFromFile('errorHandler.js').getContent());
+  const errorHandlerCode = HtmlService
+    .createHtmlOutputFromFile('errorHandler.js')
+    .getContent()
+    .replace(/<script[^>]*>/i, '')
+    .replace(/<\/script>/i, '')
+    .trim();
+  eval(errorHandlerCode);
   if (typeof logError === 'undefined') {
     throw new Error('Failed to load errorHandler.js before Core.gs');
   }


### PR DESCRIPTION
## Summary
- strip `<script>` tags from errorHandler.js content before evaluating it
- streamline error handler import to a single evaluation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eac9b1fc8832bbe7c3001baa26108