### PR TITLE
fix: ensure custom form has default title

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -4968,10 +4968,12 @@ function createCustomFormAndSheet(userEmail, requestUserId, config) {
     }
   };
 
-  const overrides = {
-    titlePrefix: config.formTitle || 'カスタムフォーム',
-    customConfig: convertedConfig
-  };
+  const overrides = { customConfig: convertedConfig };
+  if (config.formTitle) {
+    overrides.formTitle = config.formTitle;
+  } else {
+    overrides.titlePrefix = 'カスタムフォーム';
+  }
 
   const formAndSsInfo = createUnifiedForm('custom', userEmail, requestUserId, overrides);
 
@@ -5059,10 +5061,12 @@ function createCustomFormUI(requestUserId, config) {
 
     debugLog('createCustomFormUI - converted config:', JSON.stringify(convertedConfig));
 
-    const overrides = {
-      titlePrefix: config.formTitle || 'カスタムフォーム',
-      customConfig: convertedConfig
-    };
+    const overrides = { customConfig: convertedConfig };
+    if (config.formTitle) {
+      overrides.formTitle = config.formTitle;
+    } else {
+      overrides.titlePrefix = 'カスタムフォーム';
+    }
 
     const result = createUnifiedForm('custom', activeUserEmail, requestUserId, overrides);
 

--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -1822,6 +1822,27 @@ function loadSavedClassChoices() {
 }
 
 // Create form with custom configuration
+/**
+ * QuickStartと同じ形式のフォームタイトルを生成する。
+ * @returns {string} フォームタイトル。
+ */
+function generateQuickstartFormTitle() {
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: 'Asia/Tokyo'
+  });
+  const formatted = formatter.format(now);
+  const [datePart, timePart] = formatted.split(' ');
+  const [year, month, day] = datePart.split('/');
+  return `みんなの回答ボード ${year}年${month}月${day}日 ${timePart}`;
+}
+
 function createFormWithConfig() {
   const questionTextarea = document.getElementById('custom-main-question');
   const questionTypeSelect = document.getElementById('main-question-type');
@@ -1866,6 +1887,7 @@ function createFormWithConfig() {
     classChoices: classChoices,
     includeOthers: includeOthersOption,
     enableClass: enableClassSelection && classChoices.length > 0,
+    formTitle: generateQuickstartFormTitle(),
   };
   
   console.log('📋 カスタムフォーム設定準備完了');


### PR DESCRIPTION
## Summary
- generate QuickStart-like form title and include in custom setup
- use provided form title directly when creating custom form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68918c399e60832b8690f537347b8bea