### PR TITLE
fix: refresh admin UI after unpublish

### DIFF
--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -1643,19 +1643,15 @@ function unpublishBoard() {
   return runGasWithUserId('unpublishBoard', 'ボードの公開を停止中...')
     .then(function(response) {
       logDebug('公開停止レスポンス:', response);
-      showMessage(response.message || '✅ 回答ボードの公開を停止しました。', 'success');
-      
       // 公開停止時に履歴を保存
       saveHistoryOnUnpublish(response);
-      
+
       // 強化されたキャッシュクリア処理（キャッシュバスティング対応）
       clearAllCachesForUnpublish();
-      
+
       // Reset column selection dropdowns to default "--列を選択--" state
       resetColumnSelections();
-      
-      loadStatus(true); // ステータスを強制更新
-      
+
       // 公開停止処理が成功したことを返す
       return Promise.resolve(response);
     })

--- a/src/adminPanel-events.js.html
+++ b/src/adminPanel-events.js.html
@@ -51,7 +51,19 @@ function setupEventListeners() {
       showConfirmationModal(
         '公開停止の確認',
         '回答ボードの公開を停止しますか？',
-        unpublishBoard
+        function() {
+          unpublishBoard()
+            .then(function() {
+              return loadStatus(true);
+            })
+            .then(function() {
+              showMessage('回答ボードは非公開になりました。', 'success');
+            })
+            .catch(function(error) {
+              console.error('❌ 公開停止に失敗しました:', error);
+              showMessage('❌ 公開停止に失敗しました。再度お試しください。', 'error');
+            });
+        }
       );
     });
   }
@@ -224,15 +236,17 @@ function setupEventListeners() {
   // 公開停止→フォーム作成の実行
   function executeStopAndCreateForm() {
     console.log('🛑 公開停止処理を実行中...');
-    
+
     // unpublishBoard関数を呼び出し
     unpublishBoard()
       .then(function(response) {
         console.log('✅ 公開停止が完了しました:', response);
-        
+        return loadStatus(true).then(() => response);
+      })
+      .then(function(response) {
         // 公開停止が確実に完了した旨を表示
         showMessage('✅ 公開停止が完了しました。カスタムフォームを作成できます。', 'success');
-        
+
         // 全セクション展開フラグを設定（公開停止後の管理パネル表示改善）
         try {
           localStorage.setItem('expandAllSections', 'true');
@@ -240,7 +254,7 @@ function setupEventListeners() {
         } catch (e) {
           console.warn('⚠️ localStorage設定に失敗:', e);
         }
-        
+
         // 少し遅延してからフォーム作成モーダルを表示
         setTimeout(function() {
           console.log('🎨 フォーム作成モーダルを表示します');

--- a/src/main.gs
+++ b/src/main.gs
@@ -1055,21 +1055,19 @@ function processViewRequest(userInfo, params) {
     isCurrentlyPublished: isCurrentlyPublished
   });
 
-  // Redirect to unpublished page if not published
+  // Redirect to access restricted page if not published
   if (!isCurrentlyPublished) {
-    infoLog('🚫 Board is unpublished, redirecting to Unpublished page immediately');
-    debugLog('🔍 UserInfo for unpublished page:', {
-      userId: userInfo.userId,
-      adminEmail: userInfo.adminEmail,
-      spreadsheetId: userInfo.spreadsheetId
-    });
+    infoLog('🚫 Board is unpublished, redirecting to Access Restricted page');
 
-    try {
-      return renderUnpublishedPage(userInfo, params);
-    } catch (unpublishedError) {
-      logError(unpublishedError, 'renderUnpublishedPage', ERROR_SEVERITY.HIGH, ERROR_CATEGORIES.SYSTEM);
-      return renderMinimalUnpublishedPage(userInfo);
-    }
+    const accessCheck = {
+      hasAccess: false,
+      isApplicationEnabled: true,
+      isSystemAdmin: false,
+      userEmail: Session.getActiveUser().getEmail(),
+      accessReason: 'Board is unpublished'
+    };
+
+    return showAccessRestrictedPage(accessCheck);
   }
 
   return renderAnswerBoard(userInfo, params);


### PR DESCRIPTION
## Summary
- refresh admin panel after unpublishing by reloading status and showing feedback
- clean up unpublishBoard API to leave UI updates to caller
- show access restricted page when visiting unpublished board

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891c12756c8832ba7aabefdf28687d3