### PR TITLE
fix: close admin panel events function

### DIFF
--- a/src/adminPanel-events.js.html
+++ b/src/adminPanel-events.js.html
@@ -296,7 +296,10 @@ function setupEventListeners() {
   // Real-time validation
   setupRealtimeValidation();
   
-  UnifiedErrorHandler.logError('✅ AdminPanel: Event handlers ready', UnifiedErrorHandler.ErrorTypes.INFO, UnifiedErrorHandler.ErrorCategories.SYSTEM_INITIALIZATION);
+    UnifiedErrorHandler.logError('✅ AdminPanel: Event handlers ready', UnifiedErrorHandler.ErrorTypes.INFO, UnifiedErrorHandler.ErrorCategories.SYSTEM_INITIALIZATION);
+  }
+
+  // Close setupEventListeners
 }
 
 // =============================================================================
@@ -658,8 +661,9 @@ function manageFocusForModal(modalId, show) {
   if (!modal) return;
   
   if (show) {
-    // Store currently focused element
-    modal.setAttribute('data-previous-focus', document.activeElement?.id || '');
+    // Store currently focused element - avoid optional chaining for wider compatibility
+    var activeEl = document.activeElement;
+    modal.setAttribute('data-previous-focus', activeEl && activeEl.id ? activeEl.id : '');
     
     // Focus first interactive element in modal
     var firstFocusable = modal.querySelector('button, input, textarea, select, [tabindex]:not([tabindex="-1"])');


### PR DESCRIPTION
## Summary
- fix missing brace in admin panel events script and remove optional chaining in focus handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ebc5a158c832b9d814f40e147bf50