### PR TITLE
Improve custom setup state handling

### DIFF
--- a/tests/applyAutoConfiguration.test.js
+++ b/tests/applyAutoConfiguration.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('applyAutoConfiguration', () => {
+  let context;
+  beforeEach(() => {
+    const errorHandlerCode = fs.readFileSync('src/errorHandler.gs', 'utf8');
+    const coreCode = fs.readFileSync('src/Core.gs', 'utf8');
+    context = {
+      console,
+      debugLog: () => {},
+      infoLog: jest.fn(),
+      errorLog: jest.fn(),
+      Utilities: { getUuid: () => 'test-uuid' }
+    };
+    vm.createContext(context);
+    vm.runInContext(errorHandlerCode, context);
+    vm.runInContext(coreCode, context);
+    context.saveSheetConfig = jest.fn();
+  });
+
+  test('returns success when saveSheetConfig succeeds', () => {
+    context.saveSheetConfig.mockReturnValue({ status: 'success', message: 'ok' });
+    const res = context.applyAutoConfiguration('U', 'SID', 'Sheet1', {
+      success: true,
+      guessedConfig: { opinionHeader: 'Q', nameHeader: 'N' }
+    });
+    expect(res.success).toBe(true);
+    expect(context.saveSheetConfig).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries and fails when saveSheetConfig keeps failing', () => {
+    context.saveSheetConfig.mockReturnValue({ status: 'error', message: 'fail' });
+    const res = context.applyAutoConfiguration('U', 'SID', 'Sheet1', {
+      success: true,
+      guessedConfig: { opinionHeader: 'Q', nameHeader: 'N' }
+    });
+    expect(res.success).toBe(false);
+    expect(context.saveSheetConfig).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- make auto configuration save robust with validation and retry
- keep user config in sync after publishing to avoid pending setup state
- expose actual completion status in custom setup response

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6890130ea560832b9f6e63d076eb0651