### PR TITLE
fix(auth): add fallback admin verification

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1116,10 +1116,25 @@ function handleAdminMode(params) {
   }
 
   debugLog('handleAdminMode: verifying admin access for userId:', params.userId);
-  if (!verifyAdminAccess(params.userId)) {
+
+  /** @type {boolean} */
+  let isVerified = verifyAdminAccess(params.userId);
+
+  // Fallback verification using active user email when standard check fails
+  if (!isVerified) {
+    const activeEmail = getCurrentUserEmail();
+    const userInfo = activeEmail ? findUserByEmail(activeEmail) : null;
+    if (userInfo && userInfo.userId === params.userId && userInfo.isActive) {
+      infoLog('handleAdminMode: admin access verified via fallback for userId:', params.userId);
+      isVerified = true;
+    }
+  }
+
+  if (!isVerified) {
     infoLog('handleAdminMode: admin access denied for userId:', params.userId);
     return showErrorPage('アクセス拒否', 'この管理パネルにアクセスする権限がありません。');
   }
+
   debugLog('handleAdminMode: admin access verified for userId:', params.userId);
 
   // Save admin session state

--- a/tests/handleAdminModeFallback.test.js
+++ b/tests/handleAdminModeFallback.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('handleAdminMode fallback verification', () => {
+  const mainCode = fs.readFileSync('src/main.gs', 'utf8');
+  let context;
+
+  beforeEach(() => {
+    context = {
+      console,
+      debugLog: () => {},
+      infoLog: () => {},
+      verifyAdminAccess: jest.fn(() => false),
+      getCurrentUserEmail: () => 'admin@example.com',
+      findUserByEmail: jest.fn(() => ({ userId: 'U1', isActive: true })),
+      findUserById: jest.fn(() => ({ userId: 'U1' })),
+      renderAdminPanel: jest.fn(() => 'panel'),
+      showErrorPage: jest.fn(() => 'error'),
+      PropertiesService: {
+        getUserProperties: () => ({
+          setProperty: jest.fn(),
+          getProperty: jest.fn(),
+          deleteProperty: jest.fn(),
+        }),
+        getScriptProperties: () => ({ getProperty: jest.fn(() => '') }),
+      },
+    };
+    vm.createContext(context);
+    vm.runInContext(mainCode, context);
+    // Overwrite renderAdminPanel to avoid HtmlService dependency
+    context.renderAdminPanel = jest.fn(() => 'panel');
+  });
+
+  test('grants access when fallback validation succeeds', () => {
+    const res = context.handleAdminMode({ userId: 'U1' });
+    expect(context.verifyAdminAccess).toHaveBeenCalledWith('U1');
+    expect(context.findUserByEmail).toHaveBeenCalledWith('admin@example.com');
+    expect(context.renderAdminPanel).toHaveBeenCalled();
+    expect(res).toBe('panel');
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow admin access via email fallback when standard verification fails
- add unit test for admin access fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68961c913fdc832bb4aa67e3a4b08984