### PR TITLE
fix: guard missing modal handlers in admin panel

### DIFF
--- a/src/adminPanel-events.js.html
+++ b/src/adminPanel-events.js.html
@@ -1,3 +1,4 @@
+
 <script>
 // =============================================================================
 // ADMIN PANEL EVENT LISTENERS & UI INTERACTIONS
@@ -318,15 +319,22 @@ function setupFormConfigModalHandlers() {
   var formConfigClose = document.getElementById('form-config-close');
   var formConfigCancel = document.getElementById('form-config-cancel');
   var formConfigCreate = document.getElementById('form-config-create');
-  
-  if (formConfigClose) {
+
+  // hideFormConfigModal が未定義の場合はイベント登録をスキップ
+  var canHideModal = typeof hideFormConfigModal === 'function';
+
+  if (formConfigClose && canHideModal) {
     formConfigClose.addEventListener('click', hideFormConfigModal);
   }
-  
-  if (formConfigCancel) {
+
+  if (formConfigCancel && canHideModal) {
     formConfigCancel.addEventListener('click', hideFormConfigModal);
   }
-  
+
+  if (!canHideModal) {
+    console.error('hideFormConfigModal function not found');
+  }
+
   if (formConfigCreate) {
     formConfigCreate.addEventListener('click', createFormWithConfig);
   }


### PR DESCRIPTION
## Summary
- avoid crashing event initialization when `hideFormConfigModal` is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891caa7e800832bb79b2f0225c8a81c