### PR TITLE
fix(logging): add logDebug alias for compatibility

### DIFF
--- a/src/debugConfig.gs
+++ b/src/debugConfig.gs
@@ -170,3 +170,12 @@ function updateDebugConfig(newConfig) {
   Object.assign(DEBUG_CONFIG, newConfig);
   infoLog('デバッグ設定を更新しました', newConfig);
 }
+
+/**
+ * 旧式のデバッグロガー。互換性のために残しています。
+ * @deprecated debugLog の使用を推奨します。
+ * @param {...any} args debugLog へ渡す引数。
+ */
+function logDebug(...args) {
+  debugLog(...args);
+}


### PR DESCRIPTION
## Summary
- add `logDebug` wrapper around `debugLog`
- ensure newline termination in `debugConfig.gs`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eba3a2834832ba2402665a60f58ef