### PR TITLE
Sanitize status icons in messages

### DIFF
--- a/src/SetupPage.html
+++ b/src/SetupPage.html
@@ -135,14 +135,16 @@
                 warning: 'bg-yellow-600/20 border-yellow-500/50 text-yellow-100',
                 info: 'bg-blue-600/20 border-blue-500/50 text-blue-100'
             };
-            
+
+            const sanitizedMessage = (message || '').replace(/^[✅❌⚠️ℹ️]\s*/, '');
+
             messageArea.innerHTML = `
                 <div class="message show glass-panel rounded-lg p-4 border ${colors[type]}">
                     <div class="flex items-center">
                         <div class="mr-3">
                             ${type === 'success' ? '✅' : type === 'error' ? '❌' : type === 'warning' ? '⚠️' : 'ℹ️'}
                         </div>
-                        <div class="flex-1">${message}</div>
+                        <div class="flex-1">${sanitizedMessage}</div>
                         <button onclick="this.closest('.message').style.display='none'" class="ml-4 text-gray-400 hover:text-white">✕</button>
                     </div>
                 </div>

--- a/src/SharedUtilities.html
+++ b/src/SharedUtilities.html
@@ -624,12 +624,14 @@ class MessageManager {
       this.messageContainer.className = this.getContainerClasses();
     }
 
+    const sanitizedMessage = (message || '').replace(/^[✅❌⚠️ℹ️]\s*/, '');
+
     const messageEl = document.createElement('div');
     messageEl.className = `notification glass-panel rounded-lg p-4 border shadow-lg flex items-center transition-all duration-300 ease-out transform translate-x-full opacity-0 ${this.getTypeClasses(type)}`;
-    
+
     messageEl.innerHTML = `
       <div class="mr-3 text-2xl">${this.getIcon(type)}</div>
-      <div class="flex-1 text-sm">${message}</div>
+      <div class="flex-1 text-sm">${sanitizedMessage}</div>
       <button class="ml-4 text-gray-400 hover:text-white text-xl leading-none" onclick="this.closest('.notification').remove()">✕</button>
     `;
 


### PR DESCRIPTION
## Summary
- sanitize message strings in SharedUtilities MessageManager to prevent double status icons
- strip leading icons in SetupPage message display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689249b5e66c832b90b609501f571fb1