### PR TITLE
fix(auth): restore admin verification

### DIFF
--- a/src/auth.gs
+++ b/src/auth.gs
@@ -142,7 +142,7 @@ function verifyAdminAccess(userId) {
 
     // データベースから指定されたIDのユーザー情報を取得
     // セキュリティ認証では最新データが必要だが、過度なキャッシュクリアを避ける
-    debugLog('verifyAdminAccess: ユーザー検索開始 - userId:', userId);
+    debugLog('verifyAdminAccess: ユーザー検索開始 - userId:', userId, 'activeUserEmail:', activeUserEmail);
 
     // 複数段階でのユーザー情報取得（最新データ確保のため）
     var userFromDb = null;
@@ -164,7 +164,7 @@ function verifyAdminAccess(userId) {
     if (!userFromDb || !userFromDb.adminEmail) {
       debugLog('verifyAdminAccess: 直接データベース検索にフォールバック');
       try {
-        userFromDb = fetchUserFromDatabase('userId', userId);
+        userFromDb = fetchUserFromDatabase('userId', userId, { clearCache: true });
         searchAttempts.push({ method: 'fetchUserFromDatabase', success: !!userFromDb });
       } catch (error) {
         errorLog('verifyAdminAccess: fetchUserFromDatabase でエラー:', error.message);
@@ -172,15 +172,15 @@ function verifyAdminAccess(userId) {
       }
     }
 
-    // 第3段階: findUserById による追加検証
+    // 第3段階: findUserByIdFresh による追加検証
     if (!userFromDb) {
-      debugLog('verifyAdminAccess: findUserById による最終検証を実行');
+      debugLog('verifyAdminAccess: findUserByIdFresh による最終検証を実行');
       try {
-        userFromDb = findUserById(userId, { useExecutionCache: false, forceRefresh: true });
-        searchAttempts.push({ method: 'findUserById', success: !!userFromDb });
+        userFromDb = findUserByIdFresh(userId);
+        searchAttempts.push({ method: 'findUserByIdFresh', success: !!userFromDb });
       } catch (error) {
-        errorLog('verifyAdminAccess: findUserById でエラー:', error.message);
-        searchAttempts.push({ method: 'findUserById', error: error.message });
+        errorLog('verifyAdminAccess: findUserByIdFresh でエラー:', error.message);
+        searchAttempts.push({ method: 'findUserByIdFresh', error: error.message });
       }
     }
 
@@ -351,8 +351,8 @@ function processLoginFlow(userEmail) {
       if (!waitForUserRecord(newUser.userId, 5000, 300)) { // 5秒間待機、300ms間隔でリトライ
         warnLog('processLoginFlow: ユーザーレコード検証でタイムアウト:', newUser.userId);
         
-        // 追加検証: 直接データベースから取得を試行
-        const verifyUser = findUserById(newUser.userId, { useExecutionCache: false, forceRefresh: true });
+        // 追加検証: キャッシュをバイパスして直接データベースから取得を試行
+        const verifyUser = findUserByIdFresh(newUser.userId);
         if (!verifyUser) {
           errorLog('processLoginFlow: 🚨 ユーザー作成後の検証に失敗 - ユーザーがデータベースに見つかりません:', newUser.userId);
           throw new Error('ユーザー登録の処理中にエラーが発生しました。しばらく待ってから再度お試しください。');

--- a/src/database.gs
+++ b/src/database.gs
@@ -1225,7 +1225,13 @@ function createUser(userData) {
     }
 
     // 最適化: 新規ユーザー作成時は対象キャッシュのみ無効化
-    invalidateUserCache(userData.userId, userData.adminEmail, userData.spreadsheetId, false);
+    invalidateUserCache(
+      userData.userId,
+      userData.adminEmail,
+      userData.spreadsheetId,
+      false,
+      dbId
+    );
 
     return userData;
   });
@@ -1241,7 +1247,7 @@ function createUser(userData) {
 function waitForUserRecord(userId, maxWaitMs, intervalMs) {
   var start = Date.now();
   while (Date.now() - start < maxWaitMs) {
-    if (fetchUserFromDatabase('userId', userId)) return true;
+    if (fetchUserFromDatabase('userId', userId, { clearCache: true })) return true;
     Utilities.sleep(intervalMs);
   }
   return false;

--- a/src/main.gs
+++ b/src/main.gs
@@ -1115,9 +1115,27 @@ function handleAdminMode(params) {
     return showErrorPage('不正なリクエスト', 'ユーザーIDが指定されていません。');
   }
 
-  if (!verifyAdminAccess(params.userId)) {
+  debugLog('handleAdminMode: verifying admin access for userId:', params.userId);
+
+  /** @type {boolean} */
+  let isVerified = verifyAdminAccess(params.userId);
+
+  // Fallback verification using active user email when standard check fails
+  if (!isVerified) {
+    const activeEmail = getCurrentUserEmail();
+    const userInfo = activeEmail ? findUserByEmail(activeEmail) : null;
+    if (userInfo && userInfo.userId === params.userId && userInfo.isActive) {
+      infoLog('handleAdminMode: admin access verified via fallback for userId:', params.userId);
+      isVerified = true;
+    }
+  }
+
+  if (!isVerified) {
+    infoLog('handleAdminMode: admin access denied for userId:', params.userId);
     return showErrorPage('アクセス拒否', 'この管理パネルにアクセスする権限がありません。');
   }
+
+  debugLog('handleAdminMode: admin access verified for userId:', params.userId);
 
   // Save admin session state
   const userProperties = PropertiesService.getUserProperties();

--- a/tests/handleAdminModeFallback.test.js
+++ b/tests/handleAdminModeFallback.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('handleAdminMode fallback verification', () => {
+  const mainCode = fs.readFileSync('src/main.gs', 'utf8');
+  let context;
+
+  beforeEach(() => {
+    context = {
+      console,
+      debugLog: () => {},
+      infoLog: () => {},
+      verifyAdminAccess: jest.fn(() => false),
+      getCurrentUserEmail: () => 'admin@example.com',
+      findUserByEmail: jest.fn(() => ({ userId: 'U1', isActive: true })),
+      findUserById: jest.fn(() => ({ userId: 'U1' })),
+      renderAdminPanel: jest.fn(() => 'panel'),
+      showErrorPage: jest.fn(() => 'error'),
+      PropertiesService: {
+        getUserProperties: () => ({
+          setProperty: jest.fn(),
+          getProperty: jest.fn(),
+          deleteProperty: jest.fn(),
+        }),
+        getScriptProperties: () => ({ getProperty: jest.fn(() => '') }),
+      },
+    };
+    vm.createContext(context);
+    vm.runInContext(mainCode, context);
+    // Overwrite renderAdminPanel to avoid HtmlService dependency
+    context.renderAdminPanel = jest.fn(() => 'panel');
+  });
+
+  test('grants access when fallback validation succeeds', () => {
+    const res = context.handleAdminMode({ userId: 'U1' });
+    expect(context.verifyAdminAccess).toHaveBeenCalledWith('U1');
+    expect(context.findUserByEmail).toHaveBeenCalledWith('admin@example.com');
+    expect(context.renderAdminPanel).toHaveBeenCalled();
+    expect(res).toBe('panel');
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure verifyAdminAccess bypasses stale cache and uses fresh database lookups
- add email-based fallback in handleAdminMode so newly registered admins can access
- test admin fallback verification

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896219d8db0832b8f871e7786235341