### PR TITLE
test: getDataCountテストの修正

### DIFF
--- a/tests/getDataCount.test.js
+++ b/tests/getDataCount.test.js
@@ -33,7 +33,7 @@ describe('getDataCount reflects new rows', () => {
       Session: { getActiveUser: () => ({ getEmail: () => 'user@example.com' }) },
       SpreadsheetApp: {
         openById: jest.fn(() => ({
-          getSheetByName: (name) => getFreshSheet(),
+          getSheetByName: () => getFreshSheet(),
         })),
       },
       Utilities: { getUuid: () => 'test-uuid-' + Math.random() },
@@ -41,23 +41,23 @@ describe('getDataCount reflects new rows', () => {
         const scriptCacheStore = {};
         return {
           getScriptCache: () => ({
-            get: jest.fn((key) => scriptCacheStore[key] === undefined ? null : scriptCacheStore[key]),
+            get: jest.fn(key => (scriptCacheStore[key] === undefined ? null : scriptCacheStore[key])),
             put: jest.fn((key, value) => { scriptCacheStore[key] = value; }),
-            remove: jest.fn((key) => { delete scriptCacheStore[key]; }),
+            remove: jest.fn(key => { delete scriptCacheStore[key]; }),
             removeAll: jest.fn(() => { Object.keys(scriptCacheStore).forEach(key => delete scriptCacheStore[key]); }),
-            getAll: jest.fn((keys) => {
+            getAll: jest.fn(keys => {
               const result = {};
-              keys.forEach(key => { if (scriptCacheStore.hasOwnProperty(key)) result[key] = scriptCacheStore[key]; });
+              keys.forEach(key => { if (Object.prototype.hasOwnProperty.call(scriptCacheStore, key)) result[key] = scriptCacheStore[key]; });
               return result;
             }),
-            putAll: jest.fn((values) => { Object.assign(scriptCacheStore, values); })
+            putAll: jest.fn(values => { Object.assign(scriptCacheStore, values); }),
           }),
           getUserCache: () => ({
             get: jest.fn(),
             put: jest.fn(),
             remove: jest.fn(),
-            removeAll: jest.fn()
-          })
+            removeAll: jest.fn(),
+          }),
         };
       })(),
       verifyUserAccess: jest.fn(),
@@ -70,125 +70,25 @@ describe('getDataCount reflects new rows', () => {
       })),
       getHeaderIndices: () => ({ クラス: 1 }),
       COLUMN_HEADERS: { CLASS: 'クラス' },
+      getCurrentUserEmail: () => 'user@example.com',
     };
+    context.global = context;
     vm.createContext(context);
     vm.runInContext(debugConfigCode, context);
     vm.runInContext(unifiedCacheManagerCode, context);
-
-    
-    
     vm.runInContext(mainCode, context);
     vm.runInContext(coreCode, context);
-
-    // Mock CacheManager for testing purposes
-    class MockCacheManager {
-      constructor() {
-        this.cache = {};
-      }
-      remove(key) {
-        delete this.cache[key];
-      }
-      get(key, valueFn) {
-        if (Object.prototype.hasOwnProperty.call(this.cache, key)) {
-          return this.cache[key];
-        }
-        const value = valueFn();
-        this.cache[key] = value;
-        return value;
-      }
-    }
-
-    // Redefine countSheetRows to use MockCacheManager
-    const originalCountSheetRows = context.countSheetRows; // Store original if needed
-    context.countSheetRows = (spreadsheetId, sheetName, classFilter) => {
-      const key = `rowCount_${spreadsheetId}_${sheetName}_${classFilter}`;
-      const mockCacheManagerInstance = new MockCacheManager(); // Create a new instance for each call
-      return mockCacheManagerInstance.get(key, () => {
-        const sheet = context.SpreadsheetApp.openById(spreadsheetId).getSheetByName(sheetName);
-        if (!sheet) return 0;
-        const lastRow = sheet.getLastRow();
-        if (!classFilter || classFilter === 'すべて') {
-          return Math.max(0, lastRow - 1);
-        }
-        // Simplified for testing, actual logic is more complex
-        return Math.max(0, lastRow - 1);
-      }, { ttl: 30, enableMemoization: true });
-    };
-
-        vm.runInContext(coreCode, context);
-
-    // Redefine countSheetRows to use MockCacheManager
-    const originalCountSheetRows = context.countSheetRows; // Store original if needed
-    context.countSheetRows = (spreadsheetId, sheetName, classFilter) => {
-      const key = `rowCount_${spreadsheetId}_${sheetName}_${classFilter}`;
-      const mockCacheManagerInstance = new MockCacheManager(); // Create a new instance for each call
-      return mockCacheManagerInstance.get(key, () => {
-        const sheet = context.SpreadsheetApp.openById(spreadsheetId).getSheetByName(sheetName);
-        if (!sheet) return 0;
-        const lastRow = sheet.getLastRow();
-        if (!classFilter || classFilter === 'すべて') {
-          return Math.max(0, lastRow - 1);
-        }
-        // Simplified for testing, actual logic is more complex
-        return Math.max(0, lastRow - 1);
-      }, { ttl: 30, enableMemoization: true });
-    };
-
-        vm.runInContext(coreCode, context);
-
-    // Mock CacheManager for testing purposes
-    class MockCacheManager {
-      constructor() {
-        this.cache = {};
-      }
-      remove(key) {
-        delete this.cache[key];
-      }
-      get(key, valueFn) {
-        if (Object.prototype.hasOwnProperty.call(this.cache, key)) {
-          return this.cache[key];
-        }
-        const value = valueFn();
-        this.cache[key] = value;
-        return value;
-      }
-    }
-
-    // Redefine countSheetRows to use MockCacheManager
-    const originalCountSheetRows = context.countSheetRows; // Store original if needed
-    context.countSheetRows = (spreadsheetId, sheetName, classFilter) => {
-      const key = `rowCount_${spreadsheetId}_${sheetName}_${classFilter}`;
-      const mockCacheManagerInstance = new MockCacheManager(); // Create a new instance for each call
-      return mockCacheManagerInstance.get(key, () => {
-        const sheet = context.SpreadsheetApp.openById(spreadsheetId).getSheetByName(sheetName);
-        if (!sheet) return 0;
-        const lastRow = sheet.getLastRow();
-        if (!classFilter || classFilter === 'すべて') {
-          return Math.max(0, lastRow - 1);
-        }
-        // Simplified for testing, actual logic is more complex
-        return Math.max(0, lastRow - 1);
-      }, { ttl: 30, enableMemoization: true });
-    };
-
     context.verifyUserAccess = jest.fn();
   });
 
   test('returns updated count after adding row', () => {
-    console.log('Before first call, sheetData.length:', sheetData.length);
     const first = context.getDataCount('U1', 'すべて', 'newest', false);
-    console.log('After first call, first.count:', first.count);
     expect(first.count).toBe(1);
 
     sheetData.push(['2024-01-02', 'A']);
-    console.log('After push, sheetData.length:', sheetData.length);
-
     context.cacheManager.remove('rowCount_SID_Sheet1_すべて');
-    console.log('After cache remove, sheetData.length:', sheetData.length);
 
     const second = context.getDataCount('U1', 'すべて', 'newest', false);
-    console.log('After second call, second.count:', second.count);
     expect(second.count).toBe(2);
   });
 });
-


### PR DESCRIPTION
## Summary
- rebuild getDataCount.test.js to use proper mock context and cache
- verify row counting updates after cache invalidation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af2614d64832bb93f0693d51e3fab