### PR TITLE
fix: include user ID in setup URL generation

### DIFF
--- a/src/config.gs
+++ b/src/config.gs
@@ -2644,7 +2644,7 @@ function buildResponseFromContext(context) {
           return {
             webAppUrl: fallbackBaseUrl,
             viewUrl: userInfo.viewUrl || (fallbackBaseUrl + '?userId=' + encodeURIComponent(context.requestUserId) + '&mode=view'),
-            setupUrl: fallbackBaseUrl + '?setup=true',
+            setupUrl: fallbackBaseUrl + '?setup=true&userId=' + encodeURIComponent(context.requestUserId),
             adminUrl: fallbackBaseUrl + '?mode=admin&userId=' + context.requestUserId,
             status: 'success'
           };

--- a/src/url.gs
+++ b/src/url.gs
@@ -183,7 +183,7 @@ function generateUserUrls(userId) {
     webAppUrl: webAppUrl,
     adminUrl: `${webAppUrl}?mode=admin&userId=${encodedId}`,
     viewUrl: `${webAppUrl}?mode=view&userId=${encodedId}`,
-    setupUrl: `${webAppUrl}?setup=true`,
+    setupUrl: `${webAppUrl}?setup=true&userId=${encodedId}`,
     status: 'success'
   };
 }

--- a/tests/generateAppUrls.test.js
+++ b/tests/generateAppUrls.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const vm = require('vm');
 
-describe('generateAppUrls admin url', () => {
+describe('generateUserUrls', () => {
   const mainCode = fs.readFileSync('src/main.gs', 'utf8');
   const urlCode = fs.readFileSync('src/url.gs', 'utf8');
   let context;
@@ -70,5 +70,10 @@ describe('generateAppUrls admin url', () => {
   test('returns adminUrl with userId and mode parameter', () => {
     const urls = context.generateUserUrls('abc');
     expect(urls.adminUrl).toBe('https://script.google.com/macros/s/ID/exec?mode=admin&userId=abc');
+  });
+
+  test('returns setupUrl with userId parameter', () => {
+    const urls = context.generateUserUrls('abc');
+    expect(urls.setupUrl).toBe('https://script.google.com/macros/s/ID/exec?setup=true&userId=abc');
   });
 });


### PR DESCRIPTION
## Summary
- include userId parameter in setup URL returned by `generateUserUrls`
- add fallback setup URL with userId in `config.gs`
- test setup URL generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dd6c50868832b8f0f5038e22e97f6