### PR TITLE
Ensure board URL retrieval falls back when Apps Script API is unavailable

### DIFF
--- a/src/url.gs
+++ b/src/url.gs
@@ -43,12 +43,30 @@ function getWebAppUrl() {
     }).deployments || [];
     const webApp = deployments.find(d => d.deploymentConfig && d.deploymentConfig.webApp);
     const url = webApp ? webApp.deploymentConfig.webApp.url : '';
-    infoLog('Web app URL obtained:', url);
-    return url;
+    if (url) {
+      infoLog('Web app URL obtained:', url);
+      return url;
+    }
+    warnLog('getWebAppUrl: no deployments found, falling back');
   } catch (e) {
-    errorLog('getWebAppUrl error:', e.message);
-    return '';
+    warnLog('getWebAppUrl API error:', e.message);
   }
+
+  // Fallback to ScriptApp service URL if API is unavailable or returns nothing
+  try {
+    const serviceUrl = ScriptApp.getService && ScriptApp.getService().getUrl
+      ? ScriptApp.getService().getUrl()
+      : '';
+    if (serviceUrl) {
+      infoLog('Web app URL fallback obtained:', serviceUrl);
+      return serviceUrl;
+    }
+    warnLog('getWebAppUrl fallback failed: service URL unavailable');
+  } catch (e) {
+    errorLog('getWebAppUrl fallback error:', e.message);
+  }
+
+  return '';
 }
 
 /**

--- a/tests/getWebAppUrl.test.js
+++ b/tests/getWebAppUrl.test.js
@@ -24,4 +24,24 @@ describe('getWebAppUrl', () => {
     vm.runInContext(urlCode, context);
     expect(context.getWebAppUrl()).toBe('https://script.google.com/macros/s/ID/exec');
   });
+
+  test('falls back to ScriptApp service URL when API fails', () => {
+    const context = {
+      ScriptApp: {
+        getScriptId: () => 'ID',
+        getService: () => ({ getUrl: () => 'https://script.google.com/macros/s/ID/exec' })
+      },
+      AppsScript: {
+        Script: {
+          Deployments: {
+            list: () => { throw new Error('API disabled'); }
+          }
+        }
+      },
+      console: { log: () => {}, error: () => {}, warn: () => {} }
+    };
+    vm.createContext(context);
+    vm.runInContext(urlCode, context);
+    expect(context.getWebAppUrl()).toBe('https://script.google.com/macros/s/ID/exec');
+  });
 });


### PR DESCRIPTION
## Summary
- Enhance `getWebAppUrl` to fall back to `ScriptApp.getService().getUrl()` when Apps Script API cannot provide a deployment URL
- Add test confirming the fallback behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890a3a65b34832bbb6f6c368cdb1573