### PR TITLE
Remove unused setup and auto-stop panels from admin UI

### DIFF
--- a/src/AdminPanel.html
+++ b/src/AdminPanel.html
@@ -981,34 +981,6 @@
         </div>
       </div>
 
-      <!-- セットアップ情報 -->
-      <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
-        <h4 class="text-sm font-medium text-gray-200 mb-3 flex items-center gap-2">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-          </svg>
-          セットアップ情報
-        </h4>
-        <div class="space-y-2 text-xs">
-          <div class="flex justify-between items-center">
-            <span class="text-gray-400">作成完了:</span>
-            <span class="text-white text-sm" id="info-completed-at">-</span>
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="text-gray-400">公開開始:</span>
-            <span class="text-white text-sm" id="info-published-at">-</span>
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="text-gray-400">公開回数:</span>
-            <span class="text-white font-bold" id="info-publish-count">-</span>
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="text-gray-400">公開シート:</span>
-            <span class="text-white text-sm" id="info-published-sheet-name">-</span>
-          </div>
-        </div>
-      </div>
-
       <!-- リソース -->
       <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
         <h4 class="text-sm font-medium text-gray-200 mb-3 flex items-center gap-2">
@@ -1043,31 +1015,7 @@
         </div>
         
       </div>
-      
-      <!-- 自動停止設定 -->
-      <div class="bg-gray-800/30 border border-gray-600/30 rounded-lg p-4">
-        <h4 class="text-sm font-medium text-gray-200 mb-3 flex items-center gap-2">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-          </svg>
-          自動停止設定
-        </h4>
-        <div class="space-y-2 text-xs">
-          <div class="flex justify-between items-center">
-            <span class="text-gray-400">自動停止:</span>
-            <span class="text-white text-sm" id="info-auto-stop-enabled">-</span>
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="text-gray-400">停止時間:</span>
-            <span class="text-white text-sm" id="info-auto-stop-duration">-</span>
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="text-gray-400">予定終了:</span>
-            <span class="text-white text-sm" id="info-scheduled-end">-</span>
-          </div>
-        </div>
-      </div>
-      
+
       <!-- アプリ設定リンク -->
 <? if (isDeployUser) { ?>
       <div id="app-setup-link" class="bg-blue-900/10 border border-blue-500/30 rounded-lg p-3 transition-all hover:border-blue-500/50">

--- a/src/adminPanel-ui.js.html
+++ b/src/adminPanel-ui.js.html
@@ -371,11 +371,6 @@ function updateDatabaseInfo(status) {
   safeSetText('info-user-id', status.userInfo.userId);
   safeSetText('info-published-sheet', cfg.publishedSheetName || status.publishedSheetName || 'なし');
   
-  // セットアップ情報の更新
-  updateSetupInfo(status);
-  
-  // 自動停止設定の更新
-  updateAutoStopInfo(status);
 
   // 公開状態の表示を更新
   const isPublished = cfg.isPublished !== undefined
@@ -3031,92 +3026,6 @@ function fixConfigForPublishedState(config) {
 document.addEventListener('DOMContentLoaded', function() {
   loadSimpleHistoryTable();
 });
-
-// セットアップ情報を更新する関数
-function updateSetupInfo(status) {
-  try {
-    // statusからconfigJsonデータを取得
-    let configData = {};
-    if (status.userInfo && status.userInfo.configJson) {
-      configData = typeof status.userInfo.configJson === 'string' 
-        ? JSON.parse(status.userInfo.configJson) 
-        : status.userInfo.configJson;
-    }
-    
-    // 作成完了日時
-    if (configData.completedAt) {
-      const completedDate = new Date(configData.completedAt);
-      safeSetText('info-completed-at', formatDateTime(completedDate));
-    } else {
-      safeSetText('info-completed-at', '-');
-    }
-    
-    // 公開開始日時
-    if (configData.publishedAt) {
-      const publishedDate = new Date(configData.publishedAt);
-      safeSetText('info-published-at', formatDateTime(publishedDate));
-    } else {
-      safeSetText('info-published-at', '-');
-    }
-    
-    // 公開回数
-    safeSetText('info-publish-count', `${configData.totalPublishCount || 0}回`);
-    
-    // 公開シート名
-    safeSetText('info-published-sheet-name', configData.publishedSheetName || '-');
-    
-  } catch (error) {
-    console.warn('⚠️ Failed to update setup info:', error);
-    safeSetText('info-completed-at', '-');
-    safeSetText('info-published-at', '-');
-    safeSetText('info-publish-count', '-');
-    safeSetText('info-published-sheet-name', '-');
-  }
-}
-
-// 自動停止設定を更新する関数
-function updateAutoStopInfo(status) {
-  try {
-    // statusからconfigJsonデータを取得
-    let configData = {};
-    if (status.userInfo && status.userInfo.configJson) {
-      configData = typeof status.userInfo.configJson === 'string' 
-        ? JSON.parse(status.userInfo.configJson) 
-        : status.userInfo.configJson;
-    }
-    
-    // 自動停止有効フラグ
-    if (configData.autoStopEnabled) {
-      safeSetText('info-auto-stop-enabled', '有効');
-    } else {
-      safeSetText('info-auto-stop-enabled', '無効');
-    }
-    
-    // 停止時間
-    if (configData.autoStopMinutes) {
-      const hours = Math.floor(configData.autoStopMinutes / 60);
-      const minutes = configData.autoStopMinutes % 60;
-      const durationText = hours > 0 ? `${hours}時間${minutes > 0 ? minutes + '分' : ''}` : `${minutes}分`;
-      safeSetText('info-auto-stop-duration', durationText);
-    } else {
-      safeSetText('info-auto-stop-duration', '-');
-    }
-    
-    // 予定終了日時
-    if (configData.scheduledEndAt) {
-      const endDate = new Date(configData.scheduledEndAt);
-      safeSetText('info-scheduled-end', formatDateTime(endDate));
-    } else {
-      safeSetText('info-scheduled-end', '-');
-    }
-    
-  } catch (error) {
-    console.warn('⚠️ Failed to update auto-stop info:', error);
-    safeSetText('info-auto-stop-enabled', '-');
-    safeSetText('info-auto-stop-duration', '-');
-    safeSetText('info-scheduled-end', '-');
-  }
-}
 
 // 日時フォーマット関数
 function formatDateTime(date) {


### PR DESCRIPTION
## Summary
- remove setup info and auto-stop panels from admin dashboard
- drop helper functions for setup and auto-stop display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689244297e10832b912bcaf48eb914b4