### PR TITLE
fix(ui): handle invalid config json safely

### DIFF
--- a/src/SharedUtilities.html
+++ b/src/SharedUtilities.html
@@ -1495,6 +1495,31 @@ if (!initializeTimingManagerIntegration()) {
   }
 })();
 
+// =============================================================================
+// JSON UTILITIES
+// =============================================================================
+
+/**
+ * userInfo.configJson を安全にパースします。
+ * 無効な文字列や空文字列の場合は空オブジェクトを返します。
+ * @param {string|Object|null|undefined} configJson JSON文字列またはオブジェクト
+ * @returns {Object} パース結果のオブジェクト。失敗時は空オブジェクト
+ */
+function parseUserConfig(configJson) {
+  if (!configJson) return {};
+  if (typeof configJson === 'object') return configJson;
+  try {
+    return JSON.parse(configJson);
+  } catch (error) {
+    if (typeof AppLogger !== 'undefined') {
+      AppLogger.warn('parseUserConfig', 'Invalid configJson detected', error);
+    } else {
+      console.warn('parseUserConfig: invalid configJson', error);
+    }
+    return {};
+  }
+}
+
 // Prevent duplicate loading messages
 if (!window.sharedUtilitiesLoaded) {
   window.sharedUtilitiesLoaded = true;

--- a/src/adminPanel-ui.js.html
+++ b/src/adminPanel-ui.js.html
@@ -44,7 +44,7 @@ function getPublicationState(status) {
   let config = null;
   if (status.userInfo && status.userInfo.configJson) {
     try {
-      config = JSON.parse(status.userInfo.configJson);
+      config = parseUserConfig(status.userInfo.configJson);
     } catch (e) {
       console.warn('Failed to parse configJson:', e);
       return { isPublished: false, reason: 'configJson解析エラー', confidence: 'low' };
@@ -195,7 +195,7 @@ function determinePublicationStatus(status) {
   if (status.userInfo && status.userInfo.configJson) {
     try {
       const config = typeof status.userInfo.configJson === 'string' 
-        ? JSON.parse(status.userInfo.configJson) 
+        ? parseUserConfig(status.userInfo.configJson)
         : status.userInfo.configJson;
       if (typeof config.appPublished === 'boolean') {
         console.log('📋 Publication status from configJson (fallback):', config.appPublished);
@@ -277,7 +277,7 @@ function _fullUpdateUIWithNewStatus(status) {
     }
     
     // 公開状態の更新
-    const config = JSON.parse(status.userInfo.configJson || '{}');
+    const config = parseUserConfig(status.userInfo.configJson);
     const isPublished = config.appPublished || false;
     const publishText = isPublished ? '公開中' : '停止中';
     
@@ -420,7 +420,7 @@ function updateUnpublishButton(status) {
   
   if (!explicitAppPublished && status.userInfo && status.userInfo.configJson) {
     try {
-      const config = JSON.parse(status.userInfo.configJson);
+      const config = parseUserConfig(status.userInfo.configJson);
       explicitAppPublished = config.appPublished === true;
     } catch (configError) {
       console.warn('❌ Failed to parse configJson for unpublish button check:', configError);
@@ -610,7 +610,7 @@ function syncCheckboxStates(status) {
   } else if (status.userInfo && status.userInfo.configJson) {
     // 2. Fallback to raw configJson
     try {
-      const config = JSON.parse(status.userInfo.configJson);
+      const config = parseUserConfig(status.userInfo.configJson);
       if (config.showNames !== undefined) showNames = config.showNames;
       if (config.showCounts !== undefined) showCounts = config.showCounts;
     } catch (e) {
@@ -986,7 +986,7 @@ function getStepCompletionFromConfig(status) {
 
   try {
     const config = typeof status.userInfo.configJson === 'string' 
-      ? JSON.parse(status.userInfo.configJson) 
+      ? parseUserConfig(status.userInfo.configJson)
       : status.userInfo.configJson;
 
     // 公開状態の優先チェック（データ不整合に関係なく公開済みなら全ステップ完了）
@@ -1379,7 +1379,7 @@ function updateTopicText(status) {
   // userInfo.configJsonからも情報を取得（安全性チェック強化）
   if (status.userInfo && status.userInfo.configJson) {
     try {
-      const fullConfig = JSON.parse(status.userInfo.configJson);
+      const fullConfig = parseUserConfig(status.userInfo.configJson);
       if (fullConfig && typeof fullConfig === 'object') {
         cfg = Object.assign({}, cfg, fullConfig);
         console.log('📋 updateTopicText: merged config:', cfg);
@@ -1422,7 +1422,7 @@ function updateTopicText(status) {
     if (sheetName && sheetName !== 'フォームの回答 1') {
       if (status.userInfo && status.userInfo.configJson) {
         try {
-          const fullCfg = JSON.parse(status.userInfo.configJson);
+          const fullCfg = parseUserConfig(status.userInfo.configJson);
           const sheetCfg = fullCfg['sheet_' + (sheetName || '')] || {};
           console.log('📋 Sheet config found:', sheetCfg);
           
@@ -2100,7 +2100,7 @@ function activateSelectedSheet(sheetName) {
       // currentStatusを更新
       if (currentStatus.userInfo.configJson) {
         try {
-          const config = JSON.parse(currentStatus.userInfo.configJson);
+          const config = parseUserConfig(currentStatus.userInfo.configJson);
           config.publishedSheetName = sheetName;
           currentStatus.userInfo.configJson = JSON.stringify(config);
           currentStatus.activeSheetName = sheetName;
@@ -2450,7 +2450,7 @@ function getSetupStatusFromUserInfo(userInfo) {
     }
 
     const config = typeof userInfo.configJson === 'string'
-      ? JSON.parse(userInfo.configJson)
+      ? parseUserConfig(userInfo.configJson)
       : userInfo.configJson;
 
     // setupStatusが明示的に設定されている場合はそれを使用
@@ -2609,7 +2609,7 @@ function getActiveResourceUrls(status) {
   if (status.userInfo.configJson) {
     try {
       config = typeof status.userInfo.configJson === 'string' 
-        ? JSON.parse(status.userInfo.configJson) 
+        ? parseUserConfig(status.userInfo.configJson)
         : status.userInfo.configJson;
       console.log('getActiveResourceUrls: configJson parsed:', config); // Gemini Debug
     } catch (e) {

--- a/src/adminPanel.js.html
+++ b/src/adminPanel.js.html
@@ -37,9 +37,7 @@
   function getSetupStatusFromGlobalStatus() {
     try {
       if (currentStatus && currentStatus.userInfo && currentStatus.userInfo.configJson) {
-        const config = typeof currentStatus.userInfo.configJson === 'string' 
-          ? JSON.parse(currentStatus.userInfo.configJson) 
-          : currentStatus.userInfo.configJson;
+        const config = parseUserConfig(currentStatus.userInfo.configJson);
         return config.setupStatus || 'pending';
       }
       return 'pending';
@@ -84,9 +82,7 @@
     }
     
     try {
-      const config = typeof currentStatus.userInfo.configJson === 'string' 
-        ? JSON.parse(currentStatus.userInfo.configJson) 
-        : currentStatus.userInfo.configJson;
+      const config = parseUserConfig(currentStatus.userInfo.configJson);
       
       // データベース状態に基づく統一判定
       const setupCompleted = config.setupStatus === 'completed' && 

--- a/tests/parseUserConfig.test.js
+++ b/tests/parseUserConfig.test.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview parseUserConfigのテスト
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function loadParseUserConfig() {
+  const file = fs.readFileSync(path.join(__dirname, '../src/SharedUtilities.html'), 'utf8');
+  const start = file.indexOf('function parseUserConfig');
+  if (start === -1) {
+    throw new Error('parseUserConfig not found');
+  }
+  let i = file.indexOf('{', start);
+  let depth = 1;
+  i += 1;
+  while (i < file.length && depth > 0) {
+    const char = file[i];
+    if (char === '{') depth += 1;
+    if (char === '}') depth -= 1;
+    i += 1;
+  }
+  const fnStr = file.slice(start, i);
+  const fn = new Function(`${fnStr}; return parseUserConfig;`);
+  return fn();
+}
+
+describe('parseUserConfig', () => {
+  const parseUserConfig = loadParseUserConfig();
+
+  test('空文字列は空オブジェクトを返す', () => {
+    expect(parseUserConfig('')).toEqual({});
+  });
+
+  test('不正なJSON文字列は空オブジェクトを返す', () => {
+    expect(parseUserConfig('{invalid')).toEqual({});
+  });
+
+  test('正しいJSON文字列はオブジェクトを返す', () => {
+    expect(parseUserConfig('{"a":1}')).toEqual({ a: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- add `parseUserConfig` utility to safely parse user configuration
- use `parseUserConfig` in admin panel UI to avoid crashing on malformed config
- test `parseUserConfig` against empty and invalid JSON strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac12c50400832bb52dad1e4b4eaf96