### PR TITLE
fix: clear cached data on account deletion

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -1195,6 +1195,16 @@ function verifyUserAccess(requestUserId) {
     throw new Error(`認証エラー: 指定されたユーザーID (${requestUserId}) が見つかりません。`);
   }
 
+  const freshUserInfo = fetchUserFromDatabase('userId', requestUserId, {
+    retryCount: 0,
+    enableDiagnostics: false,
+    autoRepair: false,
+    clearCache: true
+  });
+  if (!freshUserInfo) {
+    throw new Error(`認証エラー: 指定されたユーザーID (${requestUserId}) は無効です。`);
+  }
+
   // 管理者かどうかを確認
   if (activeUserEmail !== requestedUserInfo.adminEmail) {
     const config = JSON.parse(requestedUserInfo.configJson || '{}');

--- a/src/cache.gs
+++ b/src/cache.gs
@@ -886,7 +886,7 @@ function validateRequiredHeaders(indices) {
  * @param {string} [spreadsheetId] - 関連スプレッドシートID
  * @param {boolean} [clearPattern=false] - パターンベースのクリアを行うか
  */
-function invalidateUserCache(userId, email, spreadsheetId, clearPattern) {
+function invalidateUserCache(userId, email, spreadsheetId, clearPattern, dbSpreadsheetId) {
   const keysToRemove = [];
 
   if (userId) {
@@ -911,6 +911,10 @@ function invalidateUserCache(userId, email, spreadsheetId, clearPattern) {
   // さらに包括的なパターンマッチングが必要な場合
   if (clearPattern && spreadsheetId) {
     cacheManager.clearByPattern(spreadsheetId);
+  }
+
+  if (dbSpreadsheetId) {
+    cacheManager.invalidateRelated('spreadsheet', dbSpreadsheetId);
   }
 
   debugLog(`[Cache] Invalidated user cache for userId: ${userId}, email: ${email}, spreadsheetId: ${spreadsheetId}`);

--- a/src/database.gs
+++ b/src/database.gs
@@ -3095,7 +3095,7 @@ function deleteUserAccount(userId) {
       );
 
       // 関連するすべてのキャッシュを削除
-      invalidateUserCache(userId, userInfo.adminEmail, userInfo.spreadsheetId, false);
+      invalidateUserCache(userId, userInfo.adminEmail, userInfo.spreadsheetId, false, dbId);
 
       // Google Drive のデータは保持するため何も操作しない
 

--- a/tests/deleteAccountCache.test.js
+++ b/tests/deleteAccountCache.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('deleteUserAccount cache handling', () => {
+  const dbCode = fs.readFileSync('src/database.gs', 'utf8');
+  let context;
+
+  beforeEach(() => {
+    context = {
+      console,
+      debugLog: () => {},
+      infoLog: () => {},
+      warnLog: () => {},
+      errorLog: () => {},
+      cacheManager: { invalidateRelated: jest.fn(), remove: jest.fn(), clearByPattern: jest.fn() },
+      invalidateUserCache: jest.fn(),
+      executeWithStandardizedLock: (lock, name, fn) => fn(),
+      PropertiesService: {
+        getScriptProperties: () => ({ getProperty: () => 'db123' }),
+        getUserProperties: () => ({ deleteProperty: jest.fn() })
+      },
+      DB_SHEET_CONFIG: { SHEET_NAME: 'Users', HEADERS: ['userId'] },
+      SCRIPT_PROPS_KEYS: { DATABASE_SPREADSHEET_ID: 'DATABASE_SPREADSHEET_ID' }
+    };
+    vm.createContext(context);
+    vm.runInContext(dbCode, context);
+    context.findUserById = jest.fn(() => ({ adminEmail: 'admin@example.com', spreadsheetId: 'userSheet' }));
+    context.getSheetsServiceCached = () => ({});
+    context.getSpreadsheetsData = () => ({ sheets: [{ properties: { title: 'Users', sheetId: 0 } }] });
+    context.batchGetSheetsData = () => ({ valueRanges: [{ values: [['userId'], ['U1']] }] });
+    context.batchUpdateSpreadsheet = jest.fn();
+    context.logAccountDeletion = jest.fn();
+  });
+
+  test('passes database id to invalidateUserCache', () => {
+    context.deleteUserAccount('U1');
+    expect(context.invalidateUserCache).toHaveBeenCalledWith('U1', 'admin@example.com', 'userSheet', false, 'db123');
+  });
+});

--- a/tests/verifyUserAccess.test.js
+++ b/tests/verifyUserAccess.test.js
@@ -16,6 +16,7 @@ describe('verifyUserAccess security checks', () => {
         adminEmail: 'admin@example.com',
         configJson: JSON.stringify({ appPublished: false }),
       })),
+      fetchUserFromDatabase: jest.fn(() => ({ adminEmail: 'admin@example.com' })),
     };
     vm.createContext(context);
     vm.runInContext(coreCode, context);
@@ -37,6 +38,12 @@ describe('verifyUserAccess security checks', () => {
       configJson: JSON.stringify({ appPublished: true }),
     });
     expect(() => context.verifyUserAccess('U1')).not.toThrow();
+  });
+
+  test('denies access when user missing in database', () => {
+    context.fetchUserFromDatabase.mockReturnValue(null);
+    expect(() => context.verifyUserAccess('U1')).toThrow('認証エラー');
+    expect(context.fetchUserFromDatabase).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- remove leftover cached entries when deleting a user account
- validate current user against database even if cached
- test cache invalidation on delete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892c2e12aa8832b9da96a64b375f655