### PR TITLE
fix: ドライブフォルダボタンが新しいタブで開かない問題を修正

### DIFF
--- a/src/adminPanel-ui.js.html
+++ b/src/adminPanel-ui.js.html
@@ -3247,7 +3247,13 @@ function updateNewResourceButtons(resourceUrls) {
     if (folderUrl) {
       folderBtn.onclick = () => {
         console.log('📁 Opening folder URL:', folderUrl);
-        window.open(folderUrl, '_blank');
+        const link = document.createElement('a');
+        link.href = folderUrl;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
       };
       folderBtn.title = 'ドライブフォルダを開く';
       console.log('✅ Folder button enabled with URL:', folderUrl);


### PR DESCRIPTION
## Summary
- 管理パネルの「ドライブフォルダを開く」ボタンが新しいタブで開かない問題を修正
- クリック時に一時的なアンカー要素を生成して、新しいタブでフォルダURLを開くよう変更

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923c6aaab4832babdbdccad46c43e4