### PR TITLE
Refactor admin panel resources and maintenance layout

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -1025,25 +1025,19 @@
               </svg>
               スプレッドシート
             </button>
-            <button type="button" id="open-folder-btn" class="flex-1 bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all" disabled>
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>
-              </svg>
-              フォルダ
-            </button>
-          </div>
-          <div class="flex gap-2">
             <button type="button" id="open-form-btn" class="flex-1 bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all" disabled>
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
               </svg>
               フォーム(回答)
             </button>
-            <button type="button" id="open-edit-form-btn" class="flex-1 bg-purple-600 hover:bg-purple-700 text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all" disabled>
+          </div>
+          <div>
+            <button type="button" id="open-folder-btn" class="w-full bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all" disabled>
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>
               </svg>
-              フォーム(編集)
+              フォルダ
             </button>
           </div>
         </div>
@@ -1074,29 +1068,44 @@
         </div>
       </div>
       
-      <!-- セットアップ修復ツール -->
-      <div class="bg-red-900/10 border border-red-500/30 rounded-lg p-3 transition-all hover:border-red-500/50">
-        <h4 class="text-sm font-medium text-red-300 mb-3 flex items-center gap-2">
+      <!-- 管理ツール -->
+      <div class="bg-red-900/10 border border-red-500/30 rounded-lg p-3 transition-all hover:border-red-500/50 space-y-3">
+        <h4 class="text-sm font-medium text-red-300 flex items-center gap-2">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
           </svg>
-          修復ツール
+          管理ツール
         </h4>
-        <div class="space-y-2">
-          <button type="button" id="setup-repair-btn" onclick="runSetupRepair()" 
-                  class="w-full bg-red-600 hover:bg-red-700 text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all text-xs">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 7.172V5L8 4z"></path>
-            </svg>
-            セットアップ状態を修復
-          </button>
-          <p class="text-xs text-red-200/70">
-            ステップ表示の不整合やフォームURL問題を自動修復します
-          </p>
+        <div class="space-y-3 text-xs">
+          <div>
+            <button type="button" id="setup-repair-btn" onclick="runSetupRepair()" class="w-full bg-red-600 hover:bg-red-700 text-white px-3 py-2 rounded flex items-center justify-center gap-2 transition-all">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 7.172V5L8 4z"></path>
+              </svg>
+              セットアップ状態を修復
+            </button>
+            <p class="mt-1 text-red-200/70">ステップ表示の不整合やフォームURL問題を自動修復します</p>
+          </div>
+          <div>
+            <button type="button" id="reset-config-btn" class="w-full bg-orange-600 hover:bg-orange-700 text-white px-3 py-2 rounded border border-orange-500 flex items-center justify-center gap-2 transition-colors" title="データベースの設定を初期値にリセット">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+              </svg>
+              設定をリセット
+            </button>
+            <p class="mt-1 text-orange-200/80">設定を初期状態にリセットします。アカウントは削除されません。</p>
+          </div>
+          <div>
+            <button type="button" id="delete-account-btn" class="btn btn-danger w-full text-sm py-2">
+              <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
+              <span>自分のアカウントを完全に削除する</span>
+            </button>
+            <p class="mt-1 text-red-200/80">この操作は元に戻せません。アカウントを削除すると、作成したすべてのボードと設定が完全に消去されます。</p>
+          </div>
         </div>
       </div>
-      
+
       <!-- アプリ設定リンク -->
 <? if (isDeployUser) { ?>
       <div id="app-setup-link" class="bg-blue-900/10 border border-blue-500/30 rounded-lg p-3 transition-all hover:border-blue-500/50">
@@ -1139,45 +1148,6 @@
           </div>
         </div>
       </div>
-      
-      <details id="account-deletion-section" class="bg-red-900/10 border border-red-500/30 rounded-lg transition-all hover:border-red-500/50">
-        <summary class="p-3 cursor-pointer text-sm font-medium text-red-300 hover:text-red-200 flex items-center justify-between">
-          <span>アカウントの管理</span>
-          <svg class="w-4 h-4 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
-        </summary>
-        <div class="p-3 pt-0 space-y-3">
-          <p class="text-xs text-red-200/80 mb-3">
-            この操作は元に戻せません。アカウントを削除すると、作成したすべてのボードと設定が完全に消去されます。
-          </p>
-          
-          <!-- 設定リセットボタン -->
-          <div class="bg-orange-900/20 border border-orange-500/30 rounded-lg p-3">
-            <div class="flex items-start gap-2 mb-2">
-              <svg class="w-4 h-4 text-orange-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
-              </svg>
-              <div class="flex-1">
-                <h5 class="text-xs font-medium text-orange-300 mb-1">設定をリセット</h5>
-                <p class="text-xs text-orange-200/80 mb-3">設定を初期状態にリセットします。アカウントは削除されません。</p>
-                <button type="button" id="reset-config-btn" 
-                        class="text-xs bg-orange-600 hover:bg-orange-700 text-white px-3 py-1.5 rounded border border-orange-500 transition-colors flex items-center gap-1.5"
-                        title="データベースの設定を初期値にリセット">
-                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
-                  </svg>
-                  設定をリセット
-                </button>
-              </div>
-            </div>
-          </div>
-          
-          <!-- アカウント削除ボタン -->
-          <button type="button" id="delete-account-btn" class="btn btn-danger w-full text-sm py-2">
-            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
-            <span>自分のアカウントを完全に削除する</span>
-          </button>
-        </div>
-      </details>
       </div>
     </div>
   </main>

--- a/src/adminPanel-ui.js.html
+++ b/src/adminPanel-ui.js.html
@@ -2218,8 +2218,7 @@ function getActiveResourceUrls(status) {
   const urls = {
     spreadsheet: null,
     folder: null,
-    form: null,
-    editForm: null
+    form: null
   };
 
   if (!status || !status.userInfo) {
@@ -2242,7 +2241,11 @@ function getActiveResourceUrls(status) {
   }
 
   // 3. フォルダURLの取得 (configJsonから)
-  urls.folder = config.folderUrl || null;
+  if (config.folderUrl) {
+    urls.folder = config.folderUrl;
+  } else if (config.folderId) {
+    urls.folder = `https://drive.google.com/drive/folders/${config.folderId}`;
+  }
 
   // 4. フォームURLの取得 (configJsonから、公開シートを優先)
   const publishedSheetName = config.publishedSheetName;
@@ -2250,16 +2253,12 @@ function getActiveResourceUrls(status) {
     const sheetConfig = config[`sheet_${publishedSheetName}`];
     if (sheetConfig) {
       urls.form = sheetConfig.formUrl || urls.form;
-      urls.editForm = sheetConfig.editFormUrl || urls.editForm;
     }
   }
   
   // フォールバック: トップレベルのフォームURL
   if (!urls.form && config.formUrl) {
     urls.form = config.formUrl;
-  }
-  if (!urls.editForm && config.editFormUrl) {
-    urls.editForm = config.editFormUrl;
   }
 
   return urls;
@@ -2317,7 +2316,7 @@ function updateSystemStatusDisplay(status) {
   // Handle generic resource button in Step 1 (any resource)
   const resourceBtn = document.getElementById('add-resource-btn');
   if (resourceBtn) {
-    const anyResourceUrl = resourceUrls.spreadsheet || resourceUrls.folder || resourceUrls.form || resourceUrls.editForm;
+    const anyResourceUrl = resourceUrls.spreadsheet || resourceUrls.folder || resourceUrls.form;
     resourceBtn.disabled = false;
     if (anyResourceUrl) {
       resourceBtn.onclick = () => window.open(anyResourceUrl, '_blank');
@@ -3163,11 +3162,9 @@ function formatDateTime(date) {
 // 新しいリソースボタンを更新する関数
 function updateNewResourceButtons(resourceUrls) {
   const folderBtn = document.getElementById('open-folder-btn');
-  const editFormBtn = document.getElementById('open-edit-form-btn');
 
   // 引数で渡されたURLを使用
   const folderUrl = resourceUrls.folder;
-  const editFormUrl = resourceUrls.editForm;
   
   // フォルダボタンの有効化
   if (folderBtn) {
@@ -3181,21 +3178,6 @@ function updateNewResourceButtons(resourceUrls) {
       folderBtn.onclick = () => showMessage('フォルダURLが未設定です', 'warning');
       folderBtn.title = 'フォルダURLが未設定です';
       console.log('⚠️ Folder button enabled - no URL available');
-    }
-  }
-
-  // 編集フォームボタンの有効化
-  if (editFormBtn) {
-    editFormBtn.disabled = false;
-    editFormBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-    if (editFormUrl) {
-      editFormBtn.onclick = () => window.open(editFormUrl, '_blank');
-      editFormBtn.title = 'フォーム編集画面を開く';
-      console.log('✅ Edit form button enabled with URL:', editFormUrl);
-    } else {
-      editFormBtn.onclick = () => showMessage('編集フォームURLが未設定です', 'warning');
-      editFormBtn.title = '編集フォームURLが未設定です';
-      console.log('⚠️ Edit form button enabled - no URL available');
     }
   }
 }


### PR DESCRIPTION
## Summary
- Simplify resource controls: keep only spreadsheet and response form side-by-side with a full-width folder button
- Group repair, reset, and account deletion actions in a single "管理ツール" block for easier access
- Remove edit-form handling from UI logic and build folder URL from `folderId` when needed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891b608127c832bbc4c75f3eb46e24a