### PR TITLE
fix(auth): handle registerNewUser error cases cleanly

### DIFF
--- a/src/Core.gs
+++ b/src/Core.gs
@@ -818,8 +818,11 @@ function getOpinionHeaderSafely(userId, sheetName) {
 }
 
 /**
- * 新規ユーザーを登録する（データベース登録のみ）
- * フォーム作成はクイックスタートで実行される
+ * Register a new user or update an existing one.
+ *
+ * @param {string} adminEmail - Email address of the user performing the action.
+ * @returns {Object} Registration result including URLs and flags.
+ * @throws {Error} When authentication fails or database operations error.
  */
 function registerNewUser(adminEmail) {
   const activeUserEmail = getCurrentUserEmail();
@@ -913,7 +916,7 @@ function registerNewUser(adminEmail) {
     // 生成されたユーザー情報のキャッシュをクリア
     invalidateUserCache(userId, adminEmail, null, false);
   } catch (e) {
-    logDatabaseError(e, 'userRegistration', { userId: userInfo.userId, email: userInfo.email });
+    logDatabaseError(e, 'userRegistration', { userId: userId, email: adminEmail });
     throw new Error('ユーザー登録に失敗しました。システム管理者に連絡してください。');
   }
 

--- a/tests/coreFunctions.test.js
+++ b/tests/coreFunctions.test.js
@@ -107,7 +107,8 @@ describe('Core.gs utilities', () => {
         updateUser: jest.fn(),
         invalidateUserCache: jest.fn(),
         generateUserUrls: jest.fn(() => ({ adminUrl: 'admin', viewUrl: 'view' })),
-        getDeployUserDomainInfo: jest.fn(() => ({ deployDomain: '', isDomainMatch: true }))
+        getDeployUserDomainInfo: jest.fn(() => ({ deployDomain: '', isDomainMatch: true })),
+        logDatabaseError: jest.fn()
       });
     });
 
@@ -123,6 +124,13 @@ describe('Core.gs utilities', () => {
       const res = context.registerNewUser('admin@example.com');
       expect(context.updateUser).toHaveBeenCalled();
       expect(res.isExistingUser).toBe(true);
+    });
+
+    test('logs and throws when createUser fails', () => {
+      context.findUserByEmail.mockReturnValue(null);
+      context.createUser.mockImplementation(() => { throw new Error('db'); });
+      expect(() => context.registerNewUser('admin@example.com')).toThrow('ユーザー登録に失敗しました。システム管理者に連絡してください。');
+      expect(context.logDatabaseError).toHaveBeenCalledWith(expect.any(Error), 'userRegistration', { userId: 'UUID', email: 'admin@example.com' });
     });
   });
 });


### PR DESCRIPTION
## Summary
- avoid referencing undefined variables when user registration fails and document registerNewUser
- add test ensuring registration errors are logged correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895ec946c00832b93379dbca50d6a41