### PR TITLE
fix: guard copyFormUrl in admin panel external link handlers

### DIFF
--- a/src/adminPanel-events.js.html
+++ b/src/adminPanel-events.js.html
@@ -516,7 +516,14 @@ function setupExternalLinkHandlers() {
   // Copy form URL
   var copyFormUrlBtn = document.getElementById('copy-form-url-btn');
   if (copyFormUrlBtn) {
-    copyFormUrlBtn.addEventListener('click', copyFormUrl);
+    copyFormUrlBtn.addEventListener('click', function() {
+      if (typeof copyFormUrl === 'function') {
+        copyFormUrl();
+      } else {
+        console.error('CRITICAL: copyFormUrl is not available');
+        showMessage('フォームURLをコピーできません。ページを再読み込みしてください。', 'warning');
+      }
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid ReferenceError by checking copyFormUrl before use in adminPanel-events.js.html

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0d4b6594832bb5dfdeba25943ebc