### PR TITLE
feat: save history locally on publish

### DIFF
--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -1438,9 +1438,8 @@ function proceedWithSaveAndPublish(config) {
       if (result && (result.userInfo || result.status === 'success')) {
         showMessage('✅ 設定が保存され、ボードが公開されました！', 'success');
         
-        // 履歴に保存
-        // 公開時は履歴保存を行わない（公開停止時に保存するため）
-        logDebug('Board published successfully - history will be saved on unpublish');
+        // 履歴に保存（公開時）
+        saveHistoryOnPublish(result, config);
         
         // ボードビューアーに即座更新を通知
         try {
@@ -1640,83 +1639,53 @@ async function clearAllCachesForUnpublish() {
 
 // Unpublish board
 function unpublishBoard() {
-  return runGasWithUserId('unpublishBoard', 'ボードの公開を停止中...')
-    .then(function(response) {
-      logDebug('公開停止レスポンス:', response);
-      // 公開停止時に履歴を保存
-      saveHistoryOnUnpublish(response);
+    return runGasWithUserId('unpublishBoard', 'ボードの公開を停止中...')
+      .then(function(response) {
+        logDebug('公開停止レスポンス:', response);
 
-      // 強化されたキャッシュクリア処理（キャッシュバスティング対応）
-      clearAllCachesForUnpublish();
+        // 強化されたキャッシュクリア処理（キャッシュバスティング対応）
+        clearAllCachesForUnpublish();
 
-      // Reset column selection dropdowns to default "--列を選択--" state
-      resetColumnSelections();
+        // Reset column selection dropdowns to default "--列を選択--" state
+        resetColumnSelections();
 
-      // 公開停止処理が成功したことを返す
-      return Promise.resolve(response);
-    })
-    .catch(function(error) {
-      handleError(error, 'unpublishBoard', 'ボードの公開停止に失敗しました。');
-      // エラーを再スローして呼び出し元でキャッチできるようにする
-      return Promise.reject(error);
-    });
-}
-
-// 公開停止時に履歴を保存する関数
-function saveHistoryOnUnpublish(unpublishResponse) {
-  try {
-    // 現在のステータスを取得（キャッシュから）
-    const currentStatus = window.lastStatusCache;
-    if (!currentStatus || !currentStatus.config) {
-      logWarn('履歴保存: 現在のステータス情報が取得できません');
-      return;
-    }
-    
-    const config = currentStatus.config;
-    const userInfo = currentStatus.userInfo || {};
-    
-    // 履歴アイテムを作成
-    const historyItem = {
-      questionText: config.opinionHeader || config.opinionColumn || userInfo.customFormInfo?.mainQuestion || '（問題文未設定）',
-      sheetName: config.publishedSheetName || '',
-      publishedAt: config.publishedAt || config.lastPublishedAt || new Date().toISOString(),
-      endTime: new Date().toISOString(), // 実際の終了日時
-      scheduledEndTime: config.scheduledEndTime || null, // 予定終了日時
-      answerCount: unpublishResponse.answerCount || currentStatus.answerCount || 0,
-      reactionCount: unpublishResponse.reactionCount || currentStatus.reactionCount || 0,
-      config: config,
-      formUrl: userInfo.formUrl || '',
-      spreadsheetUrl: userInfo.spreadsheetUrl || '',
-      setupType: determineSetupType(config, userInfo),
-      isActive: false // 終了したのでfalse
-    };
-    
-    // LocalStorage履歴保存を実行
-    saveToHistory(historyItem);
-    
-    // サーバーサイド履歴保存も実行
-    try {
-      runGasWithUserId('saveHistoryToSheetAPI', '履歴をサーバーに保存中...', historyItem)
-        .then(response => {
-          if (response && response.status === 'success') {
-            logDebug('✅ サーバーサイド履歴保存完了:', response);
-          } else {
-            logWarn('⚠️ サーバーサイド履歴保存で警告:', response);
-          }
-        })
-        .catch(error => {
-          logWarn('❌ サーバーサイド履歴保存エラー:', error);
-        });
-    } catch (serverError) {
-      logWarn('❌ サーバーサイド履歴保存の呼び出しに失敗:', serverError);
-    }
-    
-    logDebug('履歴保存完了（公開停止時）:', historyItem);
-    
-  } catch (error) {
-    logWarn('公開停止時の履歴保存に失敗:', error);
+        // 公開停止処理が成功したことを返す
+        return Promise.resolve(response);
+      })
+      .catch(function(error) {
+        handleError(error, 'unpublishBoard', 'ボードの公開停止に失敗しました。');
+        // エラーを再スローして呼び出し元でキャッチできるようにする
+        return Promise.reject(error);
+      });
   }
-}
+
+  // 公開時に履歴を保存する関数
+  function saveHistoryOnPublish(publishResponse, config) {
+    try {
+      const userInfo = publishResponse.userInfo || {};
+      const historyItem = {
+        questionText:
+          config.opinionHeader ||
+          config.opinionColumn ||
+          userInfo.customFormInfo?.mainQuestion ||
+          '（問題文未設定）',
+        sheetName: config.publishedSheetName || '',
+        publishedAt: publishResponse.publishedAt || new Date().toISOString(),
+        answerCount: 0,
+        reactionCount: 0,
+        config: config,
+        formUrl: userInfo.formUrl || '',
+        spreadsheetUrl: userInfo.spreadsheetUrl || '',
+        setupType: determineSetupType(config, userInfo),
+        isActive: false
+      };
+
+      saveToHistory(historyItem);
+      logDebug('履歴保存完了（公開時）:', historyItem);
+    } catch (error) {
+      logWarn('公開時の履歴保存に失敗:', error);
+    }
+  }
 
 // セットアップタイプを判定する補助関数
 function determineSetupType(config, userInfo) {

--- a/src/adminPanel-events.js.html
+++ b/src/adminPanel-events.js.html
@@ -74,76 +74,47 @@ function setupEventListeners() {
     clearHistoryBtn.addEventListener('click', function() {
       console.log('🗑️ 履歴クリアボタンがクリックされました');
       
-      if (typeof showConfirmationModal === 'function') {
-        showConfirmationModal(
-          '履歴削除の確認',
-          'すべての履歴を削除しますか？この操作は取り消せません。',
-          function() {
-            console.log('📝 履歴削除が確認されました');
+        if (typeof showConfirmationModal === 'function') {
+          showConfirmationModal(
+            '履歴削除の確認',
+            'すべての履歴を削除しますか？この操作は取り消せません。',
+            function() {
+              console.log('📝 履歴削除が確認されました');
+              try {
+                localStorage.removeItem(HISTORY_STORAGE_KEY);
+                console.log('✅ ローカルストレージから履歴を削除しました');
+                showMessage('✅ 履歴をクリアしました', 'success');
+
+                // 履歴テーブルを更新
+                if (typeof loadSimpleHistoryTable === 'function') {
+                  loadSimpleHistoryTable();
+                  console.log('📊 履歴テーブルを更新しました');
+                } else {
+                  console.warn('⚠️ loadSimpleHistoryTable関数が見つかりません');
+                }
+              } catch (error) {
+                console.error('❌ 履歴クリアに失敗:', error);
+                showMessage('❌ 履歴クリアに失敗しました', 'error');
+              }
+            }
+          );
+        } else {
+          console.error('❌ showConfirmationModal関数が見つかりません');
+          // フォールバック: 直接確認
+          if (confirm('すべての履歴を削除しますか？この操作は取り消せません。')) {
             try {
               localStorage.removeItem(HISTORY_STORAGE_KEY);
-              console.log('✅ ローカルストレージから履歴を削除しました');
-              
-              // サーバーサイドの履歴もクリア
-              runGasWithUserId('clearHistoryFromServerAPI', 'サーバーから履歴をクリア中...')
-                .then(function(serverResponse) {
-                  console.log('✅ サーバーサイド履歴もクリアしました:', serverResponse);
-                  showMessage('✅ 履歴をクリアしました（ローカル・サーバー両方）', 'success');
-                  
-                  // 履歴テーブルを更新
-                  if (typeof loadSimpleHistoryTable === 'function') {
-                    loadSimpleHistoryTable();
-                    console.log('📊 履歴テーブルを更新しました');
-                  } else {
-                    console.warn('⚠️ loadSimpleHistoryTable関数が見つかりません');
-                  }
-                })
-                .catch(function(serverError) {
-                  console.warn('⚠️ サーバーサイド履歴クリアに失敗:', serverError);
-                  showMessage('✅ ローカル履歴をクリアしました（サーバー側は手動で確認してください）', 'success');
-                  
-                  // 履歴テーブルを更新
-                  if (typeof loadSimpleHistoryTable === 'function') {
-                    loadSimpleHistoryTable();
-                    console.log('📊 履歴テーブルを更新しました');
-                  } else {
-                    console.warn('⚠️ loadSimpleHistoryTable関数が見つかりません');
-                  }
-                });
+              console.log('✅ ローカルストレージから履歴を削除しました（フォールバック）');
+              showMessage('✅ 履歴をクリアしました', 'success');
+              if (typeof loadSimpleHistoryTable === 'function') {
+                loadSimpleHistoryTable();
+              }
             } catch (error) {
               console.error('❌ 履歴クリアに失敗:', error);
               showMessage('❌ 履歴クリアに失敗しました', 'error');
             }
           }
-        );
-      } else {
-        console.error('❌ showConfirmationModal関数が見つかりません');
-        // フォールバック: 直接確認
-        if (confirm('すべての履歴を削除しますか？この操作は取り消せません。')) {
-          try {
-            localStorage.removeItem(HISTORY_STORAGE_KEY);
-            console.log('✅ ローカルストレージから履歴を削除しました（フォールバック）');
-            
-            // サーバーサイドの履歴もクリア（フォールバック）
-            runGasWithUserId('clearHistoryFromServerAPI', 'サーバーから履歴をクリア中...')
-              .then(function(serverResponse) {
-                console.log('✅ サーバーサイド履歴もクリアしました（フォールバック）:', serverResponse);
-                showMessage('✅ 履歴をクリアしました（ローカル・サーバー両方）', 'success');
-              })
-              .catch(function(serverError) {
-                console.warn('⚠️ サーバーサイド履歴クリアに失敗（フォールバック）:', serverError);
-                showMessage('✅ ローカル履歴をクリアしました（サーバー側は手動で確認してください）', 'success');
-              });
-            
-            if (typeof loadSimpleHistoryTable === 'function') {
-              loadSimpleHistoryTable();
-            }
-          } catch (error) {
-            console.error('❌ 履歴クリアに失敗:', error);
-            showMessage('❌ 履歴クリアに失敗しました', 'error');
-          }
         }
-      }
     });
     console.log('✅ 履歴クリアボタンのイベントリスナーを設定しました');
   } else {

--- a/src/adminPanel-ui.js.html
+++ b/src/adminPanel-ui.js.html
@@ -2520,61 +2520,6 @@ function generateHistoryId() {
 /**
  * 簡単な履歴テーブルを表示（新実装）
  */
-// 履歴同期の管理変数
-let historySyncInProgress = false;
-let lastHistorySync = 0;
-const HISTORY_SYNC_COOLDOWN = 60000; // 1分のクールダウン
-
-/**
- * サーバーから履歴を同期してLocalStorageに保存（最適化版）
- */
-async function syncHistoryFromServer() {
-  try {
-    // 重複同期防止チェック
-    const now = Date.now();
-    if (historySyncInProgress) {
-      console.log('🔄 履歴同期が既に実行中です。スキップします。');
-      return getHistoryFromStorage(); // ローカルの履歴を返す
-    }
-    
-    // クールダウンチェック
-    if (now - lastHistorySync < HISTORY_SYNC_COOLDOWN) {
-      const remainingTime = Math.ceil((HISTORY_SYNC_COOLDOWN - (now - lastHistorySync)) / 1000);
-      console.log(`⏳ 履歴同期のクールダウン中です。あと${remainingTime}秒後に実行可能です。`);
-      return getHistoryFromStorage(); // ローカルの履歴を返す
-    }
-    
-    historySyncInProgress = true;
-    lastHistorySync = now;
-    console.log('🔄 サーバーから履歴を同期中...');
-    
-    const response = await runGasWithUserId('getHistoryFromServerAPI', 'サーバーから履歴を取得中...');
-    
-    if (response && response.status === 'success' && Array.isArray(response.historyArray)) {
-      // 空履歴時の最適化処理
-      if (response.historyArray.length === 0 && response.count === 0) {
-        console.log('📋 サーバー履歴は空です。処理を最適化します。');
-        localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify([]));
-        historySyncInProgress = false;
-        return [];
-      }
-      
-      // サーバーからの履歴をLocalStorageに保存
-      localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(response.historyArray));
-      console.log('✅ サーバーから履歴を同期しました:', response.count, '件');
-      historySyncInProgress = false;
-      return response.historyArray;
-    } else {
-      console.warn('⚠️ サーバーからの履歴取得で警告:', response);
-      historySyncInProgress = false;
-      return [];
-    }
-  } catch (error) {
-    console.error('❌ サーバー履歴同期エラー:', error);
-    historySyncInProgress = false;
-    return [];
-  }
-}
 
 function loadSimpleHistoryTable() {
   const tableBody = document.getElementById('history-table-body');
@@ -2615,7 +2560,7 @@ function createHistoryTableRow(item, index) {
   const row = document.createElement('tr');
   
   // 公開中の項目は緑色のハイライト
-  const isActive = item.isActive || (!item.endTime && item.publishedAt);
+  const isActive = !!item.isActive;
   row.className = isActive 
     ? 'hover:bg-green-700/20 cursor-pointer transition-colors bg-green-900/10' 
     : 'hover:bg-gray-700/30 cursor-pointer transition-colors';
@@ -3084,34 +3029,7 @@ function fixConfigForPublishedState(config) {
 
 // 簡単な履歴テーブル初期化
 document.addEventListener('DOMContentLoaded', function() {
-  // 依存関数が利用可能になるまで待機してから実行
-  function waitForDependencies(attempts = 0) {
-    if (typeof runGasWithUserId === 'function') {
-      // サーバーから履歴を同期してからテーブルを読み込み
-      syncHistoryFromServer()
-        .then(function(syncedHistory) {
-          console.log('🔄 ページ読み込み時の履歴同期完了:', syncedHistory.length, '件');
-          loadSimpleHistoryTable();
-        })
-        .catch(function(syncError) {
-          console.warn('⚠️ ページ読み込み時の履歴同期に失敗、ローカルデータで表示:', syncError);
-          loadSimpleHistoryTable();
-        });
-      return;
-    }
-    
-    if (attempts < 20) { // 最大2秒待機
-      console.log('⏳ runGasWithUserId関数の読み込み待機中...');
-      setTimeout(() => waitForDependencies(attempts + 1), 100);
-      return;
-    }
-    
-    // タイムアウト後はローカルデータのみで動作
-    console.warn('⚠️ runGasWithUserId関数が利用できません。ローカルデータのみで表示します。');
-    loadSimpleHistoryTable();
-  }
-  
-  waitForDependencies();
+  loadSimpleHistoryTable();
 });
 
 // セットアップ情報を更新する関数


### PR DESCRIPTION
## Summary
- save board history to localStorage when publishing
- drop server-side history sync and clearing
- simplify history table initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923c17ecd8832b8ed25835e02c9ab8