### PR TITLE
fix(ui): navigate back to admin panel using API-provided URL

### DIFF
--- a/src/AppSetupPage.html
+++ b/src/AppSetupPage.html
@@ -489,6 +489,7 @@
     <script>
         let currentUserInfo = null;
         let setupInProgress = false;
+        let adminPanelUrl = '';
 
         // 統一されたメッセージ表示関数 - SharedUtilitiesを使用
         function showMessage(message, type = 'info', duration = 5000) {
@@ -614,19 +615,41 @@
             }
         }
 
-        // 管理パネルに戻る
+        /**
+         * 管理パネルのURLを取得して保存する。
+         * @returns {void}
+         */
+        function fetchAdminPanelUrl() {
+            google.script.run
+                .withSuccessHandler((urls) => {
+                    if (urls && urls.adminUrl) {
+                        adminPanelUrl = urls.adminUrl;
+                    } else {
+                        console.error('管理パネルURLの取得に失敗:', urls);
+                    }
+                })
+                .withFailureHandler((error) => {
+                    console.error('管理パネルURLの取得エラー:', error);
+                })
+                .generateUserUrls(__USER_ID__);
+        }
+
+        /**
+         * 管理パネルに戻る。
+         * 非同期処理を挟まずユーザー操作として認識されるよう同期的に遷移する。
+         */
         function goBackToAdminPanel() {
             // ボタンの視覚フィードバック: クリック時に無効化
             const backButton = document.querySelector('[onclick="goBackToAdminPanel()"]');
             const originalText = backButton ? backButton.textContent : '';
-            
+
             if (backButton) {
                 backButton.disabled = true;
                 backButton.style.opacity = '0.6';
                 backButton.style.pointerEvents = 'none';
                 backButton.textContent = '← 移動中...';
             }
-            
+
             // ボタンを元に戻すヘルパー関数（エラー時のみ使用）
             const restoreButton = () => {
                 if (backButton) {
@@ -636,33 +659,26 @@
                     backButton.textContent = originalText || '← 管理パネルに戻る';
                 }
             };
-            
-            google.script.run
-                .withSuccessHandler((webAppUrl) => {
-                    const targetUrl = webAppUrl + '?mode=admin&userId=' + __USER_ID__;
-                    // サンドボックス環境では window.top への直接アクセスが制限されるため
-                    // 確実に遷移させるために window.open を利用する
-                    // 成功時はページが切り替わるのでrestoreButton()は呼ばない
-                    window.open(targetUrl, '_top');
-                })
-                .withFailureHandler((error) => {
-                    console.error('WebApp URL取得エラー:', error);
-                    restoreButton(); // エラー時のみボタンを復元
-                    showMessage('管理パネルへの移動に失敗しました。再度お試しください。', 'error');
-                    
-                    // フォールバックとして現在のURLベースでの遷移も試みる
-                    setTimeout(() => {
-                        const currentUrl = window.location.href.split('?')[0];
-                        const targetUrl = currentUrl + '?mode=admin&userId=' + __USER_ID__;
-                        window.open(targetUrl, '_top');
-                    }, 2000);
-                })
-                .getWebAppUrl();
+
+            if (!adminPanelUrl) {
+                restoreButton();
+                showMessage('管理パネルURLを取得できませんでした。ページを再読み込みして再試行してください。', 'error');
+                return;
+            }
+
+            try {
+                window.open(adminPanelUrl, '_top');
+            } catch (error) {
+                console.error('管理パネルへの遷移に失敗:', error);
+                restoreButton();
+                showMessage('管理パネルへの移動に失敗しました。再度お試しください。', 'error');
+            }
         }
 
         // ページ読み込み時の処理
         window.addEventListener('load', function() {
             loadCurrentStatus();
+            fetchAdminPanelUrl();
         });
 
         // ユーザー管理機能のJavaScript関数


### PR DESCRIPTION
## Summary
- prefetch admin panel URL via `generateUserUrls` API
- use the fetched URL for synchronous navigation back to admin panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc5b8ac34832bb7c9138a7b32f6ba