### PR TITLE
fix(server): 管理者アクセス拒否時のログレベルをINFOに変更

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1117,7 +1117,7 @@ function handleAdminMode(params) {
 
   debugLog('handleAdminMode: verifying admin access for userId:', params.userId);
   if (!verifyAdminAccess(params.userId)) {
-    warnLog('handleAdminMode: admin access denied for userId:', params.userId);
+    infoLog('handleAdminMode: admin access denied for userId:', params.userId);
     return showErrorPage('アクセス拒否', 'この管理パネルにアクセスする権限がありません。');
   }
   debugLog('handleAdminMode: admin access verified for userId:', params.userId);


### PR DESCRIPTION
## Summary
- change admin access denied log from WARN to INFO

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689619e1ae30832baff86f65970c7e34