### PR TITLE
fix: 管理者検証のキャッシュ無効化強化

### DIFF
--- a/src/auth.gs
+++ b/src/auth.gs
@@ -142,7 +142,7 @@ function verifyAdminAccess(userId) {
 
     // データベースから指定されたIDのユーザー情報を取得
     // セキュリティ認証では最新データが必要だが、過度なキャッシュクリアを避ける
-    debugLog('verifyAdminAccess: ユーザー検索開始 - userId:', userId);
+    debugLog('verifyAdminAccess: ユーザー検索開始 - userId:', userId, 'activeUserEmail:', activeUserEmail);
 
     // 複数段階でのユーザー情報取得（最新データ確保のため）
     var userFromDb = null;
@@ -164,7 +164,7 @@ function verifyAdminAccess(userId) {
     if (!userFromDb || !userFromDb.adminEmail) {
       debugLog('verifyAdminAccess: 直接データベース検索にフォールバック');
       try {
-        userFromDb = fetchUserFromDatabase('userId', userId);
+        userFromDb = fetchUserFromDatabase('userId', userId, { clearCache: true });
         searchAttempts.push({ method: 'fetchUserFromDatabase', success: !!userFromDb });
       } catch (error) {
         errorLog('verifyAdminAccess: fetchUserFromDatabase でエラー:', error.message);
@@ -174,13 +174,13 @@ function verifyAdminAccess(userId) {
 
     // 第3段階: findUserById による追加検証
     if (!userFromDb) {
-      debugLog('verifyAdminAccess: findUserById による最終検証を実行');
+      debugLog('verifyAdminAccess: findUserByIdFresh による最終検証を実行');
       try {
-        userFromDb = findUserById(userId, { useExecutionCache: false, forceRefresh: true });
-        searchAttempts.push({ method: 'findUserById', success: !!userFromDb });
+        userFromDb = findUserByIdFresh(userId);
+        searchAttempts.push({ method: 'findUserByIdFresh', success: !!userFromDb });
       } catch (error) {
-        errorLog('verifyAdminAccess: findUserById でエラー:', error.message);
-        searchAttempts.push({ method: 'findUserById', error: error.message });
+        errorLog('verifyAdminAccess: findUserByIdFresh でエラー:', error.message);
+        searchAttempts.push({ method: 'findUserByIdFresh', error: error.message });
       }
     }
 
@@ -351,8 +351,8 @@ function processLoginFlow(userEmail) {
       if (!waitForUserRecord(newUser.userId, 5000, 300)) { // 5秒間待機、300ms間隔でリトライ
         warnLog('processLoginFlow: ユーザーレコード検証でタイムアウト:', newUser.userId);
         
-        // 追加検証: 直接データベースから取得を試行
-        const verifyUser = findUserById(newUser.userId, { useExecutionCache: false, forceRefresh: true });
+        // 追加検証: キャッシュをバイパスして直接データベースから取得を試行
+        const verifyUser = findUserByIdFresh(newUser.userId);
         if (!verifyUser) {
           errorLog('processLoginFlow: 🚨 ユーザー作成後の検証に失敗 - ユーザーがデータベースに見つかりません:', newUser.userId);
           throw new Error('ユーザー登録の処理中にエラーが発生しました。しばらく待ってから再度お試しください。');

--- a/src/database.gs
+++ b/src/database.gs
@@ -1225,7 +1225,13 @@ function createUser(userData) {
     }
 
     // 最適化: 新規ユーザー作成時は対象キャッシュのみ無効化
-    invalidateUserCache(userData.userId, userData.adminEmail, userData.spreadsheetId, false);
+    invalidateUserCache(
+      userData.userId,
+      userData.adminEmail,
+      userData.spreadsheetId,
+      false,
+      dbId
+    );
 
     return userData;
   });
@@ -1241,7 +1247,7 @@ function createUser(userData) {
 function waitForUserRecord(userId, maxWaitMs, intervalMs) {
   var start = Date.now();
   while (Date.now() - start < maxWaitMs) {
-    if (fetchUserFromDatabase('userId', userId)) return true;
+    if (fetchUserFromDatabase('userId', userId, { clearCache: true })) return true;
     Utilities.sleep(intervalMs);
   }
   return false;

--- a/src/main.gs
+++ b/src/main.gs
@@ -1115,9 +1115,12 @@ function handleAdminMode(params) {
     return showErrorPage('不正なリクエスト', 'ユーザーIDが指定されていません。');
   }
 
+  debugLog('handleAdminMode: verifying admin access for userId:', params.userId);
   if (!verifyAdminAccess(params.userId)) {
+    warnLog('handleAdminMode: admin access denied for userId:', params.userId);
     return showErrorPage('アクセス拒否', 'この管理パネルにアクセスする権限がありません。');
   }
+  debugLog('handleAdminMode: admin access verified for userId:', params.userId);
 
   // Save admin session state
   const userProperties = PropertiesService.getUserProperties();


### PR DESCRIPTION
## Summary
- invalidate user cache with database ID after creation and refresh wait to bypass stale data
- force fresh reads in admin verification and login flow
- add debug logs when accessing admin panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689615ceff34832bb58cc6d7956a9653