### PR TITLE
fix(ui): navigate back to admin panel synchronously

### DIFF
--- a/src/AppSetupPage.html
+++ b/src/AppSetupPage.html
@@ -614,19 +614,22 @@
             }
         }
 
-        // 管理パネルに戻る
+        /**
+         * 管理パネルに戻る。
+         * 非同期処理を挟まずユーザー操作として認識されるよう同期的に遷移する。
+         */
         function goBackToAdminPanel() {
             // ボタンの視覚フィードバック: クリック時に無効化
             const backButton = document.querySelector('[onclick="goBackToAdminPanel()"]');
             const originalText = backButton ? backButton.textContent : '';
-            
+
             if (backButton) {
                 backButton.disabled = true;
                 backButton.style.opacity = '0.6';
                 backButton.style.pointerEvents = 'none';
                 backButton.textContent = '← 移動中...';
             }
-            
+
             // ボタンを元に戻すヘルパー関数（エラー時のみ使用）
             const restoreButton = () => {
                 if (backButton) {
@@ -636,28 +639,17 @@
                     backButton.textContent = originalText || '← 管理パネルに戻る';
                 }
             };
-            
-            google.script.run
-                .withSuccessHandler((webAppUrl) => {
-                    const targetUrl = webAppUrl + '?mode=admin&userId=' + __USER_ID__;
-                    // サンドボックス環境では window.top への直接アクセスが制限されるため
-                    // 確実に遷移させるために window.open を利用する
-                    // 成功時はページが切り替わるのでrestoreButton()は呼ばない
-                    window.open(targetUrl, '_top');
-                })
-                .withFailureHandler((error) => {
-                    console.error('WebApp URL取得エラー:', error);
-                    restoreButton(); // エラー時のみボタンを復元
-                    showMessage('管理パネルへの移動に失敗しました。再度お試しください。', 'error');
-                    
-                    // フォールバックとして現在のURLベースでの遷移も試みる
-                    setTimeout(() => {
-                        const currentUrl = window.location.href.split('?')[0];
-                        const targetUrl = currentUrl + '?mode=admin&userId=' + __USER_ID__;
-                        window.open(targetUrl, '_top');
-                    }, 2000);
-                })
-                .getWebAppUrl();
+
+            const currentUrl = window.location.href.split('?')[0];
+            const targetUrl = currentUrl + '?mode=admin&userId=' + __USER_ID__;
+
+            try {
+                window.open(targetUrl, '_top');
+            } catch (error) {
+                console.error('管理パネルへの遷移に失敗:', error);
+                restoreButton();
+                showMessage('管理パネルへの移動に失敗しました。再度お試しください。', 'error');
+            }
         }
 
         // ページ読み込み時の処理


### PR DESCRIPTION
## Summary
- ensure the settings page return button navigates directly to the admin panel without asynchronous calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc5b8ac34832bb7c9138a7b32f6ba