### PR TITLE
fix: adjust quickstart history and footer handling

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -2716,6 +2716,9 @@ function generateQuickStartResponse(setupContext, createdFiles, updatedConfig, p
     sheetName: formAndSsInfo.sheetName,
     formId: formAndSsInfo.formId,
     spreadsheetId: formAndSsInfo.spreadsheetId,
+    // Display settings for history and UI
+    displayMode: updatedConfig.displayMode || 'anonymous',
+    showCounts: updatedConfig.showCounts === true,
     // シート設定データ（フロントエンド同期用）
     config: sheetConfig.guessedConfig || {},
     publishedSheetName: formAndSsInfo.sheetName,

--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -1832,9 +1832,9 @@ function unpublishBoard() {
         questionText: questionText,
         sheetName: quickStartResult.sheetName || quickStartResult.publishedSheetName || '',
         
-        // Display settings (QuickStart defaults)
-        displayMode: quickStartResult.config?.displayMode === 'anonymous' ? '匿名表示' : '通常表示',
-        countDisplay: quickStartResult.config?.showCounts === false ? '非表示' : '表示',
+        // Display settings (QuickStart provides explicit values)
+        displayMode: quickStartResult.displayMode === 'anonymous' ? '匿名表示' : '通常表示',
+        countDisplay: quickStartResult.showCounts ? '表示' : '非表示',
         
         // Form configuration and state
         config: quickStartResult.config || {},
@@ -1861,20 +1861,20 @@ function unpublishBoard() {
         configurationComplete: true // QuickStart always completes configuration
       };
       
-      // Save QuickStart history entry using existing localStorage mechanism
+      // Save QuickStart history entry using unified localStorage mechanism
       const history = getHistoryFromStorage();
-      
+
       // Add new QuickStart entry at the beginning without removing existing ones
       history.unshift(quickStartHistoryItem);
-      
+
       // Enforce maximum history items limit
       const MAX_HISTORY_ITEMS = 10;
       if (history.length > MAX_HISTORY_ITEMS) {
         history.splice(MAX_HISTORY_ITEMS);
       }
-      
-      // Save to localStorage
-      localStorage.setItem('answerboard_history', JSON.stringify(history));
+
+      // Save to localStorage using shared key
+      localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
       
       // Sync to server (async)
       syncHistoryToServer(quickStartHistoryItem);
@@ -3879,7 +3879,13 @@ function executeStopAndQuickStart(quickstartBtn, quickstartText) {
     unpublishBoard()
       .then(function(stopResult) {
         showMessage('✅ 公開停止が完了しました。新しいフォームを作成します...', 'success');
-        
+
+        // Immediately update footer to reflect unpublished state
+        if (typeof updateFooterAndGuidance === 'function') {
+          updateFooterAndGuidance(stopResult);
+        }
+        window.lastStatusCache = stopResult;
+
         // 公開停止が完了したら、少し遅延してからクイックスタートを実行
         setTimeout(() => {
           quickstartText.textContent = 'セットアップ中...';


### PR DESCRIPTION
## Summary
- ensure QuickStart response returns display settings
- fix QuickStart history storage and icon values
- hide footer immediately after unpublishing before QuickStart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a7896cf8832bb82ae9e4f87b574d