### PR TITLE
feat(admin): enable direct app setup navigation

### DIFF
--- a/src/adminPanel-api.js.html
+++ b/src/adminPanel-api.js.html
@@ -2584,79 +2584,76 @@ function openForm() {
   }
 }
 
-// Open app setup page
+/** @type {string} */
+let appSetupUrl = '';
+
+/**
+ * アプリ設定ページのURLを取得して保存する。
+ * @returns {void}
+ */
+function fetchAppSetupUrl() {
+  google.script.run
+    .withSuccessHandler((urls) => {
+      if (urls && urls.setupUrl) {
+        appSetupUrl = urls.setupUrl;
+      } else {
+        console.error('アプリ設定ページURLの取得に失敗:', urls);
+      }
+    })
+    .withFailureHandler((error) => {
+      console.error('アプリ設定ページURLの取得エラー:', error);
+    })
+    .generateUserUrls(userId);
+}
+
+/**
+ * アプリ設定管理ページを開く。
+ * @returns {void}
+ */
 function openAppSetupPage() {
-  // ボタンの視覚フィードバック: クリック時に無効化
   const setupButton = document.querySelector('[onclick="openAppSetupPage()"]');
   const originalText = setupButton ? setupButton.textContent : '';
-  
+
   if (setupButton) {
     setupButton.disabled = true;
     setupButton.style.opacity = '0.6';
     setupButton.style.pointerEvents = 'none';
     const span = setupButton.querySelector('span');
     if (span) {
-      span.textContent = '準備中...';
+      span.textContent = '移動中...';
     }
   }
-  
-  // ボタンを元に戻すヘルパー関数
+
   const restoreButton = () => {
     if (setupButton) {
       setupButton.disabled = false;
       setupButton.style.opacity = '';
       setupButton.style.pointerEvents = '';
       const span = setupButton.querySelector('span');
-      if (span && originalText.includes('アプリ設定管理')) {
-        span.textContent = 'アプリ設定管理';
+      if (span) {
+        span.textContent = originalText || 'アプリ設定管理';
       }
     }
   };
 
-  const loadingMessage = 'アプリ設定ページを準備中...';
-  const errorMessage = 'アプリ設定ページへの移動に失敗しました。';
-  const timeoutMessage = 'リダイレクトがタイムアウトしました。新しいタブで開きます。';
-  const fallbackMessage = 'アプリ設定ページを新しいタブで開きます。';
+  if (!appSetupUrl) {
+    restoreButton();
+    showMessage('アプリ設定ページのURLを取得できませんでした。ページを再読み込みしてください。', 'error');
+    return;
+  }
 
-  runGasWithUserId('getWebAppUrl', loadingMessage)
-    .then(function(webAppUrl) {
-      const setupUrl = webAppUrl + '?setup=true&mode=appsetup&userId=' + encodeURIComponent(userId);
-
-      // ユーザーにリダイレクト中であることを伝える
-      showMessage('アプリ設定ページへ移動中...', 'info');
-      window.unifiedLoading.showSimple('アプリ設定ページへ移動中...');
-
-      const redirectTimeout = setTimeout(() => {
-        console.warn('Redirect to app setup page timed out. Attempting fallback.');
-        window.unifiedLoading.hide();
-        restoreButton();
-        showMessage(timeoutMessage, 'warning');
-        window.open(setupUrl, '_blank'); // Fallback: open in new tab
-      }, 10000); // 10秒でタイムアウト
-
-      // 直接リダイレクトを試みる
-      try {
-        clearTimeout(redirectTimeout);
-        window.unifiedLoading.hide();
-        // 成功時はページが切り替わるのでrestoreButton()は呼ばない
-        window.open(setupUrl, '_top'); // _top を使用して現在のウィンドウで開く
-      } catch (e) {
-        console.error('Error opening app setup page:', e);
-        window.unifiedLoading.hide();
-        restoreButton();
-        showMessage(errorMessage + ' ' + (e.message || ''), 'error');
-        // フォールバック: 新しいタブで開く
-        showMessage(fallbackMessage, 'info');
-        window.open(setupUrl, '_blank');
-      }
-    })
-    .catch(function(error) {
-      console.error('Failed to get web app URL for app setup page:', error);
-      window.unifiedLoading.hide();
-      restoreButton();
-      showMessage('アプリ設定ページのURLを取得できませんでした。' + (error.message || ''), 'error');
-    });
+  try {
+    window.open(appSetupUrl, '_top');
+  } catch (error) {
+    console.error('アプリ設定ページへの遷移に失敗:', error);
+    restoreButton();
+    showMessage('アプリ設定ページへの移動に失敗しました。再度お試しください。', 'error');
+  }
 }
+
+userIdPromise.then(() => {
+  fetchAppSetupUrl();
+});
 
 
 

--- a/src/adminPanel.js.html
+++ b/src/adminPanel.js.html
@@ -416,25 +416,6 @@
     openAppSetupPage,
     logoutAndRedirect
   };
-
-  // StudyQuest アプリ設定への遷移
-  function openAppSetupPage() {
-    google.script.run
-      .withSuccessHandler(function(url) {
-        if (url) {
-          // ログイン画面からの遷移と同じフローを再現
-          showAdminPanelRedirect(url, 'アプリ設定管理へ遷移します');
-        } else {
-          showMessage('アプリ設定URLの取得に失敗しました', 'error');
-        }
-      })
-      .withFailureHandler(function(error) {
-        console.error('Failed to get app setup URL:', error);
-        showMessage('アプリ設定URLの取得中にエラーが発生しました', 'error');
-      })
-      .getAppSetupUrl(); // この関数はバックエンドで実装されていると仮定
-  }
-
   // ログアウトしてログイン画面へリダイレクト
   function logoutAndRedirect() {
     if (confirm('ログアウトしてログイン画面に戻りますか？')) {
@@ -447,70 +428,6 @@
           showMessage('ログアウト処理中にエラーが発生しました', 'error');
         })
         .resetUserAuthentication(); // バックエンドの認証リセット関数を呼び出す
-    }
-  }
-  /**
-   * 管理パネルから別のページへのリダイレクト画面を表示
-   * @param {string} targetUrl - 遷移先のURL
-   * @param {string} message - 表示メッセージ
-   */
-  function showAdminPanelRedirect(targetUrl, message) {
-    try {
-      // 引数の妥当性チェック
-      if (!targetUrl || typeof targetUrl !== 'string') {
-        console.error('showAdminPanelRedirect: 無効なtargetUrlが渡されました:', targetUrl);
-        showMessage('遷移URLが無効です。ページを再読み込みしてください。', 'error');
-        return;
-      }
-      
-      console.log('管理パネルからの遷移画面を表示:', targetUrl);
-      
-      // ローディング状態を停止
-      if (typeof setLoading === 'function') {
-        setLoading(false);
-      }
-      
-      // 簡潔なリダイレクトページ
-      const redirectHtml = `<!DOCTYPE html>
-<html lang="ja">
-<head>
-  <title>${message || 'ページ遷移中...'}</title>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    body { 
-      font-family: system-ui, sans-serif; background: #1a1b26; min-height: 100vh; 
-      margin: 0; display: flex; align-items: center; justify-content: center; padding: 20px; 
-    }
-    .container { 
-      background: rgba(26,27,38,0.9); border-radius: 16px; padding: 2rem; 
-      max-width: 420px; text-align: center; 
-    }
-    .title { color: #10b981; font-size: 1.5rem; margin-bottom: 1rem; }
-    .message { color: #94a3b8; margin-bottom: 2rem; }
-    .btn { 
-      background: #10b981; color: white; border: none; border-radius: 8px; 
-      padding: 12px 24px; margin: 0.5rem; text-decoration: none; display: inline-block; 
-    }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="title">🚀 準備完了</div>
-    <div class="message">${message || 'ページ遷移の準備が完了しました'}</div>
-    <a href="${targetUrl}" class="btn" target="_top">アプリ設定画面を開く</a>
-  </div>
-</body>
-</html>`;
-      
-      // 新しいページに遷移
-      document.open();
-      document.write(redirectHtml);
-      document.close();
-      
-    } catch (error) {
-      console.error('showAdminPanelRedirectでエラー:', error);
-      showMessage('ページ遷移中にエラーが発生しました: ' + error.message, 'error');
     }
   }
 


### PR DESCRIPTION
## Summary
- prefetch app setup URL on admin panel load and open it directly without redirect
- remove intermediate redirect logic from admin panel script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dd311090c832b87eb9a249521a06f