### PR TITLE
Refactor admin panel resource URL handling

### DIFF
--- a/src/adminPanel-ui.js.html
+++ b/src/adminPanel-ui.js.html
@@ -1600,19 +1600,20 @@ function updateFormUrlDisplay(status = null) {
   const formUrlInput = document.getElementById('form-url-input');
   const formUrlSection = document.getElementById('form-url-section');
   const openFormLink = document.getElementById('open-form-url-link');
-  
+
   if (!formUrlInput) return;
-  
+
   // 現在のstatusの最適化された取得
   const currentStatusToUse = status || currentStatus;
   if (!currentStatusToUse || !currentStatusToUse.userInfo) {
     logWarn('⚠️ updateFormUrlDisplay: status情報が不足しています');
     return;
   }
-  
-  // フォームURL取得の最適化（優先度順）
-  const formUrl = getFormUrlFromStatus(currentStatusToUse);
-  
+
+  // 新しい統一ヘルパー関数からフォームURLを取得
+  const resourceUrls = getActiveResourceUrls(currentStatusToUse);
+  const formUrl = resourceUrls.form;
+
   // UI更新の最適化
   if (formUrl) {
     updateFormUrlElements(formUrlInput, openFormLink, formUrl);
@@ -1622,41 +1623,6 @@ function updateFormUrlDisplay(status = null) {
     clearFormUrlElements(formUrlInput, formUrlSection);
     logDebug('📭 FormURL未設定のためUI非表示');
   }
-}
-
-// フォームURL取得の最適化されたヘルパー関数
-function getFormUrlFromStatus(status) {
-  const userInfo = status.userInfo;
-  
-  // 1. configJsonから直接取得（最も確実）
-  if (userInfo.configJson) {
-    try {
-      const configJson = typeof userInfo.configJson === 'string' 
-        ? JSON.parse(userInfo.configJson) 
-        : userInfo.configJson;
-      
-      if (configJson?.formUrl) {
-        logDebug('✅ FormURL: configJsonから取得');
-        return configJson.formUrl;
-      }
-    } catch (error) {
-      logWarn('⚠️ configJSON解析エラー:', error.message);
-    }
-  }
-  
-  // 2. ユーザー情報から直接取得
-  if (userInfo.formUrl) {
-    logDebug('📋 FormURL: userInfoから取得');
-    return userInfo.formUrl;
-  }
-  
-  // 3. カスタムフォーム情報から取得（後方互換性）
-  if (status.customFormInfo?.formUrl) {
-    logDebug('📄 FormURL: customFormInfoから取得');
-    return status.customFormInfo.formUrl;
-  }
-  
-  return null;
 }
 
 // フォームURL要素更新の最適化
@@ -2166,11 +2132,14 @@ function getActiveResourceUrls(status) {
 
 function updateSystemStatusDisplay(status) {
   if (!status) return;
-  
+
+  // すべてのリソースURLを一括取得
+  const resourceUrls = getActiveResourceUrls(status);
+
   // Update publish status
   const publishIndicator = document.getElementById('info-publish-indicator');
   const publishText = document.getElementById('info-publish-text');
-  
+
   if (status.isPublished) {
     publishIndicator.className = 'w-2 h-2 rounded-full bg-green-400';
     publishText.textContent = '公開中';
@@ -2178,12 +2147,12 @@ function updateSystemStatusDisplay(status) {
     publishIndicator.className = 'w-2 h-2 rounded-full bg-gray-400';
     publishText.textContent = '非公開';
   }
-  
+
   // Update other status fields
   document.getElementById('info-published-sheet').textContent = status.sheetName || '-';
   document.getElementById('info-display-mode').textContent = status.displayMode || '-';
   document.getElementById('info-show-counts').textContent = status.showCounts ? '表示' : '非表示';
-  
+
   // Enable resource buttons if URLs are available
   const spreadsheetBtn = document.getElementById('open-spreadsheet-btn');
   if (spreadsheetBtn) {
@@ -2196,113 +2165,34 @@ function updateSystemStatusDisplay(status) {
     }
   }
 
-  // フォームURLの取得（複数ソースから）
-  let formUrl = null;
-  
-  // 1. configJsonから取得（シート固有優先）
-  if (status.userInfo && status.userInfo.configJson) {
-    try {
-      const configJson = typeof status.userInfo.configJson === 'string' 
-        ? JSON.parse(status.userInfo.configJson) 
-        : status.userInfo.configJson;
-      
-      // 1a. シート固有のformURLを最優先
-      const publishedSheetName = configJson.publishedSheetName;
-      if (publishedSheetName) {
-        const sheetConfigKey = `sheet_${publishedSheetName}`;
-        const sheetConfig = configJson[sheetConfigKey];
-        if (sheetConfig && sheetConfig.formUrl) {
-          formUrl = sheetConfig.formUrl;
-          console.log('✅ FormURL found in sheet-specific config:', formUrl);
-        }
-      }
-      
-      // 1b. フォールバック: トップレベルのformURL
-      if (!formUrl && configJson && configJson.formUrl) {
-        formUrl = configJson.formUrl;
-        console.log('✅ FormURL found in top-level configJson:', formUrl);
-      }
-    } catch (error) {
-      console.warn('⚠️ configJson parse error:', error);
-    }
-  }
-  
-  // 2. userInfo.formUrlから取得（フォールバック）
-  if (!formUrl && status.userInfo && status.userInfo.formUrl) {
-    formUrl = status.userInfo.formUrl;
-    console.log('📋 FormURL found in userInfo:', formUrl);
-  }
-  
-  // 3. customFormInfoから取得（後方互換性）
-  if (!formUrl && status.customFormInfo && status.customFormInfo.formUrl) {
-    formUrl = status.customFormInfo.formUrl;
-    console.log('📄 FormURL found in customFormInfo:', formUrl);
-  }
-  
-  // statusオブジェクトにformUrlを設定
-  status.formUrl = formUrl;
-
-  // folderUrlとeditFormUrlも同様に設定（updateNewResourceButtons用）
-  if (status.userInfo && status.userInfo.configJson) {
-    try {
-      const configJson = typeof status.userInfo.configJson === 'string' 
-        ? JSON.parse(status.userInfo.configJson) 
-        : status.userInfo.configJson;
-      
-      // フォルダURL設定
-      status.folderUrl = configJson.folderUrl;
-      
-      // 編集フォームURL設定（シート固有優先）
-      const publishedSheetName = configJson.publishedSheetName;
-      if (publishedSheetName) {
-        const sheetConfigKey = `sheet_${publishedSheetName}`;
-        const sheetConfig = configJson[sheetConfigKey];
-        if (sheetConfig && sheetConfig.editFormUrl) {
-          status.editFormUrl = sheetConfig.editFormUrl;
-        }
-      }
-      
-      // フォールバック: トップレベルのeditFormUrl
-      if (!status.editFormUrl && configJson.editFormUrl) {
-        status.editFormUrl = configJson.editFormUrl;
-      }
-    } catch (error) {
-      console.warn('⚠️ Failed to extract additional URLs from configJson:', error);
-    }
-  }
-
-  if (status.formUrl) { // statusオブジェクトにformUrlが存在する場合
-    if (formBtn) {
+  // フォームボタンの有効化/無効化
+  const formBtn = document.getElementById('open-form-btn');
+  if (formBtn) {
+    if (resourceUrls.form) {
       formBtn.disabled = false;
-      // onclick は既に adminPanel-events.js で openForm 関数が設定されているため、
-      // ここでは disabled 状態とスタイルのみを制御
       formBtn.title = 'フォームを開く';
       formBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-      console.log('✅ Form button enabled with URL:', status.formUrl);
-    }
-  } else { // formUrlが存在しない場合、ボタンを無効化し、メッセージを表示
-    if (formBtn) {
+    } else {
       formBtn.disabled = true;
-      // onclick イベントは既存のものを保持（openForm関数）
       formBtn.title = 'フォームURLが未設定です。フォームを作成してください。';
       formBtn.classList.add('opacity-50', 'cursor-not-allowed');
-      console.log('⚠️ Form button disabled - no URL available');
     }
   }
-  
+
   // Handle generic resource button in Step 1 (spreadsheet only)
-  if (resourceBtn && status.spreadsheetUrl) {
+  const resourceBtn = document.getElementById('add-resource-btn');
+  if (resourceBtn && resourceUrls.spreadsheet) {
     resourceBtn.disabled = false;
     resourceBtn.onclick = () => {
-      window.open(status.spreadsheetUrl, '_blank');
+      window.open(resourceUrls.spreadsheet, '_blank');
     };
-    
+
     // Update button title for spreadsheet only
     resourceBtn.title = 'スプレッドシートを開く';
   }
-  
+
   // Handle new resource buttons
-  updateNewResourceButtons(status);
+  updateNewResourceButtons(resourceUrls);
 }
 
 // Navigate to specific step
@@ -3057,13 +2947,13 @@ function formatDateTime(date) {
 }
 
 // 新しいリソースボタンを更新する関数
-function updateNewResourceButtons(status) {
+function updateNewResourceButtons(resourceUrls) {
   const folderBtn = document.getElementById('open-folder-btn');
   const editFormBtn = document.getElementById('open-edit-form-btn');
-  
-  // statusオブジェクトから直接URLを取得（updateSystemStatusDisplayで設定済み）
-  const folderUrl = status.folderUrl;
-  const editFormUrl = status.editFormUrl;
+
+  // 引数で渡されたURLを使用
+  const folderUrl = resourceUrls.folder;
+  const editFormUrl = resourceUrls.editForm;
   
   // フォルダボタンの有効化
   if (folderBtn) {


### PR DESCRIPTION
## Summary
- streamline `updateSystemStatusDisplay` to derive resource URLs via `getActiveResourceUrls`
- pass unified resource URLs to `updateNewResourceButtons` and simplify its signature
- remove obsolete form URL parsing helper in favor of the unified URL retrieval

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f51b15d74832bb2e627d1b3a7cc18